### PR TITLE
Avoid a nasty crash when trying to impersonate an invalid user

### DIFF
--- a/app/views/user_impersonate/_header.html.haml
+++ b/app/views/user_impersonate/_header.html.haml
@@ -4,7 +4,7 @@
     %span.admin-name<>= current_staff_user
     ) utilisez voyez le site en tant que
     %span.user-name= current_user
-    = " (ID de l'utilisateur : #{current_user.id})"
+    = " (ID de l'utilisateur : #{current_user&.id})"
 
   .impersonate-buttons
     = form_tag impersonate_engine.revert_impersonate_user_url, method: :delete, class: 'revert-form' do


### PR DESCRIPTION
The user couldn’t even get out of the crash loop. This doesn’t fix the underlying issue, but at least users should be able to login/logout again.