### PR TITLE
Add DiagnosedNeed.last_activity_at

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -65,6 +65,7 @@ group :test do
   gem 'selenium-webdriver'
   gem 'shoulda-matchers'
   gem 'webmock'
+  gem 'timecop'
 end
 
 group :development, :test do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -414,6 +414,7 @@ GEM
     thor (0.19.4)
     thread_safe (0.3.6)
     tilt (2.0.9)
+    timecop (0.9.1)
     turbolinks (5.2.0)
       turbolinks-source (~> 5.2)
     turbolinks-source (5.2.0)
@@ -498,6 +499,7 @@ DEPENDENCIES
   spring-commands-rspec
   spring-watcher-listen
   therubyracer
+  timecop
   turbolinks
   uglifier
   user_impersonate2

--- a/app/admin/diagnosed_need.rb
+++ b/app/admin/diagnosed_need.rb
@@ -29,6 +29,7 @@ ActiveAdmin.register DiagnosedNeed do
     end
     column :advisor
     column :created_at
+    column :last_activity_at
     column :status do |d|
       css_class = { quo: '', taking_care: 'warning', done: 'ok', not_for_me: 'error' }[d.status_synthesis.to_sym]
       status_tag d.status_short_description, class: css_class
@@ -37,6 +38,7 @@ ActiveAdmin.register DiagnosedNeed do
     end
     column(:matches) do |d|
       div admin_link_to(d, :matches)
+      div admin_link_to(d, :feedbacks)
     end
 
     actions dropdown: true do |d|
@@ -57,6 +59,7 @@ ActiveAdmin.register DiagnosedNeed do
     column :content
     column :advisor
     column :created_at
+    column :last_activity_at
     column :status_short_description
     column :archived?
     column_count :matches
@@ -70,6 +73,7 @@ ActiveAdmin.register DiagnosedNeed do
       row :question
       row :advisor
       row :created_at
+      row :last_activity_at
       row :archived_at
       row :content
       row :status_description do |d|

--- a/app/admin/feedback.rb
+++ b/app/admin/feedback.rb
@@ -8,6 +8,7 @@ ActiveAdmin.register Feedback do
   index do
     selectable_column
     id_column
+    column :created_at
 
     column :match do |f|
       link_to(f.diagnosed_need, admin_match_path(f.match))
@@ -28,6 +29,7 @@ ActiveAdmin.register Feedback do
   #
   csv do
     column :id
+    column :created_at
     column :diagnosed_need
     column :expert
     column :description
@@ -37,6 +39,7 @@ ActiveAdmin.register Feedback do
   #
   show do
     attributes_table do
+      row :created_at
       row :match do |f|
         link_to(f.diagnosed_need, admin_match_path(f.match))
       end

--- a/app/admin/match.rb
+++ b/app/admin/match.rb
@@ -48,7 +48,7 @@ ActiveAdmin.register Match do
 
   filter :status
 
-  filter :created_at
+  filter :updated_at
 
   filter :advisor, as: :ajax_select, data: { url: :admin_users_path, search_fields: [:full_name] }
   filter :advisor_antenne, as: :ajax_select, data: { url: :admin_antennes_path, search_fields: [:name] }
@@ -94,6 +94,9 @@ ActiveAdmin.register Match do
       end
       row :diagnosed_need
       row :created_at
+      row :updated_at
+      row :taken_care_of_at
+      row :closed_at
       row :status_synthesis do |m|
         css_class = { quo: '', taking_care: 'warning', done: 'ok', not_for_me: 'error' }[m.diagnosed_need.status_synthesis.to_sym]
         status_tag m.diagnosed_need.status_description, class: css_class

--- a/config/locales/active_record.fr.yml
+++ b/config/locales/active_record.fr.yml
@@ -254,6 +254,7 @@ fr:
     intervention_zone: Zone d’intervention
     interview_sort_order: Ordre dans le questionnaire
     label: Intitulé
+    last_activity_at: Dernière activité
     legal_form_code: Forme juridique
     matches:
       one: Mise en relation


### PR DESCRIPTION
This takes into account comments and matches updated: allows scoping diagnosed_needs not recently updated.