### PR TITLE
Refactor DiagnosedNeed.status and description

### DIFF
--- a/app/admin/diagnosed_need.rb
+++ b/app/admin/diagnosed_need.rb
@@ -31,9 +31,7 @@ ActiveAdmin.register DiagnosedNeed do
     column :created_at
     column :last_activity_at
     column :status do |d|
-      css_class = { quo: '', taking_care: 'warning', done: 'ok', not_for_me: 'error' }[d.status_synthesis.to_sym]
-      status_tag d.status_short_description, class: css_class
-
+      status_tag(*status_tag_status_params(d.status))
       status_tag t('active_admin.archivable.archive_done') if d.archived?
     end
     column(:matches) do |d|
@@ -46,6 +44,8 @@ ActiveAdmin.register DiagnosedNeed do
     end
   end
 
+  statuses = DiagnosedNeed::STATUSES.map { |s| [StatusHelper.status_description(s, :short), s] }
+  filter :by_status_in, as: :select, collection: statuses, label: I18n.t('attributes.status')
   filter :created_at
   filter :company, as: :ajax_select, data: { url: :admin_companies_path, search_fields: [:name] }
   filter :question, collection: -> { Question.order(:label) }
@@ -76,10 +76,7 @@ ActiveAdmin.register DiagnosedNeed do
       row :last_activity_at
       row :archived_at
       row :content
-      row :status_description do |d|
-        css_class = { quo: '', taking_care: 'warning', done: 'ok', not_for_me: 'error' }[d.status_synthesis.to_sym]
-        status_tag d.status_description, class: css_class
-      end
+      row(:status) { |d| status_tag(*status_tag_status_params(d.status)) }
       row(:matches) do |d|
         div admin_link_to(d, :matches)
         div admin_link_to(d, :matches, list: true)

--- a/app/admin/diagnosed_need.rb
+++ b/app/admin/diagnosed_need.rb
@@ -9,7 +9,7 @@ ActiveAdmin.register DiagnosedNeed do
 
   ## index
   #
-  includes :diagnosis, :question, :advisor, :matches, :company
+  includes :diagnosis, :question, :advisor, :matches, :feedbacks, :company
 
   scope :all, default: true
   scope :unsent

--- a/app/admin/match.rb
+++ b/app/admin/match.rb
@@ -16,15 +16,13 @@ ActiveAdmin.register Match do
     selectable_column
     column :match, sortable: :status do |m|
       div admin_link_to(m)
-      css_class = { quo: '', taking_care: 'warning', done: 'ok', not_for_me: 'error' }[m.status.to_sym]
-      status_tag m.status_short_description, class: css_class
+      status_tag(*status_tag_status_params(m.status))
     end
     column :updated_at
     column :diagnosed_need, sortable: :created_at do |m|
       div admin_link_to(m, :diagnosed_need)
       div I18n.l(m.created_at, format: '%Y-%m-%d %H:%M')
-      css_class = { quo: '', taking_care: 'warning', done: 'ok', not_for_me: 'error' }[m.diagnosed_need.status_synthesis.to_sym]
-      status_tag m.diagnosed_need.status_short_description, class: css_class
+      status_tag(*status_tag_status_params(m.diagnosed_need.status))
     end
     column :advisor do |m|
       div admin_link_to(m, :advisor)
@@ -91,19 +89,13 @@ ActiveAdmin.register Match do
   #
   show do
     attributes_table do
-      row :status do |m|
-        css_class = { quo: '', taking_care: 'warning', done: 'ok', not_for_me: 'error' }[m.status.to_sym]
-        status_tag m.status_description, class: css_class
-      end
+      row(:status) { |m| status_tag(*status_tag_status_params(m.status)) }
       row :diagnosed_need
       row :created_at
       row :updated_at
       row :taken_care_of_at
       row :closed_at
-      row :status_synthesis do |m|
-        css_class = { quo: '', taking_care: 'warning', done: 'ok', not_for_me: 'error' }[m.diagnosed_need.status_synthesis.to_sym]
-        status_tag m.diagnosed_need.status_description, class: css_class
-      end
+      row(:diagnosed_need) { |m| status_tag(*status_tag_status_params(m.diagnosed_need.status)) }
       row :advisor
       row :advisor_antenne
       row :contacted_expert do |m|

--- a/app/admin/match.rb
+++ b/app/admin/match.rb
@@ -19,6 +19,7 @@ ActiveAdmin.register Match do
       css_class = { quo: '', taking_care: 'warning', done: 'ok', not_for_me: 'error' }[m.status.to_sym]
       status_tag m.status_short_description, class: css_class
     end
+    column :updated_at
     column :diagnosed_need, sortable: :created_at do |m|
       div admin_link_to(m, :diagnosed_need)
       div I18n.l(m.created_at, format: '%Y-%m-%d %H:%M')
@@ -73,6 +74,8 @@ ActiveAdmin.register Match do
     column(:diagnosed_need) { |m| m.diagnosed_need_id }
     column(:question) { |m| m.diagnosed_need.question }
     column :created_at
+    column :taken_care_of_at
+    column :closed_at
     column(:status_description) { |m| m.diagnosed_need.status_short_description }
     column :advisor
     column :advisor_antenne

--- a/app/helpers/admin_helper.rb
+++ b/app/helpers/admin_helper.rb
@@ -69,6 +69,13 @@ module AdminHelper
     "#{klass.human_attribute_name(attribute)} : #{object.send(attribute)}"
   end
 
+  def status_tag_status_params(status)
+    # Note: “status” is a property of Match and DiagnosedNeed, but status_tag is also an ActiveAdmin helper
+    css_class = { taking_care: 'warning', done: 'ok', not_for_me: 'error' }[status.to_sym]
+    title = StatusHelper::status_description(status, :short)
+    [title, class: css_class]
+  end
+
   ::ActiveAdmin::CSVBuilder.module_eval do
     def column_count(attribute)
       column(attribute) { |object| object.send(attribute).size }

--- a/app/helpers/status_helper.rb
+++ b/app/helpers/status_helper.rb
@@ -1,5 +1,22 @@
-module MatchHelper
+module StatusHelper
+  ##
+  #
+  def self.status_description(status, variant = '')
+    namespace = 'attributes.statuses'
+    case variant
+    when :short
+      namespace = 'attributes.statuses_short'
+    when :action
+      namespace = 'attributes.statuses_action'
+    when nil
+      namespace = 'attributes.statuses'
+    end
+    I18n.t(status, scope: namespace)
+  end
+
   STATUS_COLORS = {
+    diagnosis_not_complete: %w[lightgrey],
+    sent_to_no_one: %w[lightgrey],
     quo: %w[lightgrey],
     not_for_me: %w[red],
     taking_care: %w[green],
@@ -7,6 +24,8 @@ module MatchHelper
   }
 
   STATUS_ICONS = {
+    diagnosis_not_complete: %w[],
+    sent_to_no_one: %w[],
     quo: %w[],
     not_for_me: %w[icon remove],
     taking_care: %w[icon handshake outline],
@@ -17,7 +36,7 @@ module MatchHelper
     allowed_actions = match.allowed_new_status
 
     links = allowed_actions.map do |new_status|
-      title = I18n.t("activerecord.attributes.match.statuses_action.#{new_status}")
+      title = StatusHelper::status_description(new_status, :action)
       path = match_path(match.id, status: new_status, access_token: params[:access_token])
       classes = %w[ui small button] + STATUS_COLORS[new_status]
       link_to path, data: { remote: true, method: :patch }, class: classes.join(' ') do
@@ -27,9 +46,9 @@ module MatchHelper
     links.join.html_safe
   end
 
-  def match_status_label(status)
+  def status_label(status)
     status = status.to_sym
-    title = I18n.t("activerecord.attributes.match.statuses_short.#{status}")
+    title = StatusHelper::status_description(status, :short)
     classes = %w[ui label] + STATUS_COLORS[status]
     content_tag(:div, class: classes.join(' ')) do
       status_icon(status) + title
@@ -39,5 +58,15 @@ module MatchHelper
   def status_icon(status)
     classes = STATUS_ICONS[status.to_sym]
     tag.i(class: classes.join(' '))
+  end
+
+  module StatusDescription
+    def status_description
+      StatusHelper.status_description(status)
+    end
+
+    def status_short_description
+      StatusHelper.status_description(status, :short)
+    end
   end
 end

--- a/app/models/match.rb
+++ b/app/models/match.rb
@@ -128,13 +128,7 @@ class Match < ApplicationRecord
     status_done? || status_not_for_me?
   end
 
-  def status_description
-    I18n.t("activerecord.attributes.match.statuses.#{status}")
-  end
-
-  def status_short_description
-    I18n.t("activerecord.attributes.match.statuses_short.#{status}")
-  end
+  include StatusHelper::StatusDescription
 
   DATE_PROPERTIES = {
     quo: :created_at,

--- a/app/services/relay_service/csv_generator.rb
+++ b/app/services/relay_service/csv_generator.rb
@@ -37,7 +37,7 @@ module RelayService
           I18n.t('attributes.content'),
           I18n.t('activerecord.models.expert.one'),
           I18n.t('attributes.institution'),
-          I18n.t('activerecord.attributes.match.status'),
+          I18n.t('attributes.status'),
           I18n.t('activerecord.attributes.match.taken_care_of_at'),
           I18n.t('activerecord.attributes.match.closed_at')
         ]
@@ -54,7 +54,7 @@ module RelayService
           diagnosed_need.content,
           match.expert_full_name,
           match.expert_institution_name,
-          I18n.t("activerecord.attributes.match.statuses.#{match.status}"),
+          I18n.t("attributes.statuses.#{match.status}"),
           match.taken_care_of_at&.to_date,
           match.closed_at&.to_date
         ]

--- a/app/services/stats/matches_stats.rb
+++ b/app/services/stats/matches_stats.rb
@@ -27,7 +27,7 @@ module Stats
     end
 
     def category_name(category)
-      I18n.t("activerecord.attributes.match.statuses.#{category}")
+      StatusHelper::status_description(category)
     end
 
     def category_order_attribute

--- a/app/views/needs/_diagnoses_list.haml
+++ b/app/views/needs/_diagnoses_list.haml
@@ -17,7 +17,7 @@
           .diagnoses-list-item-need
             %h4.ui.header
               = need.question_label
-              .match-status= match_status_label(need.status_synthesis)
+              .match-status= status_label(need.status)
               .sub.header= models_human_description(need.matches)
         - can_archive = diagnosis.advisor == current_user
         - if can_archive

--- a/app/views/needs/_match.haml
+++ b/app/views/needs/_match.haml
@@ -8,11 +8,11 @@
                        role: match.expert_institution_name)
 
   .match-status
-    = match_status_label(match.status)
+    = status_label(match.status)
 
 - if for_me
   %h4.ui.header
-    = I18n.t("activerecord.attributes.match.statuses.#{match.status}")
+    = match.status_description
     .sub.header= match.status_date
 
   = match_actions match

--- a/app/views/needs/_need_header.haml
+++ b/app/views/needs/_need_header.haml
@@ -4,4 +4,4 @@
   = diagnosed_need.question_label
   .sub.header= models_human_description(diagnosed_need.matches)
   .match-status
-    = match_status_label(diagnosed_need.status_synthesis)
+    = status_label(diagnosed_need.status)

--- a/config/locales/active_record.fr.yml
+++ b/config/locales/active_record.fr.yml
@@ -48,27 +48,6 @@ fr:
         expert_institution_name: Institution du référent
         expert_viewed_page_at: Date de consultation par le référent
         relay: Référent (Relais local)
-        status: Statut
-        statuses:
-          done: Besoin clôturé
-          not_for_me: Mise en relation refusée
-          quo: En attente de réponse
-          taking_care: En cours de prise en charge
-        statuses_action:
-          done: Clôturer
-          not_for_me: Refuser
-          quo: Annuler
-          taking_care: Prendre en charge
-        statuses_short:
-          done: Clôturé
-          not_for_me: Refusé
-          quo: Pas de réponse
-          taking_care: Pris en charge
-        statuses_with_date:
-          done: Clôturé le %{date} à %{time}
-          not_for_me: Refusé le %{date} à %{time}
-          quo: Annuler
-          taking_care: Prendre en charge
         taken_care_of_at: Date de prise en charge
       relay:
         territory: Territoire
@@ -290,7 +269,27 @@ fr:
       other: Mises en relation envoyées
     siren: SIREN
     siret: SIRET
+    status: Statut
     status_description: Résumé
+    statuses:
+      diagnosis_not_complete: Analyse en cours
+      done: Besoin clôturé
+      not_for_me: Mise en relation refusée
+      quo: En attente de réponse
+      sent_to_no_one: Envoyé à personne
+      taking_care: En cours de prise en charge
+    statuses_action:
+      done: Clôturer
+      not_for_me: Refuser
+      quo: Annuler
+      taking_care: Prendre en charge
+    statuses_short:
+      diagnosis_not_complete: Analyse en cours
+      done: Clôturé
+      not_for_me: Refusé
+      quo: Pas de réponse
+      sent_to_no_one: Envoyé à personne
+      taking_care: Pris en charge
     title: Titre
     updated_at: Date de mise à jour
     visit: Visite

--- a/spec/models/diagnosed_need_spec.rb
+++ b/spec/models/diagnosed_need_spec.rb
@@ -45,20 +45,29 @@ RSpec.describe DiagnosedNeed, type: :model do
     end
   end
 
-  describe 'status_synthesis' do
-    subject { diagnosed_need.status_synthesis }
+  describe 'status' do
+    subject { diagnosed_need.status }
 
-    let(:diagnosed_need) { create :diagnosed_need, matches: matches }
+    let(:diagnosed_need) { create :diagnosed_need, matches: matches, diagnosis: diagnosis }
+
+    let(:diagnosis) { create :diagnosis, step: 5 }
+    let(:matches) { [] }
 
     let(:quo_match) { build :match, status: :quo }
     let(:taking_care_match) { build :match, status: :taking_care }
     let(:done_match) { build :match, status: :done }
     let(:not_for_me_match) { build :match, status: :not_for_me }
 
+    context 'diagnosis not complete' do
+      let(:diagnosis) { create :diagnosis, step: 1 }
+
+      it { is_expected.to eq :diagnosis_not_complete }
+    end
+
     context 'with no match' do
       let(:matches) { [] }
 
-      it { is_expected.to eq :quo }
+      it { is_expected.to eq :sent_to_no_one }
     end
 
     context 'with at least a match done' do


### PR DESCRIPTION
* Rename it :status, not :status_synthesis
* Add two new status :diagnosis_not_complete and :sent_to_no_one
* Add scope :by_status() and admin filter
* Dry status description methods with Match.status

(Also fixup admin params for #409)
