### PR TITLE
Remove non-transmitted needs from stats

### DIFF
--- a/app/controllers/stats_controller.rb
+++ b/app/controllers/stats_controller.rb
@@ -11,7 +11,6 @@ class StatsController < ApplicationController
     @stats.needs = Stats::NeedsStats.new(@stats)
     @stats.experts = Stats::ExpertsStats.new(@stats)
     @stats.matches = Stats::MatchesStats.new(@stats)
-    @stats.transmitted_needs = Stats::TransmittedNeedsStats.new(@stats)
   end
 
   def users

--- a/app/services/stats/needs_stats.rb
+++ b/app/services/stats/needs_stats.rb
@@ -4,6 +4,7 @@ module Stats
 
     def main_query
       Need
+        .diagnosis_completed
         .joins(:advisor)
         .joins(subject: :theme)
     end

--- a/app/services/stats/transmitted_needs_stats.rb
+++ b/app/services/stats/transmitted_needs_stats.rb
@@ -1,8 +1,0 @@
-module Stats
-  class TransmittedNeedsStats < NeedsStats
-    def main_query
-      super
-        .where(diagnoses: { step: Diagnosis::LAST_STEP })
-    end
-  end
-end

--- a/app/views/stats/show.haml
+++ b/app/views/stats/show.haml
@@ -23,7 +23,7 @@
 
 %section.section.section-grey
   .container.container-full
-    - names = [:needs, :transmitted_needs, :companies, :matches, :advisors, :experts]
+    - names = [:companies, :needs, :matches, :advisors, :experts]
     .grid
       - names.each do |name|
         = render partial: 'stats_chart', locals: { stats: @stats, name: name }

--- a/config/locales/views/stats.fr.yml
+++ b/config/locales/views/stats.fr.yml
@@ -6,8 +6,7 @@ fr:
       companies: "%{count} entreprises aidées"
       experts: "%{count} référents"
       matches: "%{count} mises en relation"
-      needs: "%{count} besoins identifiés"
-      transmitted_needs: "%{count} besoins transmis"
+      needs: "%{count} besoins transmis"
     show:
       all: Tous
       title: Statistiques d’utilisation


### PR DESCRIPTION
(Actually, remove the “TransmittedNeedsStats” and count the transmitted needs in “NeedsStats”)

    Need.diagnosis_completed
is the same thing as

    Need.where(diagnoses: { step: Diagnosis::LAST_STEP })