### PR TITLE
Display a single dash when there is no match

### DIFF
--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -6,7 +6,7 @@ module ApplicationHelper
   end
 
   def models_human_description(objects)
-    return if objects.blank?
+    return '-' if objects.blank?
     klass = objects.first.class
     count = objects.count
     "#{count} #{klass.model_name.human(count: count).downcase}"


### PR DESCRIPTION
This is a workaround, we should ideally write “0 mise en relation”, which is possible but a little more complex.