### PR TITLE
Tweak ransacker filters to avoid crashing when there are no results

### DIFF
--- a/app/models/concerns/archivable.rb
+++ b/app/models/concerns/archivable.rb
@@ -13,6 +13,7 @@ module Archivable
 
     ransacker(:archived, formatter: -> (value) {
       archived(value).pluck(:id)
+        .presence
     }) { |parent| parent.table[:id] }
   end
 

--- a/app/models/need.rb
+++ b/app/models/need.rb
@@ -136,6 +136,7 @@ class Need < ApplicationRecord
   #
   ransacker(:by_status, formatter: -> (value) {
     by_status(value).pluck(:id)
+      .presence
   }) { |parent| parent.table[:id] }
 
   ##


### PR DESCRIPTION
I’m not 100% certain how this works:

1. The resulting query of the scope yields an array of ids.
2. Ransacker (?) uses this array to build another query that looks like this:
    SELECT <things> WHERE id IN (<array>)

If array is empty, this is a syntax error. Ransacker (or ActiveAdmin) is not smart enough to avoid this query if there are no results.

🤷🏻‍♂️

I’m seeing this in production following #439, as I’ve assigned all non-assigned needs to the Support team and there are no `sent_to_no_one` needs anymore. 🤷🏻‍♂️