### PR TITLE
Remove no-longer-needed methods

### DIFF
--- a/app/controllers/needs_controller.rb
+++ b/app/controllers/needs_controller.rb
@@ -12,12 +12,7 @@ class NeedsController < ApplicationController
   end
 
   def show
-    associations = [
-      :visitee, :advisor, facility: [:company],
-      needs: [matches: [expert_skill: :expert]]
-    ]
-    @diagnosis = Diagnosis.includes(associations).find(params[:id])
-
+    @diagnosis = diagnosis
     check_current_user_access_to(@diagnosis)
     @current_roles = current_roles
   end
@@ -29,9 +24,13 @@ class NeedsController < ApplicationController
       : [current_expert]
   end
 
+  def diagnosis
+    Diagnosis.find(params[:id])
+  end
+
   def mark_expert_viewed
     experts.each do |expert|
-      UseCases::UpdateExpertViewedPageAt.perform(diagnosis: params[:id].to_i, expert: expert)
+      UseCases::UpdateExpertViewedPageAt.perform(diagnosis: diagnosis, expert: expert)
     end
   end
 end

--- a/app/helpers/feedback_helper.rb
+++ b/app/helpers/feedback_helper.rb
@@ -16,6 +16,6 @@ module FeedbackHelper
       actions = nil
     end
 
-    raw_feedback_block(feedback.description, feedback.match.person_full_name, feedback.created_at, feedback.id, actions)
+    raw_feedback_block(feedback.description, feedback.match.expert_full_name, feedback.created_at, feedback.id, actions)
   end
 end

--- a/app/mailers/expert_mailer.rb
+++ b/app/mailers/expert_mailer.rb
@@ -4,15 +4,13 @@ class ExpertMailer < ApplicationMailer
   SENDER = "#{I18n.t('app_name')} <#{SENDER_EMAIL}>"
   default from: SENDER, template_path: 'mailers/expert_mailer'
 
-  def notify_company_needs(person, diagnosis)
-    @person = person
-    if person.is_a? Expert
-      @access_token = person.access_token
-    end
+  def notify_company_needs(expert, diagnosis)
+    @expert = expert
+    @access_token = expert.access_token
     @diagnosis = diagnosis
 
     mail(
-      to: @person.email_with_display_name,
+      to: @expert.email_with_display_name,
       cc: @diagnosis.advisor.email_with_display_name,
       subject: t('mailers.expert_mailer.notify_company_needs.subject', company_name: @diagnosis.company.name),
       reply_to: [
@@ -22,16 +20,14 @@ class ExpertMailer < ApplicationMailer
     )
   end
 
-  def remind_involvement(person, matches_taken_not_done, matches_quo_not_taken)
-    @person = person
-    if person.is_a? Expert
-      @access_token = person.access_token
-    end
+  def remind_involvement(expert, matches_taken_not_done, matches_quo_not_taken)
+    @expert = expert
+    @access_token = expert.access_token
     @matches_taken_not_done = matches_taken_not_done
     @matches_quo_not_taken = matches_quo_not_taken
 
     mail(
-      to: @person.email_with_display_name,
+      to: @expert.email_with_display_name,
       subject: t('mailers.expert_mailer.remind_involvement.subject')
     )
   end

--- a/app/mailers/user_mailer.rb
+++ b/app/mailers/user_mailer.rb
@@ -26,7 +26,7 @@ class UserMailer < ApplicationMailer
 
   def match_feedback(feedback)
     @feedback = feedback
-    @author = feedback.match.person
+    @author = feedback.match.expert
     @need = feedback.match.need
     @persons = @need.contacted_persons - [@author]
     @advisor = @need.diagnosis.advisor

--- a/app/models/diagnosis.rb
+++ b/app/models/diagnosis.rb
@@ -85,15 +85,6 @@ class Diagnosis < ApplicationRecord
       .where(needs: { matches: { expert_skill: { experts: { id: expert.id } } } })
   end
 
-  scope :of_expert, -> (expert) do
-    archived(false)
-      .includes(facility: :company)
-      .joins(:needs)
-      .merge(Need.of_expert(expert))
-      .order(happened_on: :desc, created_at: :desc)
-      .distinct
-  end
-
   scope :after_step, -> (minimum_step) { where('step >= ?', minimum_step) }
 
   def match_and_notify!(experts_skills_for_needs)

--- a/app/models/diagnosis.rb
+++ b/app/models/diagnosis.rb
@@ -146,8 +146,8 @@ class Diagnosis < ApplicationRecord
   end
 
   def notify_experts!
-    contacted_persons.each do |person|
-      ExpertMailer.delay.notify_company_needs(person, self)
+    contacted_persons.each do |expert|
+      ExpertMailer.delay.notify_company_needs(expert, self)
     end
   end
 end

--- a/app/models/match.rb
+++ b/app/models/match.rb
@@ -81,20 +81,9 @@ class Match < ApplicationRecord
 
   scope :updated_more_than_five_days_ago, -> { where('matches.updated_at < ?', 5.days.ago) }
 
-  scope :of_expert, -> (expert) do
-    if expert.is_a?(Enumerable)
-      if expert.empty?
-        none
-      else
-        relations = expert.map{ |item| of_expert(item) }.compact
-        relations.reduce(&:or)
-      end
-    elsif expert.is_a?(Expert)
-      left_outer_joins(:expert_skill).where(experts_skills: { expert: expert })
-    else
-      left_outer_joins(:expert_skill).where(id: -1)
-    end
-  end
+  scope :of_expert, -> (expert) { # TODO: remove when we get rid of :expert_skill
+    joins(:expert_skill).where(experts_skills: { expert: expert })
+  }
 
   scope :to_support, -> { joins(:skill).where(skills: { subject: Subject.support_subject }) }
 

--- a/app/models/match.rb
+++ b/app/models/match.rb
@@ -77,7 +77,6 @@ class Match < ApplicationRecord
   ## Scopes
   #
   scope :not_viewed, -> { where(expert_viewed_page_at: nil) }
-  scope :of_diagnoses, -> (diagnoses) { where(need: Need.where(diagnosis: diagnoses)) }
   scope :with_status, -> (status) { where(status: status) }
 
   scope :updated_more_than_five_days_ago, -> { where('matches.updated_at < ?', 5.days.ago) }

--- a/app/models/match.rb
+++ b/app/models/match.rb
@@ -94,7 +94,7 @@ class Match < ApplicationRecord
   ##
   #
   def to_s
-    "#{I18n.t('activerecord.models.match.one')} avec #{person_full_name}"
+    "#{I18n.t('activerecord.models.match.one')} avec #{expert_full_name}"
   end
 
   def status_closed?
@@ -131,14 +131,6 @@ class Match < ApplicationRecord
 
   def expert_full_role
     "#{expert_full_name} - #{expert_institution_name}"
-  end
-
-  def person
-    expert
-  end
-
-  def person_full_name
-    person&.full_name || expert_full_name
   end
 
   ##

--- a/app/models/need.rb
+++ b/app/models/need.rb
@@ -63,8 +63,6 @@ class Need < ApplicationRecord
 
   ## Scopes
   #
-  scope :of_expert, -> (expert) { joins(:matches).merge(Match.of_expert(expert)) }
-
   scope :made_in, -> (date_range) do
     joins(:diagnosis)
       .where(diagnoses: { happened_on: date_range })

--- a/app/models/use_cases/update_expert_viewed_page_at.rb
+++ b/app/models/use_cases/update_expert_viewed_page_at.rb
@@ -2,7 +2,7 @@ module UseCases
   class UpdateExpertViewedPageAt
     class << self
       def perform(diagnosis:, expert:)
-        matches = Match.of_diagnoses(diagnosis)
+        matches = diagnosis.matches
           .of_expert(expert)
           .not_viewed
         matches.update_all expert_viewed_page_at: Time.zone.now

--- a/app/services/admin_mailers_service.rb
+++ b/app/services/admin_mailers_service.rb
@@ -55,7 +55,7 @@ class AdminMailersService
     end
 
     def matches_count_statistics
-      matches_count = Match.of_diagnoses(@completed_diagnoses).count
+      matches_count = Match.joins(:need).where(needs: { diagnosis: @completed_diagnoses }).count
       @information_hash[:matches_count] = matches_count
     end
 

--- a/app/services/expert_reminder_service.rb
+++ b/app/services/expert_reminder_service.rb
@@ -3,24 +3,24 @@
 class ExpertReminderService
   class << self
     def send_reminders
-      @persons_matches = {}
+      @experts_matches = {}
       build_matches_taken_not_done
       build_matches_quo_not_taken
-      @persons_matches.each do |person, person_matches|
-        ExpertMailer.delay.remind_involvement(person,
-          person_matches.taken_not_done.compact,
-          person_matches.quo_not_taken.compact)
+      @experts_matches.each do |expert, expert_matches|
+        ExpertMailer.delay.remind_involvement(expert,
+          expert_matches.taken_not_done.compact,
+          expert_matches.quo_not_taken.compact)
       end
     end
 
     private
 
-    PersonMatches = Struct.new(:taken_not_done, :quo_not_taken)
+    ExpertMatches = Struct.new(:taken_not_done, :quo_not_taken)
 
-    def add_person_match(person, args)
-      person_matches = @persons_matches[person] ||= PersonMatches.new([], [])
-      person_matches.taken_not_done << args[:taken_not_done]
-      person_matches.quo_not_taken << args[:quo_not_taken]
+    def add_expert_match(expert, args)
+      expert_matches = @experts_matches[expert] ||= ExpertMatches.new([], [])
+      expert_matches.taken_not_done << args[:taken_not_done]
+      expert_matches.quo_not_taken << args[:quo_not_taken]
     end
 
     def build_matches_taken_not_done
@@ -30,12 +30,12 @@ class ExpertReminderService
             next
           end
 
-          person = match.person
-          if !match.person
+          expert = match.expert
+          if !match.expert
             next
           end
 
-          add_person_match(person, taken_not_done: match)
+          add_expert_match(expert, taken_not_done: match)
         end
       end
     end
@@ -47,12 +47,12 @@ class ExpertReminderService
             next
           end
 
-          person = match.person
-          if !match.person
+          expert = match.expert
+          if !match.expert
             next
           end
 
-          add_person_match(person, quo_not_taken: match)
+          add_expert_match(expert, quo_not_taken: match)
         end
       end
     end

--- a/app/views/mailers/expert_mailer/notify_company_needs.html.haml
+++ b/app/views/mailers/expert_mailer/notify_company_needs.html.haml
@@ -11,7 +11,7 @@
 
 %p= t('.company_expressed_needs')
 
-- @diagnosis.needs.ordered_for_interview.of_expert(@person).each do |need|
+- @diagnosis.needs.merge(@expert.received_needs).ordered_for_interview.each do |need|
   %h3.subject= need.subject
   - if need.content.present?
     %blockquote

--- a/app/views/mailers/expert_mailer/notify_company_needs.html.haml
+++ b/app/views/mailers/expert_mailer/notify_company_needs.html.haml
@@ -1,4 +1,4 @@
-%p= t('.hello', name: @person.full_name)
+%p= t('.hello', name: @expert.full_name)
 
 :ruby
   link_to_root = link_to t('app_name'), root_url

--- a/app/views/mailers/expert_mailer/remind_involvement.html.haml
+++ b/app/views/mailers/expert_mailer/remind_involvement.html.haml
@@ -1,4 +1,4 @@
-%p= t('.hello', name: @person.full_name)
+%p= t('.hello', name: @expert.full_name)
 
 - link_to_root = link_to t('app_name'), root_url
 %p= t('.here_is_a_summary_email_html', link_to_root: link_to_root)

--- a/app/views/needs/_diagnoses_list.haml
+++ b/app/views/needs/_diagnoses_list.haml
@@ -12,7 +12,7 @@
           .sub.header= diagnosis.facility.commune_name
         - needs_of_interest = diagnosis.needs
         - if expert.present?
-          - needs_of_interest = needs_of_interest.of_expert(expert)
+          - needs_of_interest = needs_of_interest.merge(expert.received_needs)
         - needs_of_interest.each do |need|
           .diagnoses-list-item-need
             %h4.ui.header

--- a/app/views/needs/_match.haml
+++ b/app/views/needs/_match.haml
@@ -1,6 +1,6 @@
 .needs-match
-  - if match.person.present?
-    = person_block(match.person, suffix: match.skill&.title)
+  - if match.expert.present?
+    = person_block(match.expert, suffix: match.skill&.title)
   - else
     = person_block_raw(prefix: t('.deleted_expert'),
                        name: match.expert_full_name,

--- a/app/views/needs/index.html.haml
+++ b/app/views/needs/index.html.haml
@@ -6,5 +6,5 @@
 
 - @experts.each do |expert|
   -# Display info about Expert: the team, the old diagnoses, etc.
-  - diagnoses = Diagnosis.of_expert(expert)
+  - diagnoses = expert.received_diagnoses.archived(false).distinct.order(happened_on: :desc, created_at: :desc)
   = render partial: 'diagnoses_list', locals: { diagnoses: diagnoses, expert: expert, title: expert.full_name }

--- a/spec/mailers/previews/expert_mailer_preview.rb
+++ b/spec/mailers/previews/expert_mailer_preview.rb
@@ -6,7 +6,7 @@ class ExpertMailerPreview < ActionMailer::Preview
 
   def remind_involvement
     match = match_with_person
-    matches = Match.of_expert(match.person)
+    matches = match.expert.received_matches
     ExpertMailer.remind_involvement(match.person, matches.sample(2), matches.sample(2))
   end
 

--- a/spec/mailers/previews/expert_mailer_preview.rb
+++ b/spec/mailers/previews/expert_mailer_preview.rb
@@ -1,18 +1,18 @@
 class ExpertMailerPreview < ActionMailer::Preview
   def notify_company_needs
-    match = match_with_person
-    ExpertMailer.notify_company_needs(match.person, match.diagnosis)
+    match = match_with_expert
+    ExpertMailer.notify_company_needs(match.expert, match.diagnosis)
   end
 
   def remind_involvement
-    match = match_with_person
+    match = match_with_expert
     matches = match.expert.received_matches
-    ExpertMailer.remind_involvement(match.person, matches.sample(2), matches.sample(2))
+    ExpertMailer.remind_involvement(match.expert, matches.sample(2), matches.sample(2))
   end
 
   private
 
-  def match_with_person
+  def match_with_expert
     Match.where.not(expert_skill: nil).sample
   end
 end

--- a/spec/models/match_spec.rb
+++ b/spec/models/match_spec.rb
@@ -145,23 +145,6 @@ RSpec.describe Match, type: :model do
       it { is_expected.to eq [match] }
     end
 
-    describe 'of_diagnoses' do
-      subject { Match.of_diagnoses [diagnosis] }
-
-      let(:diagnosis) { create :diagnosis }
-      let(:need) { create :need, diagnosis: diagnosis }
-      let(:match) do
-        create :match, need: need
-      end
-
-      before do
-        create :need, diagnosis: diagnosis
-        create :match
-      end
-
-      it { is_expected.to eq [match] }
-    end
-
     describe 'with_status' do
       let!(:match_with_status_quo) { create :match, status: :quo }
       let!(:match_taken_care_of) { create :match, status: :taking_care }

--- a/spec/views/mailers/expert_mailer/notify_company_needs.html.haml_spec.rb
+++ b/spec/views/mailers/expert_mailer/notify_company_needs.html.haml_spec.rb
@@ -11,7 +11,7 @@ RSpec.describe 'mailers/expert_mailer/notify_company_needs.html.haml', type: :vi
     let(:need2) { create(:need, matches: [create(:match, expert_skill: create(:expert_skill, expert: expert))]) }
 
     before do
-      assign(:person, expert)
+      assign(:expert, expert)
       assign(:diagnosis, diagnosis)
     end
 


### PR DESCRIPTION
Since we removed Relays, all the code in Match that switched between relays and experts can be removed. This also includes the `of_expert()` scope (previously known as `of_relay_or_expert()`.