### PR TITLE
Remove the landing-specific css rules

### DIFF
--- a/app/assets/stylesheets/solicitations/index.sass
+++ b/app/assets/stylesheets/solicitations/index.sass
@@ -27,15 +27,3 @@ label.hero__white-background
 
 .hero form
   max-width: 100%
-
-// For /entreprise landing pages
-
-.landing
-  .landing__container
-    min-height: 50vh
-  h1.hero_title
-    font-size: 3em
-  h3.hero_subtitle
-    font-size: 1.5em
-  a.button
-    padding: 1em 2em

--- a/app/views/landing/landing.haml
+++ b/app/views/landing/landing.haml
@@ -7,8 +7,8 @@
       %span.navbar__domain= 'place-des-entreprises'
       = image_tag 'pointbetagouvfr.svg', alt: 'beta.gouv.fr', class: 'navbar__gouvfr'
 
-.hero.landing.hero__background{ style: solicitation_background_style }
-  .hero__container.landing__container
+.hero.hero__background{ style: solicitation_background_style }
+  .hero__container
     %h1.hero_title= @landing.title
     %h2.hero_subtitle= @landing.subtitle
     %h3


### PR DESCRIPTION
It makes stuff way too large on mobile, and was only maybe relevant when we had a multicolumn design.