### PR TITLE
Redirect to "/conseillers" after a sign-up attempt

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -21,6 +21,7 @@ class ApplicationController < ActionController::Base
   end
 
   ## Devise overrides
+  # See also RegistrationsController::after_sign_up_path_for
   def after_sign_in_path_for(resource_or_scope)
     stored_location_for(resource_or_scope) || diagnoses_path
   end

--- a/app/controllers/users/registrations_controller.rb
+++ b/app/controllers/users/registrations_controller.rb
@@ -12,6 +12,15 @@ module Users
       end
     end
 
+    # See also ApplicationController::after_sign_in_path_for
+    def after_sign_up_path_for(resource)
+      diagnoses_path
+    end
+
+    def after_inactive_sign_up_path_for(resource)
+      conseillers_path
+    end
+
     protected
 
     def configure_permitted_parameters


### PR DESCRIPTION
Instead of redirecting to "/", which is the enterprise home page.