### PR TITLE
Fix irb_context in rails console

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -75,7 +75,7 @@ group :development, :test do
   gem 'factory_bot_rails'
   gem 'faker'
   gem 'rspec-rails'
-  gem 'rspec_junit_formatter'
+  gem 'rspec_junit_formatter', require: false
 end
 
 group :development do


### PR DESCRIPTION
Don’t require rspec_junit_formatter gem

It’s only needed when running tests (for circleci).

It messes with the console, when running `rails c` it causes this warning:
```
irb: warn: can't alias context from irb_context
```

This is related to rspec monkey_patching a `context` method on `Object` (https://github.com/rspec/rspec-rails/issues/1645)