### PR TITLE
Add admin tooling to create missing users for lonely experts

### DIFF
--- a/app/admin/expert.rb
+++ b/app/admin/expert.rb
@@ -11,6 +11,7 @@ ActiveAdmin.register Expert do
   scope :all, default: true
   scope :support_experts
   scope :with_custom_communes, group: :special
+  scope :without_users, group: :special
 
   index do
     selectable_column
@@ -47,6 +48,9 @@ ActiveAdmin.register Expert do
     end
     actions dropdown: true do |expert|
       item t('active_admin.person.normalize_values'), normalize_values_admin_expert_path(expert)
+      if expert.users.empty?
+        item t('active_admin.expert.create_matching_user', count: 1), create_matching_user_admin_expert_path(expert)
+      end
     end
   end
 
@@ -120,6 +124,10 @@ ActiveAdmin.register Expert do
     link_to t('active_admin.person.normalize_values'), normalize_values_admin_expert_path(expert)
   end
 
+  action_item :create_matching_user, only: :show, if: -> { expert.users.empty? } do
+    link_to t('active_admin.expert.create_matching_user', count: 1), create_matching_user_admin_expert_path(expert)
+  end
+
   ## Form
   #
   permit_params [
@@ -176,10 +184,22 @@ ActiveAdmin.register Expert do
     redirect_back fallback_location: collection_path, alert: t('active_admin.person.normalize_values_done')
   end
 
+  member_action :create_matching_user do
+    resource.create_matching_user!
+    redirect_back fallback_location: collection_path, alert: t('active_admin.expert.create_matching_user_done', count: 1)
+  end
+
   batch_action I18n.t('active_admin.person.normalize_values') do |ids|
     batch_action_collection.find(ids).each do |expert|
       expert.normalize_values!
     end
     redirect_back fallback_location: collection_path, notice: I18n.t('active_admin.person.normalize_values_done')
+  end
+
+  batch_action I18n.t('active_admin.expert.create_matching_user', count: 2) do |ids|
+    batch_action_collection.find(ids).each do |expert|
+      expert.create_matching_user!
+    end
+    redirect_back fallback_location: collection_path, notice: I18n.t('active_admin.expert.create_matching_user_done', count: 2)
   end
 end

--- a/app/models/expert.rb
+++ b/app/models/expert.rb
@@ -86,6 +86,8 @@ class Expert < ApplicationRecord
     where(is_global_zone: true)
   end
 
+  scope :without_users, -> { left_outer_joins(:users).where(users: { id: nil }) }
+
   ##
   #
   def generate_access_token!
@@ -112,5 +114,28 @@ class Expert < ApplicationRecord
 
   def full_role
     "#{role} - #{antenne.name}"
+  end
+
+  ##
+  #
+  def create_matching_user!
+    if !users.empty?
+      return
+    end
+
+    params = {
+      experts: [self],
+      email: email,
+      full_name: full_name,
+      phone_number: phone_number,
+      antenne: antenne,
+      role: role
+    }
+    params[:password] = SecureRandom.base64(8)
+    params[:is_approved] = true
+
+    user = User.new(params)
+    user.skip_confirmation_notification!
+    user.save!
   end
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -136,7 +136,7 @@ class User < ApplicationRecord
     where(antenne_id: nil)
   end
 
-  ##
+  ## Devise overrides
   #
   def active_for_authentication?
     super && is_approved?

--- a/config/locales/models.fr.yml
+++ b/config/locales/models.fr.yml
@@ -4,6 +4,13 @@ fr:
     dashboard: Tableau de bord
     dashboard_welcome:
       invite_users: Inviter des utilisateurs
+    expert:
+      create_matching_user:
+        one: Créer un utilisateur
+        other: Créer les utilisateurs
+      create_matching_user_done:
+        one: Utilisateur créé
+        other: Utilisateurs créés
     matches:
       deleted: Supprimé
     need:
@@ -42,6 +49,7 @@ fr:
       with_deleted_expert: Référent supprimé
       without_antenne: Sans antenne
       without_communes: Sans zone d’intervention
+      without_users: Sans équipe
     territory:
       assign_entire_territory: "[compléter]"
       confirm_assign_entire_territory: Assigner toutes les communes de %{territory} à la zone d’intervention de %{many_communes} ?


### PR DESCRIPTION
Only as admin tooling for now; confirmation email is disabled.

Experts without a team are actually _experts without an account_, and they need to click the notification email everytime; we’ll want to actually provide a user account for them, this is the first step.

<img width="720" alt="Capture d’écran 2019-05-09 à 09 33 43" src="https://user-images.githubusercontent.com/139391/57435454-bfec0b80-723d-11e9-86bd-82a45e3cca67.png">
