### PR TITLE
Rename :archived? to :is_archived

### DIFF
--- a/app/admin/diagnosis.rb
+++ b/app/admin/diagnosis.rb
@@ -24,8 +24,8 @@ ActiveAdmin.register Diagnosis do
     column(:commune) { |d| d.facility.readable_locality || d.facility.commune }
     column :created_at
     column :step
-    column :archived? do |d|
-      status_tag t('archivable.archive_done') if d.archived?
+    column :is_archived do |d|
+      status_tag t('archivable.archive_done') if d.is_archived
     end
     column :needs do |d|
       div admin_link_to(d, :needs)
@@ -42,7 +42,7 @@ ActiveAdmin.register Diagnosis do
   filter :company, as: :ajax_select, data: { url: :admin_companies_path, search_fields: [:name] }
   filter :facility_territories, as: :ajax_select, data: { url: :admin_territories_path, search_fields: [:name] }
 
-  filter :archived_in, as: :boolean, label: I18n.t('attributes.archived?')
+  filter :archived_in, as: :boolean, label: I18n.t('attributes.is_archived')
 
   ## CSV
   #
@@ -53,7 +53,7 @@ ActiveAdmin.register Diagnosis do
     column :advisor
     column :created_at
     column :step
-    column :archived?
+    column :is_archived
     column_count :needs
     column_count :matches
   end

--- a/app/admin/need.rb
+++ b/app/admin/need.rb
@@ -24,7 +24,7 @@ ActiveAdmin.register Need do
     column :last_activity_at
     column :status do |d|
       status_tag(*status_tag_status_params(d.status))
-      status_tag t('activerecord.attributes.need.archived?') if d.archived?
+      status_tag t('activerecord.attributes.need.is_archived') if d.is_archived
     end
     column(:matches) do |d|
       div admin_link_to(d, :matches)
@@ -32,7 +32,7 @@ ActiveAdmin.register Need do
     end
 
     actions dropdown: true do |need|
-      if need.archived?
+      if need.is_archived
         item t('active_admin.need.unarchive'), polymorphic_path([:unarchive, :admin, need])
       else
         item t('active_admin.need.archive'), polymorphic_path([:archive, :admin, need])
@@ -45,7 +45,7 @@ ActiveAdmin.register Need do
   statuses = Need::STATUSES.map { |s| [StatusHelper.status_description(s, :short), s] }
   filter :by_status_in, as: :select, collection: statuses, label: I18n.t('attributes.status')
 
-  filter :archived_in, as: :boolean, label: I18n.t('activerecord.attributes.need.archived?')
+  filter :archived_in, as: :boolean, label: I18n.t('activerecord.attributes.need.is_archived')
 
   filter :created_at
   filter :company, as: :ajax_select, data: { url: :admin_companies_path, search_fields: [:name] }
@@ -64,7 +64,7 @@ ActiveAdmin.register Need do
     column :created_at
     column :last_activity_at
     column :status_short_description
-    column :archived?
+    column :is_archived
     column_count :matches
   end
 
@@ -91,11 +91,11 @@ ActiveAdmin.register Need do
     link_to t('active_admin.need.match_with_support_team'), match_with_support_team_admin_need_path(need)
   end
 
-  action_item :archive, only: :show, if: -> { !resource.archived? } do
+  action_item :archive, only: :show, if: -> { !resource.is_archived } do
     link_to t('active_admin.need.archive'), polymorphic_path([:archive, :admin, resource])
   end
 
-  action_item :unarchive, only: :show, if: -> { resource.archived? } do
+  action_item :unarchive, only: :show, if: -> { resource.is_archived } do
     link_to t('active_admin.need.unarchive'), polymorphic_path([:unarchive, :admin, resource])
   end
 

--- a/app/admin/subject.rb
+++ b/app/admin/subject.rb
@@ -20,8 +20,8 @@ ActiveAdmin.register Subject do
     end
     column :theme, sortable: 'themes.interview_sort_order'
     column :interview_sort_order
-    column :archived? do |s|
-      status_tag t('archivable.archive_done') if s.archived?
+    column :is_archived do |s|
+      status_tag t('archivable.archive_done') if s.is_archived
     end
     column :is_support do |d|
       status_tag t('activerecord.attributes.subject.is_support') if d.is_support
@@ -34,7 +34,7 @@ ActiveAdmin.register Subject do
     end
   end
 
-  filter :archived_in, as: :boolean, label: I18n.t('attributes.archived?')
+  filter :archived_in, as: :boolean, label: I18n.t('attributes.is_archived')
   filter :is_support
   filter :theme, as: :ajax_select, data: { url: :admin_themes_path, search_fields: [:label] }
   filter :label
@@ -46,7 +46,7 @@ ActiveAdmin.register Subject do
     column :theme
     column :interview_sort_order
     column_count :skills
-    column :archived?
+    column :is_archived
     column :is_support
     column_count :assistances
   end

--- a/app/helpers/admin_archivable.rb
+++ b/app/helpers/admin_archivable.rb
@@ -14,11 +14,11 @@ module AdminArchivable
       redirect_back fallback_location: collection_path, notice: t('archivable.unarchive_done')
     end
 
-    dsl.action_item(:archive, only: :show, if: -> { !resource.archived? }) do
+    dsl.action_item(:archive, only: :show, if: -> { !resource.is_archived }) do
       link_to t('archivable.archive'), polymorphic_path([:archive, :admin, resource])
     end
 
-    dsl.action_item(:unarchive, only: :show, if: -> { resource.archived? }) do
+    dsl.action_item(:unarchive, only: :show, if: -> { resource.is_archived }) do
       link_to t('archivable.unarchive'), polymorphic_path([:unarchive, :admin, resource])
     end
 
@@ -39,7 +39,7 @@ module AdminArchivable
 
   ::ActiveAdmin::Views::IndexAsTable::IndexTableFor.module_eval do
     def index_row_archive_actions(resource)
-      if resource.archived?
+      if resource.is_archived
         item t('archivable.unarchive'), polymorphic_path([:unarchive, :admin, resource])
       else
         item t('archivable.archive'), polymorphic_path([:archive, :admin, resource])

--- a/app/models/concerns/archivable.rb
+++ b/app/models/concerns/archivable.rb
@@ -27,7 +27,7 @@ module Archivable
     self.save!
   end
 
-  def archived?
+  def is_archived
     archived_at.present?
   end
 end

--- a/config/locales/models.fr.yml
+++ b/config/locales/models.fr.yml
@@ -110,8 +110,8 @@ fr:
         skill_title: Compétence
         taken_care_of_at: Date de prise en charge
       need:
-        archived?: En échec
         archived_at: Mis en échec
+        is_archived: En échec
         subject: Sujet
       search:
         label: Entreprise
@@ -249,7 +249,6 @@ fr:
       one: Référent
       other: Référents
     antenne_institution: Institution
-    archived?: Archivé
     archived_at: Date d’archivage
     communes: Communes
     community: Communauté
@@ -285,6 +284,7 @@ fr:
     institution: Institution
     intervention_zone: Zone d’intervention
     interview_sort_order: Ordre dans le questionnaire
+    is_archived: Archivé
     label: Intitulé
     last_activity_at: Dernière activité
     legal_form_code: Forme juridique

--- a/spec/models/concerns/archivable_spec.rb
+++ b/spec/models/concerns/archivable_spec.rb
@@ -12,7 +12,7 @@ RSpec.describe Archivable, type: :model do
       end
 
       it('archives the diagnosis') do
-        expect(diagnosis).to be_archived
+        expect(diagnosis.is_archived).to be_truthy
         expect(Diagnosis.all.count).to eq 1
         expect(Diagnosis.archived(false).count).to eq 0
         expect(Diagnosis.archived(true).count).to eq 1


### PR DESCRIPTION
This is solely to make rubymine stop complaining about the “invalid” `archived?` key in the locale yaml file.