### PR TITLE
Forward the pk_* tracking params from the landing pages

### DIFF
--- a/app/controllers/landing_controller.rb
+++ b/app/controllers/landing_controller.rb
@@ -9,6 +9,6 @@ class LandingController < ApplicationController
 
     redirect_to root_path if @landing.nil?
 
-    @url_to_root = root_path
+    @url_to_root = root_path(params.permit(Solicitation::TRACKING_KEYS))
   end
 end


### PR DESCRIPTION
Include the tracking params in the link to the root page so that they are included as hidden params in the contact form.