### PR TITLE
Amélioration des modèles de Landing

### DIFF
--- a/app/admin/landing.rb
+++ b/app/admin/landing.rb
@@ -1,6 +1,8 @@
 ActiveAdmin.register Landing do
   menu parent: :themes, priority: 3
 
+  includes :landing_topics
+
   ## Index
   #
   index do
@@ -10,8 +12,13 @@ ActiveAdmin.register Landing do
     end
     column :title
     column :subtitle
-    column :logos
     column :button
+    column :logos do |l|
+      l.logos.truncate(50, separator: ', ')
+    end
+    column :landing_topics do |l|
+      l.landing_topics.present? ? l.landing_topics.length : '-'
+    end
     actions dropdown: true
   end
 
@@ -29,11 +36,20 @@ ActiveAdmin.register Landing do
       row :created_at
       row :updated_at
     end
+
+    panel LandingTopic.model_name.human do
+      table_for landing.landing_topics.ordered_for_landing do
+        column :title
+        column :description
+      end
+    end
   end
 
   ## Form
   #
-  permit_params :slug, :title, :subtitle, :button, :logos
+  permit_params :slug, :title, :subtitle, :button, :logos,
+    landing_topics_attributes: [:id, :title, :description, :landing_sort_order, :_destroy]
+
   form do |f|
     f.inputs do
       f.input :slug
@@ -41,6 +57,13 @@ ActiveAdmin.register Landing do
       f.input :subtitle
       f.input :button
       f.input :logos
+    end
+
+    f.inputs do
+      f.has_many :landing_topics, sortable: :landing_sort_order, sortable_start: 1, allow_destroy: true, new_record: true do |a|
+        a.input :title,       :input_html => { :style => 'width:50%' }
+        a.input :description, :input_html => { :style => 'width:50%', :rows => 3 }
+      end
     end
 
     f.actions

--- a/app/admin/landing.rb
+++ b/app/admin/landing.rb
@@ -19,6 +19,18 @@ ActiveAdmin.register Landing do
     column :landing_topics do |l|
       l.landing_topics.present? ? l.landing_topics.length : '-'
     end
+    column :featured_on_home do |l|
+      if l.featured_on_home
+        div do
+          status_tag('yes', :ok)
+          span "(position : #{l.home_sort_order})"
+        end
+        div l.home_title
+        div l.home_description, style: 'color: gray'
+      else
+        status_tag('no', :ok)
+      end
+    end
     actions dropdown: true
   end
 
@@ -37,6 +49,13 @@ ActiveAdmin.register Landing do
       row :updated_at
     end
 
+    attributes_table title: 'Page d’accueil' do
+      row :featured_on_home
+      row :home_title
+      row :home_description
+      row :home_sort_order
+    end
+
     panel LandingTopic.model_name.human do
       table_for landing.landing_topics.ordered_for_landing do
         column :title
@@ -47,7 +66,7 @@ ActiveAdmin.register Landing do
 
   ## Form
   #
-  permit_params :slug, :title, :subtitle, :button, :logos,
+  permit_params :slug, :title, :subtitle, :button, :logos, :featured_on_home, :home_title, :home_description, :home_sort_order,
     landing_topics_attributes: [:id, :title, :description, :landing_sort_order, :_destroy]
 
   form do |f|
@@ -57,6 +76,13 @@ ActiveAdmin.register Landing do
       f.input :subtitle
       f.input :button
       f.input :logos
+    end
+
+    f.inputs do
+      f.input :featured_on_home
+      f.input :home_title,       :input_html => { :style => 'width:50%' }
+      f.input :home_description, :input_html => { :style => 'width:50%', :rows => 3 }
+      f.input :home_sort_order
     end
 
     f.inputs do

--- a/app/models/landing.rb
+++ b/app/models/landing.rb
@@ -2,11 +2,15 @@
 #
 # Table name: landings
 #
-#  id         :bigint(8)        not null, primary key
-#  content    :jsonb
-#  slug       :string           not null
-#  created_at :datetime         not null
-#  updated_at :datetime         not null
+#  id               :bigint(8)        not null, primary key
+#  content          :jsonb
+#  featured_on_home :boolean          default(FALSE)
+#  home_description :text             default("f")
+#  home_sort_order  :integer
+#  home_title       :string           default("f")
+#  slug             :string           not null
+#  created_at       :datetime         not null
+#  updated_at       :datetime         not null
 #
 
 class Landing < ApplicationRecord
@@ -19,4 +23,7 @@ class Landing < ApplicationRecord
   store_accessor :content, CONTENT_KEYS
 
   accepts_nested_attributes_for :landing_topics, allow_destroy: true
+
+  scope :featured, -> { where(featured_on_home: true) }
+  scope :ordered_for_home, -> { order(:home_sort_order, :id) }
 end

--- a/app/models/landing.rb
+++ b/app/models/landing.rb
@@ -10,9 +10,13 @@
 #
 
 class Landing < ApplicationRecord
+  has_many :landing_topics, inverse_of: :landing, :dependent => :destroy
+
   ## JSON Accessors
   #
 
   CONTENT_KEYS = %w[title subtitle button logos]
   store_accessor :content, CONTENT_KEYS
+
+  accepts_nested_attributes_for :landing_topics, allow_destroy: true
 end

--- a/app/models/landing_topic.rb
+++ b/app/models/landing_topic.rb
@@ -1,0 +1,26 @@
+# == Schema Information
+#
+# Table name: landing_topics
+#
+#  id                 :bigint(8)        not null, primary key
+#  description        :text
+#  landing_sort_order :integer
+#  title              :string
+#  created_at         :datetime         not null
+#  updated_at         :datetime         not null
+#  landing_id         :bigint(8)
+#
+# Indexes
+#
+#  index_landing_topics_on_landing_id  (landing_id)
+#
+# Foreign Keys
+#
+#  fk_rails_...  (landing_id => landings.id)
+#
+
+class LandingTopic < ApplicationRecord
+  belongs_to :landing, inverse_of: :landing_topics
+
+  scope :ordered_for_landing, -> { order(:landing_sort_order, :id) }
+end

--- a/config/i18n-tasks.yml
+++ b/config/i18n-tasks.yml
@@ -90,6 +90,7 @@ ignore_unused:
   - 'errors.messages.*'
   - 'activerecord.*'
   - 'active_admin.scopes.*'
+  - 'active_admin.move'
   - 'attributes.*'
   - 'diagnoses.steps.*'
   - 'mailers.user_mailer.daily_change_update.status.*'

--- a/config/locales/models.fr.yml
+++ b/config/locales/models.fr.yml
@@ -102,6 +102,10 @@ fr:
         advisors: Conseillers
         antennes: Antennes
       landing:
+        featured_on_home: Afficher sur la page d’accueil
+        home_description: Description sur la page d’accueil
+        home_sort_order: Position sur la page d’accueil
+        home_title: Titre sur la page d’accueil
         landing_topics: Exemples
         slug: Slug
       match:

--- a/config/locales/models.fr.yml
+++ b/config/locales/models.fr.yml
@@ -13,6 +13,7 @@ fr:
         other: Utilisateurs créés
     matches:
       deleted: Supprimé
+    move: Déplacer
     need:
       archive: Marquer “En échec”
       archive_done: Marqué “En échec”
@@ -100,6 +101,9 @@ fr:
       institution:
         advisors: Conseillers
         antennes: Antennes
+      landing:
+        landing_topics: Exemples
+        slug: Slug
       match:
         closed_at: Date de clôture
         expert: Référent
@@ -203,6 +207,9 @@ fr:
       institution:
         one: Institution
         other: Institutions
+      landing_topic:
+        one: Exemple
+        other: Exemples
       match:
         one: Mise en relation
         other: Mises en relation
@@ -343,6 +350,7 @@ fr:
     subjects:
       one: Sujet
       other: Sujets
+    subtitle: Sous-titre
     territories:
       one: Territoire
       other: Territoires

--- a/db/migrate/20190520121816_create_landing_topics.rb
+++ b/db/migrate/20190520121816_create_landing_topics.rb
@@ -1,0 +1,13 @@
+class CreateLandingTopics < ActiveRecord::Migration[5.2]
+  def change
+    create_table :landing_topics do |t|
+      t.string :title
+      t.text :description
+      t.integer :landing_sort_order
+
+      t.timestamps
+    end
+
+    add_reference :landing_topics, :landing, foreign_key: true
+  end
+end

--- a/db/migrate/20190520144211_add_featured_to_landing.rb
+++ b/db/migrate/20190520144211_add_featured_to_landing.rb
@@ -1,0 +1,8 @@
+class AddFeaturedToLanding < ActiveRecord::Migration[5.2]
+  def change
+    add_column :landings, :featured_on_home, :boolean, default: false
+    add_column :landings, :home_title, :string, default: false
+    add_column :landings, :home_description, :text, default: false
+    add_column :landings, :home_sort_order, :integer
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2019_05_20_121816) do
+ActiveRecord::Schema.define(version: 2019_05_20_144211) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -200,6 +200,10 @@ ActiveRecord::Schema.define(version: 2019_05_20_121816) do
     t.jsonb "content", default: {}
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.boolean "featured_on_home", default: false
+    t.string "home_title", default: "f"
+    t.text "home_description", default: "f"
+    t.integer "home_sort_order"
   end
 
   create_table "matches", force: :cascade do |t|

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2019_04_02_142015) do
+ActiveRecord::Schema.define(version: 2019_05_20_121816) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -185,6 +185,16 @@ ActiveRecord::Schema.define(version: 2019_04_02_142015) do
     t.boolean "show_icon", default: true
   end
 
+  create_table "landing_topics", force: :cascade do |t|
+    t.string "title"
+    t.text "description"
+    t.integer "landing_sort_order"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.bigint "landing_id"
+    t.index ["landing_id"], name: "index_landing_topics_on_landing_id"
+  end
+
   create_table "landings", force: :cascade do |t|
     t.string "slug", null: false
     t.jsonb "content", default: {}
@@ -325,6 +335,7 @@ ActiveRecord::Schema.define(version: 2019_04_02_142015) do
   add_foreign_key "facilities", "communes"
   add_foreign_key "facilities", "companies"
   add_foreign_key "feedbacks", "matches"
+  add_foreign_key "landing_topics", "landings"
   add_foreign_key "matches", "experts_skills", column: "experts_skills_id"
   add_foreign_key "matches", "needs"
   add_foreign_key "needs", "diagnoses"

--- a/spec/factories/landing_topics.rb
+++ b/spec/factories/landing_topics.rb
@@ -1,0 +1,6 @@
+FactoryBot.define do
+  factory :landing_topics do
+    title { Faker::Company.bs }
+    description { Faker::Lorem.paragraph }
+  end
+end


### PR DESCRIPTION
Cette PR prépare la migration vers les nouvelles pages de Landing, en enrichissant les modèles.

Pour l'instant elle n'apporte des changements qu'à l'interface d'administration. L'affichage des nouvelles données viendra par la suite.

- Les landings peuvent maintenant avoir des « Cas d’usage » (qui seront affichés en tant que pavés explicatifs sous le texte des pages de landing)
- Les landings peuvent maintenant être marqués comme « Affichées sur la Home » – c'est à dire qu'elles seront affichées en petit pavés sur la page racine du site.

Tout cela est éditable dans l'interface d'administration.