### PR TITLE
Do not offer archived subjects when creating new skills

### DIFF
--- a/app/admin/skill.rb
+++ b/app/admin/skill.rb
@@ -43,6 +43,7 @@ ActiveAdmin.register Skill do
   #
   show do
     attributes_table do
+      row :theme
       row :subject
       row :title
       row :description
@@ -53,4 +54,14 @@ ActiveAdmin.register Skill do
   ## Form
   #
   permit_params :subject_id, :title, :description
+
+  form do |f|
+    f.semantic_errors
+    f.inputs do
+      f.input :subject, as: :select, collection: Subject.archived(false).ordered_for_interview.map{ |s| [s.full_label, s.id] }
+      f.input :title, :input_html => { :style => 'width:50%' }
+      f.input :description, :input_html => { :style => 'width:50%', :rows => 3 }
+    end
+    f.actions
+  end
 end

--- a/app/models/need.rb
+++ b/app/models/need.rb
@@ -69,9 +69,8 @@ class Need < ApplicationRecord
       .distinct
   end
   scope :ordered_for_interview, -> do
-    left_outer_joins(:subject, subject: :theme)
-      .order('themes.interview_sort_order')
-      .order('subjects.interview_sort_order')
+    left_outer_joins(:subject)
+      .merge(Subject.ordered_for_interview)
   end
 
   scope :diagnosis_completed, -> do

--- a/app/models/subject.rb
+++ b/app/models/subject.rb
@@ -63,6 +63,10 @@ class Subject < ApplicationRecord
     label
   end
 
+  def full_label
+    "#{theme.label} : #{label}"
+  end
+
   ##
   #
   def self.support_subject

--- a/app/models/subject.rb
+++ b/app/models/subject.rb
@@ -45,7 +45,11 @@ class Subject < ApplicationRecord
 
   ## Scopes
   #
-  scope :ordered_for_interview, -> { order(:interview_sort_order, :id) }
+  scope :ordered_for_interview, -> do
+    left_outer_joins(:theme)
+      .merge(Theme.ordered_for_interview)
+      .order(:interview_sort_order, :id)
+  end
 
   scope :for_interview, -> do
     ordered_for_interview


### PR DESCRIPTION
in admin/skills/new, do not display the archived subject in the picker.

Also: some cleanup in the `ordered_for_interview` scopes.