### PR TITLE
Add landing-page specific description examples

### DIFF
--- a/app/admin/landing.rb
+++ b/app/admin/landing.rb
@@ -54,6 +54,7 @@ ActiveAdmin.register Landing do
       row :subtitle
       row :button
       row :logos
+      row :description_example
       row :created_at
       row :updated_at
     end
@@ -75,7 +76,7 @@ ActiveAdmin.register Landing do
 
   ## Form
   #
-  permit_params :slug, :meta_title, :meta_description, :title, :subtitle, :button, :logos, :featured_on_home, :home_title, :home_description, :home_sort_order,
+  permit_params :slug, :meta_title, :meta_description, :title, :subtitle, :button, :logos, :description_example, :featured_on_home, :home_title, :home_description, :home_sort_order,
                 landing_topics_attributes: [:id, :title, :description, :landing_sort_order, :_destroy]
 
   form title: :slug do |f|
@@ -90,6 +91,7 @@ ActiveAdmin.register Landing do
       f.input :subtitle
       f.input :button
       f.input :logos
+      f.input :description_example
     end
 
     f.inputs I18n.t("activerecord.attributes.landing.featured_on_home") do

--- a/app/models/landing.rb
+++ b/app/models/landing.rb
@@ -19,7 +19,7 @@ class Landing < ApplicationRecord
   ## JSON Accessors
   #
 
-  CONTENT_KEYS = %w[meta_title meta_description title subtitle button logos]
+  CONTENT_KEYS = %w[meta_title meta_description title subtitle button logos description_example]
   store_accessor :content, CONTENT_KEYS
 
   accepts_nested_attributes_for :landing_topics, allow_destroy: true

--- a/app/views/landings/show.haml
+++ b/app/views/landings/show.haml
@@ -13,7 +13,7 @@
 
   %section.section.section-white
     .container.container-small
-      = render 'solicitations/form'
+      = render 'solicitations/form', description_example: @landing.description_example
 
 - if @landing.logos.present?
   %section.section.section-white#institutions

--- a/app/views/solicitations/_form.haml
+++ b/app/views/solicitations/_form.haml
@@ -4,7 +4,8 @@
       = f.hidden_field "form_info[#{k}]", value: v
     .form__group
       = f.label 'description', t('.description.label')
-      = f.text_area 'description', placeholder: t('.description.placeholder'), rows: 6, required: true
+      - example = local_assigns[:description_example] || t('.description.default_example')
+      = f.text_area 'description', placeholder: t('.description.placeholder', example: example), rows: 6, required: true
     .form__group
       .form__group
         = f.label 'phone_number', t('.phone_number.label')

--- a/config/locales/models.fr.yml
+++ b/config/locales/models.fr.yml
@@ -102,6 +102,7 @@ fr:
         advisors: Conseillers
         antennes: Antennes
       landing:
+        description_example: Exemple de description
         featured_on_home: Afficher sur la page d’accueil
         home_description: Description sur la page d’accueil
         home_sort_order: Position sur la page d’accueil

--- a/config/locales/views.fr.yml
+++ b/config/locales/views.fr.yml
@@ -480,8 +480,9 @@ fr:
       button:
         title: Envoyer ma demande
       description:
+        default_example: Je cherche à faire un site web pour mon magasin, j’ai besoin de conseils.
         label: Quel est votre besoin ?
-        placeholder: 'Décrivez simplement votre besoin. Par exemple: « Je cherche à faire un site web pour mon magasin, j’ai besoin de conseils. »'
+        placeholder: 'Décrivez simplement votre besoin. Par exemple : « %{example} »'
       email:
         label: Email
         placeholder: marie.dupont@exemple.fr


### PR DESCRIPTION
They can (must) be specified in /admin/landings.