### PR TITLE
Refactor Matches <-> Experts Skills relation

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -780,6 +780,10 @@ RSpec/AnyInstance:
 RSpec/ContextWording:
   Enabled: false
 
+RSpec/DescribeClass:
+  Exclude:
+    - spec/lib/tasks/**/*
+
 RSpec/ExampleLength:
   Enabled: false
 

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -786,6 +786,9 @@ RSpec/ExampleLength:
 RSpec/ImplicitSubject:
   Enabled: false
 
+RSpec/LeadingSubject:
+  Enabled: false
+
 RSpec/MultipleExpectations:
   Enabled: false
 

--- a/app/models/diagnosis.rb
+++ b/app/models/diagnosis.rb
@@ -82,8 +82,8 @@ class Diagnosis < ApplicationRecord
   scope :in_progress, -> { where(step: [1..LAST_STEP - 1]) }
   scope :completed, -> { where(step: LAST_STEP) }
   scope :available_for_expert, -> (expert) do
-    joins(needs: [matches: [expert_skill: :expert]])
-      .where(needs: { matches: { expert_skill: { experts: { id: expert.id } } } })
+    joins(needs: [matches: [:expert]])
+      .where(needs: { matches: { experts: { id: expert.id } } })
   end
 
   scope :after_step, -> (minimum_step) { where('step >= ?', minimum_step) }

--- a/app/models/expert.rb
+++ b/app/models/expert.rb
@@ -34,7 +34,7 @@ class Expert < ApplicationRecord
 
   has_many :experts_skills, dependent: :destroy
   has_many :skills, through: :experts_skills, dependent: :destroy, inverse_of: :experts # TODO should be direct once we remove the ExpertSkill model and use a HABTM
-  has_many :received_matches, through: :experts_skills, source: :matches, inverse_of: :expert # TODO should be direct once we remove the ExpertSkill model and use a HABTM
+  has_many :received_matches, class_name: 'Match', inverse_of: :expert
 
   ## Validations
   #

--- a/app/models/expert_skill.rb
+++ b/app/models/expert_skill.rb
@@ -22,7 +22,6 @@
 class ExpertSkill < ApplicationRecord
   belongs_to :skill
   belongs_to :expert
-  has_many :matches, foreign_key: :experts_skills_id, dependent: :nullify, inverse_of: :expert_skill
 
   scope :relevant_for, -> (need) do
     experts_in_commune = need.facility.commune.all_experts

--- a/app/models/match.rb
+++ b/app/models/match.rb
@@ -12,19 +12,25 @@
 #  taken_care_of_at        :datetime
 #  created_at              :datetime         not null
 #  updated_at              :datetime         not null
+#  expert_id               :bigint(8)
 #  experts_skills_id       :bigint(8)
 #  need_id                 :bigint(8)
+#  skill_id                :bigint(8)
 #
 # Indexes
 #
+#  index_matches_on_expert_id          (expert_id)
 #  index_matches_on_experts_skills_id  (experts_skills_id)
 #  index_matches_on_need_id            (need_id)
+#  index_matches_on_skill_id           (skill_id)
 #  index_matches_on_status             (status)
 #
 # Foreign Keys
 #
+#  fk_rails_...  (expert_id => experts.id)
 #  fk_rails_...  (experts_skills_id => experts_skills.id)
 #  fk_rails_...  (need_id => needs.id)
+#  fk_rails_...  (skill_id => skills.id)
 #
 
 class Match < ApplicationRecord

--- a/app/models/need.rb
+++ b/app/models/need.rb
@@ -195,11 +195,8 @@ class Need < ApplicationRecord
 
   ##
   #
-  def create_matches!(expert_skills)
-    if expert_skills.is_a?(Array)
-      self.matches.create(expert_skills.map{ |id| { experts_skills_id: id } })
-    else
-      self.matches.create(experts_skills_id: expert_skills)
-    end
+  def create_matches!(expert_skill_ids)
+    expert_skills = ExpertSkill.where(id: expert_skill_ids)
+    self.matches.create(expert_skills.map{ |es| es.slice(:expert, :skill) })
   end
 end

--- a/app/models/use_cases/update_expert_viewed_page_at.rb
+++ b/app/models/use_cases/update_expert_viewed_page_at.rb
@@ -3,7 +3,7 @@ module UseCases
     class << self
       def perform(diagnosis:, expert:)
         matches = diagnosis.matches
-          .of_expert(expert)
+          .where(expert: expert)
           .not_viewed
         matches.update_all expert_viewed_page_at: Time.zone.now
       end

--- a/app/views/needs/show.haml
+++ b/app/views/needs/show.haml
@@ -29,7 +29,7 @@
 
     -# Matches, mine first
     - matches = need.matches
-    - match_for_me = matches.of_expert(@current_roles).first
+    - match_for_me = matches.where(expert: @current_roles).first
     - if match_for_me.present?
       - matches -= [match_for_me]
       - matches = [match_for_me] + matches

--- a/db/migrate/20190625123951_add_experts_and_skills_to_matches.rb
+++ b/db/migrate/20190625123951_add_experts_and_skills_to_matches.rb
@@ -1,0 +1,6 @@
+class AddExpertsAndSkillsToMatches < ActiveRecord::Migration[5.2]
+  def change
+    add_reference :matches, :expert, foreign_key: true
+    add_reference :matches, :skill,  foreign_key: true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2019_05_20_144211) do
+ActiveRecord::Schema.define(version: 2019_06_25_123951) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -218,8 +218,12 @@ ActiveRecord::Schema.define(version: 2019_05_20_144211) do
     t.integer "status", default: 0, null: false
     t.datetime "taken_care_of_at"
     t.datetime "closed_at"
+    t.bigint "expert_id"
+    t.bigint "skill_id"
+    t.index ["expert_id"], name: "index_matches_on_expert_id"
     t.index ["experts_skills_id"], name: "index_matches_on_experts_skills_id"
     t.index ["need_id"], name: "index_matches_on_need_id"
+    t.index ["skill_id"], name: "index_matches_on_skill_id"
     t.index ["status"], name: "index_matches_on_status"
   end
 
@@ -340,8 +344,10 @@ ActiveRecord::Schema.define(version: 2019_05_20_144211) do
   add_foreign_key "facilities", "companies"
   add_foreign_key "feedbacks", "matches"
   add_foreign_key "landing_topics", "landings"
+  add_foreign_key "matches", "experts"
   add_foreign_key "matches", "experts_skills", column: "experts_skills_id"
   add_foreign_key "matches", "needs"
+  add_foreign_key "matches", "skills"
   add_foreign_key "needs", "diagnoses"
   add_foreign_key "needs", "subjects"
   add_foreign_key "searches", "users"

--- a/lib/tasks/migration/migrate_matches_expert_skills.rake
+++ b/lib/tasks/migration/migrate_matches_expert_skills.rake
@@ -1,0 +1,17 @@
+namespace :matches_expert_skills do
+  desc "Migrate Match#expert_skill to Match#expert and Match#skill"
+  task migrate: :environment do
+    matches_to_migrate = Match
+      .where.not(experts_skills_id: nil)
+      .where(expert_id: nil)
+      .where(skill_id: nil)
+
+    matches_to_migrate.find_each do |match|
+      expert_skill = ExpertSkill.find(match.experts_skills_id)
+      match.update_columns(
+        expert_id: expert_skill.expert.id,
+        skill_id: expert_skill.skill.id
+      )
+    end
+  end
+end

--- a/spec/controllers/matches_controller_spec.rb
+++ b/spec/controllers/matches_controller_spec.rb
@@ -32,9 +32,7 @@ RSpec.describe MatchesController, type: :controller do
       end
 
       context 'match exists' do
-        let(:expert_skill) { create :expert_skill, expert: expert }
-
-        before { match.update expert_skill: expert_skill }
+        before { match.update expert: expert }
 
         context 'with status quo' do
           it 'returns http success' do

--- a/spec/controllers/needs_controller_spec.rb
+++ b/spec/controllers/needs_controller_spec.rb
@@ -66,7 +66,7 @@ RSpec.describe NeedsController, type: :controller do
     let(:diagnosis) { create :diagnosis }
 
     context 'current user is an expert' do
-      let!(:expert_skill) { create :expert_skill, expert: create(:expert, users: [current_user]) }
+      let!(:expert) { create :expert, users: [current_user] }
 
       context 'user is not contacted for diagnosis' do
         it('raises error') { expect { request }.to raise_error ActionController::RoutingError }
@@ -75,7 +75,7 @@ RSpec.describe NeedsController, type: :controller do
       context 'user is contacted for diagnosis' do
         before do
           create(:match,
-                 expert_skill: expert_skill,
+                 expert: expert,
                  need: create(:need,
                               diagnosis: diagnosis))
         end

--- a/spec/factories/matches.rb
+++ b/spec/factories/matches.rb
@@ -2,11 +2,25 @@
 
 FactoryBot.define do
   factory :match do
-    transient do
-      expert { create :expert }
-    end
-
     need
-    expert_skill { create(:expert_skill, expert: expert) }
+    expert
+    skill
+
+    # Create a match in the legacy data format, with an expert_skill
+    # but no direct relation to expert nor skill.
+    trait :legacy do
+      transient do
+        expert_skill { nil }
+      end
+
+      after(:create) do |match, evaluator|
+        # Use update_colums to bypass validation constraints
+        match.update_columns({
+          experts_skills_id: evaluator.expert_skill&.id,
+          expert_id: nil,
+          skill_id: nil
+        })
+      end
+    end
   end
 end

--- a/spec/lib/tasks/migration/migrate_matches_expert_skills.rake_spec.rb
+++ b/spec/lib/tasks/migration/migrate_matches_expert_skills.rake_spec.rb
@@ -1,0 +1,34 @@
+require 'rails_helper'
+
+describe 'rake matches_expert_skills:migrate', type: :task do
+  it 'runs gracefully with no matches' do
+    expect { task.execute }.not_to raise_error
+  end
+
+  context 'with matches' do
+    let(:expert_skill) { create :expert_skill, expert: create(:expert), skill: create(:skill) }
+    let(:match_to_migrate) { create(:match, :legacy, expert_skill: expert_skill) }
+    let(:already_migrated_match) { create :match, expert: create(:expert), skill: create(:skill), experts_skills_id: expert_skill.id }
+
+    before do
+      match_to_migrate
+      already_migrated_match
+    end
+
+    subject(:migrate_matches) do
+      task.execute
+      match_to_migrate.reload
+      already_migrated_match.reload
+    end
+
+    it 'migrates Matches without expert or skill' do
+      migrate_matches
+      expect(match_to_migrate.expert).to eq expert_skill.expert
+      expect(match_to_migrate.skill).to eq expert_skill.skill
+    end
+
+    it 'doesn’t migrate already migrated Matches' do
+      expect{ migrate_matches }.not_to change { already_migrated_match.slice(:expert, :skill) }
+    end
+  end
+end

--- a/spec/models/antenne_spec.rb
+++ b/spec/models/antenne_spec.rb
@@ -60,8 +60,7 @@ RSpec.describe Antenne, type: :model do
 
     context 'match' do
       let(:expert) { build :expert, antenne: antenne }
-      let(:expert_skill) { build :expert_skill, expert: expert }
-      let!(:match) { create :match, expert_skill: expert_skill }
+      let!(:match) { create :match, expert: expert }
 
       it { is_expected.to eq [match] }
     end

--- a/spec/models/diagnosis_spec.rb
+++ b/spec/models/diagnosis_spec.rb
@@ -101,10 +101,10 @@ RSpec.describe Diagnosis, type: :model do
       context 'one diagnosis' do
         let(:diagnosis) { create :diagnosis }
         let(:need) { create :need, diagnosis: diagnosis }
-        let(:expert_skill) { create :expert_skill, expert: expert }
+        let(:skill) { create :skill }
 
         before do
-          create :match, need: need, expert_skill: expert_skill
+          create :match, need: need, expert: expert, skill: skill
         end
 
         it { is_expected.to eq [diagnosis] }
@@ -141,8 +141,9 @@ RSpec.describe Diagnosis, type: :model do
 
     context 'selected skills for related needs' do
       it do
-        expect{ match_and_notify }.to change { Match.count }.by(1)
-        expect(Match.last.expert_skill).to eq expert_skill
+        expect{ match_and_notify }.to change(Match, :count).by(1)
+        expect(Match.last.expert).to eq expert_skill.expert
+        expect(Match.last.skill).to eq expert_skill.skill
         expect(diagnosis.step).to eq Diagnosis::LAST_STEP
       end
     end

--- a/spec/models/diagnosis_spec.rb
+++ b/spec/models/diagnosis_spec.rb
@@ -131,17 +131,18 @@ RSpec.describe Diagnosis, type: :model do
     end
   end
 
-  describe 'match_and_notif!y' do
+  describe 'match_and_notify!' do
     subject(:match_and_notify) { diagnosis.match_and_notify!(matches) }
 
     let(:diagnosis) { create :diagnosis, step: 4 }
     let(:need) { create :need, diagnosis: diagnosis }
-    let(:skill) { create(:expert_skill, skill: create(:skill), expert: create(:expert)) }
-    let(:matches) { { need.id => [skill.id] } }
+    let(:expert_skill) { create(:expert_skill, skill: create(:skill), expert: create(:expert)) }
+    let(:matches) { { need.id => [expert_skill.id] } }
 
     context 'selected skills for related needs' do
       it do
-        expect{ match_and_notify }.not_to raise_error
+        expect{ match_and_notify }.to change { Match.count }.by(1)
+        expect(Match.last.expert_skill).to eq expert_skill
         expect(diagnosis.step).to eq Diagnosis::LAST_STEP
       end
     end

--- a/spec/models/expert_skill_spec.rb
+++ b/spec/models/expert_skill_spec.rb
@@ -5,7 +5,6 @@ require 'rails_helper'
 RSpec.describe ExpertSkill, type: :model do
   describe 'validations' do
     it do
-      is_expected.to have_many(:matches).dependent(:nullify)
       is_expected.to belong_to :skill
       is_expected.to belong_to :expert
     end

--- a/spec/models/expert_spec.rb
+++ b/spec/models/expert_spec.rb
@@ -8,6 +8,7 @@ RSpec.describe Expert, type: :model do
       is_expected.to belong_to :antenne
       is_expected.to have_many(:experts_skills).dependent(:destroy)
       is_expected.to have_many :skills
+      is_expected.to have_many :received_matches
       is_expected.to have_and_belong_to_many :users
       is_expected.to have_and_belong_to_many :communes
     end
@@ -36,10 +37,9 @@ RSpec.describe Expert, type: :model do
   describe 'associations dependencies' do
     let(:expert) { create :expert }
     let(:skill) { create :skill }
-    let(:ae) { create :expert_skill, expert: expert, skill: skill }
 
     before do
-      create :match, expert_skill: ae
+      create :match, expert: expert, skill: skill
     end
 
     context 'when removing an skill' do

--- a/spec/models/match_spec.rb
+++ b/spec/models/match_spec.rb
@@ -4,20 +4,20 @@ require 'rails_helper'
 
 RSpec.describe Match, type: :model do
   describe 'expert uniqueness for each need' do
-    subject(:match) { build :match, need: need, expert_skill: expert }
+    subject(:match) { build :match, need: need, expert: expert }
 
     let(:need) { create :need }
-    let(:expert) { create :expert_skill }
-    let(:other_expert) { create :expert_skill }
+    let(:expert) { create :expert }
+    let(:other_expert) { create :expert }
 
     context '' do
-      before { create(:match, need: need, expert_skill: other_expert) }
+      before { create(:match, need: need, expert: other_expert) }
 
       it { is_expected.to be_valid }
     end
 
     context '' do
-      before { create(:match, need: need, expert_skill: expert) }
+      before { create(:match, need: need, expert: expert) }
 
       it { is_expected.not_to be_valid }
     end

--- a/spec/models/use_cases/update_expert_viewed_page_at_spec.rb
+++ b/spec/models/use_cases/update_expert_viewed_page_at_spec.rb
@@ -7,32 +7,31 @@ describe UseCases::UpdateExpertViewedPageAt do
     subject(:perform_use_case) { described_class.perform diagnosis: diagnosis, expert: expert }
 
     let(:diagnosis) { create :diagnosis }
-    let(:need) { create :need, diagnosis: diagnosis }
     let(:expert) { create :expert }
 
     let!(:match_with_date) do
       create :match,
-             need: need,
-             expert_skill: create(:expert_skill, expert: expert),
+             need: create(:need, diagnosis: diagnosis),
+             expert: expert,
              expert_viewed_page_at: 1.day.ago
     end
 
     let!(:match_without_date) do
       create :match,
-             need: need,
-             expert_skill: create(:expert_skill, expert: expert),
+             need: create(:need, diagnosis: diagnosis),
+             expert: expert,
              expert_viewed_page_at: nil
     end
 
     let!(:match_without_need) do
       create :match,
-             expert_skill: create(:expert_skill, expert: expert),
+             expert: expert,
              expert_viewed_page_at: nil
     end
 
-    let!(:match_without_expert_skill) do
+    let!(:match_without_expert) do
       create :match,
-             need: need,
+             need: create(:need, diagnosis: diagnosis),
              expert_viewed_page_at: nil
     end
 
@@ -45,7 +44,7 @@ describe UseCases::UpdateExpertViewedPageAt do
     it 'does not change others matches' do
       expect(match_with_date.reload.expert_viewed_page_at.to_date).to eq 1.day.ago.to_date
       expect(match_without_need.reload.expert_viewed_page_at).to be_nil
-      expect(match_without_expert_skill.reload.expert_viewed_page_at).to be_nil
+      expect(match_without_expert.reload.expert_viewed_page_at).to be_nil
     end
   end
 end

--- a/spec/services/expert_reminder_service_spec.rb
+++ b/spec/services/expert_reminder_service_spec.rb
@@ -27,10 +27,10 @@ describe ExpertReminderService do
     end
 
     context 'expert is the same' do
-      let(:expert_skillA) { create :expert_skill, expert: create(:expert) }
+      let(:expert) { create(:expert) }
 
-      let(:matches_quo_not_taken) { create_list(:match, 2, expert_skill: expert_skillA) }
-      let(:matches_taken_not_done) { create_list(:match, 2, expert_skill: expert_skillA) }
+      let(:matches_quo_not_taken) { create_list(:match, 2, expert: expert) }
+      let(:matches_taken_not_done) { create_list(:match, 2, expert: expert) }
 
       it do
         expect(reminders.count).to eq 1

--- a/spec/support/tasks.rb
+++ b/spec/support/tasks.rb
@@ -1,0 +1,40 @@
+# For testing rake tasks
+# Lifted from https://github.com/eliotsykes/rails-testing-toolbox/blob/master/tasks.rb
+require 'rake'
+
+# Task names should be used in the top-level describe, with an optional
+# "rake "-prefix for better documentation. Both of these will work:
+#
+# 1) describe 'foo:bar' do ... end
+#
+# 2) describe 'rake foo:bar' do ... end
+#
+# Favor including 'rake '-prefix as in the 2nd example above as it produces
+# doc output that makes it clear a rake task is under test and how it is
+# invoked.
+module TaskExampleGroup
+  extend ActiveSupport::Concern
+
+  included do
+    let(:task_name) { self.class.top_level_description.sub(/\Arake /, '') }
+    let(:tasks) { Rake::Task }
+    subject(:task) { tasks[task_name] }
+
+    after do
+      task.all_prerequisite_tasks.each { |prerequisite| tasks[prerequisite].reenable }
+      task.reenable
+    end
+  end
+end
+
+RSpec.configure do |config|
+  config.define_derived_metadata(:file_path => %r{/spec/tasks/}) do |metadata|
+    metadata[:type] = :task
+  end
+
+  config.include TaskExampleGroup, type: :task
+
+  config.before(:suite) do
+    Rails.application.load_tasks
+  end
+end

--- a/spec/views/mailers/expert_mailer/notify_company_needs.html.haml_spec.rb
+++ b/spec/views/mailers/expert_mailer/notify_company_needs.html.haml_spec.rb
@@ -7,8 +7,8 @@ RSpec.describe 'mailers/expert_mailer/notify_company_needs.html.haml', type: :vi
     let(:contact) { create :contact, :with_email }
     let(:user) { create :user }
     let(:expert) { create :expert }
-    let(:need1) { create(:need, matches: [create(:match, expert_skill: create(:expert_skill, expert: expert))]) }
-    let(:need2) { create(:need, matches: [create(:match, expert_skill: create(:expert_skill, expert: expert))]) }
+    let(:need1) { create(:need, matches: [create(:match, expert: expert)]) }
+    let(:need2) { create(:need, matches: [create(:match, expert: expert)]) }
 
     before do
       assign(:expert, expert)


### PR DESCRIPTION
Cette PR sépare la relation `Match -> Expert Skill` en `Match -> Expert` et `Match -> Skill`. Pour l'instant ça n'apporte aucun changement visible. À terme, cela permettra d'assigner manuellement des experts à un besoin plus facilement.

## Contenu de la PR

Cette PR :

- Crée les nouvelles relations sur le modèle
- Supprime les anciennes relations
- Ajoute une tâche Rake pour migrer les données de l'ancien schéma vers le nouveau
- Met à jour le code pour utiliser direction Match#expert là où c'est pertinent

(Le modèle `ExpertSkill` sera entièrement supprimé dans une PR future.)

## Étapes pour mettre en production

Cette PR ne comporte pas d'état intermédiaire pour gérer à la fois l'ancien et le nouvel état de la base. Elle doit donc être mise en production à froid.

1. Couper l'accès au site en production
2. Mettre en production le nouveau code
3. Lancer la tâche de migration
    ```
    bin/rake matches_expert_skills:migrate
    ```
4. Ré-activer l'accès au site en production