### PR TITLE
Allow support teams to view needs

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -82,8 +82,15 @@ class ApplicationController < ActionController::Base
     end
   end
 
-  def check_current_user_access_to(resource)
-    if current_roles.any? { |role| resource.send(:can_be_viewed_by?, role) }
+  def check_current_user_access_to(resource, mode)
+    http_method = request.request_method
+    access_method = if %w[GET HEAD].include?(http_method)
+      :can_be_viewed_by?
+    elsif %w[PATCH POST PUT DELETE].include?(http_method)
+      :can_be_modified_by?
+    end
+
+    if current_roles.any? { |role| resource.send(access_method, role) }
       return
     end
     # can not be viewed:

--- a/app/controllers/diagnoses_controller.rb
+++ b/app/controllers/diagnoses_controller.rb
@@ -10,7 +10,7 @@ class DiagnosesController < ApplicationController
   end
 
   def show
-    diagnosis = safe_diagnosis_param
+    diagnosis = retrieve_diagnosis
     if diagnosis.completed?
       redirect_to besoin_path(diagnosis)
     else
@@ -19,24 +19,24 @@ class DiagnosesController < ApplicationController
   end
 
   def archive
-    diagnosis = safe_diagnosis_param
+    diagnosis = retrieve_diagnosis
     diagnosis.archive!
     redirect_to diagnoses_path
   end
 
   def unarchive
-    diagnosis = safe_diagnosis_param
+    diagnosis = retrieve_diagnosis
     diagnosis.unarchive!
     redirect_to diagnoses_path
   end
 
   def step2
-    @diagnosis = safe_diagnosis_param
+    @diagnosis = retrieve_diagnosis
     @themes = Theme.ordered_for_interview
   end
 
   def besoins
-    @diagnosis = safe_diagnosis_param
+    @diagnosis = retrieve_diagnosis
     diagnosis_params = params.require(:diagnosis).permit(:content,
                                                          needs_attributes: [:_destroy, :content, :subject_id, :id])
     diagnosis_params[:step] = 3
@@ -50,11 +50,11 @@ class DiagnosesController < ApplicationController
   end
 
   def step3
-    @diagnosis = safe_diagnosis_param
+    @diagnosis = retrieve_diagnosis
   end
 
   def visite
-    @diagnosis = safe_diagnosis_param
+    @diagnosis = retrieve_diagnosis
     diagnosis_params = params_for_visite
     diagnosis_params[:visitee_attributes][:company_id] = @diagnosis.facility.company.id
     diagnosis_params[:step] = 4
@@ -67,11 +67,11 @@ class DiagnosesController < ApplicationController
   end
 
   def step4
-    @diagnosis = safe_diagnosis_param
+    @diagnosis = retrieve_diagnosis
   end
 
   def selection
-    @diagnosis = safe_diagnosis_param
+    @diagnosis = retrieve_diagnosis
     if @diagnosis.match_and_notify!(params_for_matches)
       flash.notice = I18n.t('diagnoses.step5.notifications_sent')
       redirect_to besoin_path(@diagnosis)
@@ -111,10 +111,10 @@ class DiagnosesController < ApplicationController
     experts_skills_for_needs
   end
 
-  def safe_diagnosis_param
+  def retrieve_diagnosis
     safe_params = params.permit(:id)
     diagnosis = Diagnosis.find(safe_params[:id])
-    check_current_user_access_to(diagnosis)
+    check_current_user_access_to(diagnosis, :read_sometimes_write)
     diagnosis
   end
 end

--- a/app/controllers/feedbacks_controller.rb
+++ b/app/controllers/feedbacks_controller.rb
@@ -11,11 +11,8 @@ class FeedbacksController < ApplicationController
   end
 
   def destroy
-    @feedback_id = params[:id]
-    feedback = Feedback.find(@feedback_id)
-
-    check_current_user_access_to(feedback)
-
+    feedback = retrieve_feedback
+    @feedback_id = feedback.id
     feedback.destroy!
   end
 
@@ -23,5 +20,12 @@ class FeedbacksController < ApplicationController
 
   def feedback_params
     params.require(:feedback).permit(:match_id, :description)
+  end
+
+  def retrieve_feedback
+    safe_params = params.permit(:id)
+    feedback = Feedback.find(safe_params[:id])
+    check_current_user_access_to(feedback, :write)
+    feedback
   end
 end

--- a/app/controllers/matches_controller.rb
+++ b/app/controllers/matches_controller.rb
@@ -6,8 +6,16 @@ class MatchesController < ApplicationController
   before_action :authenticate_expert!, if: -> { params[:access_token].present? }
 
   def update
-    @match = Match.find(params[:id])
-    check_current_user_access_to(@match)
+    @match = retrieve_match
     @match.update status: params[:status]
+  end
+
+  private
+
+  def retrieve_match
+    safe_params = params.permit(:id)
+    match = Match.find(safe_params[:id])
+    check_current_user_access_to(match, :write)
+    match
   end
 end

--- a/app/controllers/needs_controller.rb
+++ b/app/controllers/needs_controller.rb
@@ -37,8 +37,7 @@ class NeedsController < ApplicationController
   end
 
   def show
-    @diagnosis = diagnosis
-    check_current_user_access_to(@diagnosis)
+    @diagnosis = retrieve_diagnosis
     @current_roles = current_roles
   end
 
@@ -57,11 +56,15 @@ class NeedsController < ApplicationController
     current_user.present? ? current_user.received_matches : current_expert.received_matches
   end
 
-  def diagnosis
-    Diagnosis.find(params[:id])
+  def retrieve_diagnosis
+    safe_params = params.permit(:id)
+    diagnosis = Diagnosis.find(safe_params[:id])
+    check_current_user_access_to(diagnosis, :read)
+    diagnosis
   end
 
   def mark_expert_viewed
+    diagnosis = retrieve_diagnosis
     experts.each do |expert|
       UseCases::UpdateExpertViewedPageAt.perform(diagnosis: diagnosis, expert: expert)
     end

--- a/app/models/contact.rb
+++ b/app/models/contact.rb
@@ -35,12 +35,6 @@ class Contact < ApplicationRecord
 
   ##
   #
-  def can_be_viewed_by?(role)
-    diagnoses.any? { |diagnosis| diagnosis.can_be_viewed_by?(role) }
-  end
-
-  ##
-  #
   def full_role
     "#{role} - #{company.name}"
   end

--- a/app/models/diagnosis.rb
+++ b/app/models/diagnosis.rb
@@ -119,11 +119,18 @@ class Diagnosis < ApplicationRecord
   ##
   #
   def can_be_viewed_by?(role)
+    # diagnosis advisor
     if role.present? && advisor == role
-      true
-    else
-      needs.any?{ |need| need.can_be_viewed_by?(role) }
+      return true
     end
+    end
+
+    # contacted experts
+    needs.any? { |need| need.experts.include?(role) }
+  end
+
+  def can_be_modified_by?(role)
+    return role.present? && advisor == role
   end
 
   private

--- a/app/models/diagnosis.rb
+++ b/app/models/diagnosis.rb
@@ -123,6 +123,10 @@ class Diagnosis < ApplicationRecord
     if role.present? && advisor == role
       return true
     end
+
+    # support team
+    if role.is_a?(Expert) && role.experts_skills.support_for(self).present?
+      return true
     end
 
     # contacted experts

--- a/app/models/feedback.rb
+++ b/app/models/feedback.rb
@@ -34,6 +34,10 @@ class Feedback < ApplicationRecord
   ##
   #
   def can_be_viewed_by?(role)
-    self.match.can_be_viewed_by?(role)
+    match.can_be_viewed_by?(role)
+  end
+
+  def can_be_modified_by?(role)
+    expert == role
   end
 end

--- a/app/models/match.rb
+++ b/app/models/match.rb
@@ -134,12 +134,12 @@ class Match < ApplicationRecord
 
   ##
   #
-  def belongs_to_expert?(role)
-    role.present? && expert == role
+  def can_be_viewed_by?(role)
+    diagnosis.can_be_viewed_by?(role)
   end
 
-  def can_be_viewed_by?(role)
-    belongs_to_expert?(role)
+  def can_be_modified_by?(role)
+    role.present? && expert == role
   end
 
   private

--- a/app/models/need.rb
+++ b/app/models/need.rb
@@ -181,20 +181,6 @@ class Need < ApplicationRecord
 
   ##
   #
-  def can_be_viewed_by?(role)
-    if role.present? && advisor == role
-      true
-    else
-      belongs_to_expert?(role)
-    end
-  end
-
-  def belongs_to_expert?(role)
-    experts.include?(role)
-  end
-
-  ##
-  #
   def create_matches!(expert_skill_ids)
     expert_skills = ExpertSkill.where(id: expert_skill_ids)
     self.matches.create(expert_skills.map{ |es| es.slice(:expert, :skill) })

--- a/spec/models/contact_spec.rb
+++ b/spec/models/contact_spec.rb
@@ -52,30 +52,6 @@ RSpec.describe Contact, type: :model do
     end
   end
 
-  describe 'can_be_viewed_by?' do
-    subject { contact.can_be_viewed_by?(user) }
-
-    let(:user) { create :user }
-    let(:contact) { create :contact, :with_email }
-
-    before do
-      create :diagnosis, advisor: advisor
-      create :diagnosis, advisor: advisor, visitee: contact
-    end
-
-    context 'diagnosis advisor is the user' do
-      let(:advisor) { user }
-
-      it { is_expected.to eq true }
-    end
-
-    context 'diagnosis advisor is not the user' do
-      let(:advisor) { create :user }
-
-      it { is_expected.to eq false }
-    end
-  end
-
   describe 'to_s' do
     let(:contact) { build :contact, full_name: 'Ivan Collombet' }
 

--- a/spec/models/diagnosis_spec.rb
+++ b/spec/models/diagnosis_spec.rb
@@ -141,6 +141,14 @@ RSpec.describe Diagnosis, type: :model do
       it { is_expected.to eq true }
     end
 
+    context 'expert has a relevant support skill' do
+      let(:role) { create :expert, is_global_zone: true, skills: [skill] }
+      let(:skill) { create :skill, subject: help_subject }
+      let(:help_subject) { create :subject, is_support: true }
+
+      it { is_expected.to eq true }
+    end
+
     context 'expert is unrelated' do
       let(:role) { create :expert }
 

--- a/spec/models/diagnosis_spec.rb
+++ b/spec/models/diagnosis_spec.rb
@@ -113,19 +113,36 @@ RSpec.describe Diagnosis, type: :model do
   end
 
   describe 'can_be_viewed_by?' do
-    subject { diagnosis.can_be_viewed_by?(user) }
+    subject { diagnosis.can_be_viewed_by?(role) }
 
-    let(:user) { create :user }
-    let!(:diagnosis) { create :diagnosis, advisor: advisor }
+    let(:diagnosis) { create :diagnosis, advisor: advisor }
+    let(:advisor) { create :user }
 
     context 'user is the diagnosis advisor' do
-      let(:advisor) { user }
+      let(:role) { advisor }
 
       it { is_expected.to eq true }
     end
 
     context 'user is unrelated' do
-      let(:advisor) { create :user }
+      let(:role) { create :user }
+
+      it { is_expected.to eq false }
+    end
+
+    context 'expert is contacted for this diagnosis' do
+      let(:role) { create :expert }
+
+      before do
+        need = create :need, diagnosis: diagnosis
+        create :match, expert: role, need: need
+      end
+
+      it { is_expected.to eq true }
+    end
+
+    context 'expert is unrelated' do
+      let(:role) { create :expert }
 
       it { is_expected.to eq false }
     end

--- a/spec/models/feedback_spec.rb
+++ b/spec/models/feedback_spec.rb
@@ -16,25 +16,19 @@ RSpec.describe Feedback, type: :model do
     end
   end
 
-  describe 'can_be_viewed_by?' do
-    subject { feedback.can_be_viewed_by?(expert) }
+  describe 'can_be_modified_by?' do
+    subject { feedback.can_be_modified_by?(expert) }
 
     let(:feedback) { create :feedback }
     let(:expert) { create :expert }
 
     context 'expert is the expert of the match' do
-      before do
-        feedback.match.expert = expert
-      end
+      before { feedback.expert = expert }
 
       it { is_expected.to eq true }
     end
 
     context 'expert is unrelated' do
-      before do
-        feedback.match.expert = create :expert
-      end
-
       it { is_expected.to eq false }
     end
   end


### PR DESCRIPTION
1. Refactor permissions model

* remove spaghetti
* use two different “can_be_viewed” and “can_be_updated” methods
* decide which method to use depending on the http method

This is still done manually and a very simple model, but it’s slightly better than it used to be.

2. Allow support experts to access diagnoses