### PR TITLE
Cleanup: remove scope `Match.with_status`

### DIFF
--- a/app/controllers/stats_controller.rb
+++ b/app/controllers/stats_controller.rb
@@ -100,9 +100,9 @@ class StatsController < ApplicationController
       "activity.needs": needs_in_range,
       "activity.needs_notified": needs_in_range.where(diagnoses: { step: 5 }),
       "activity.matches": matches_created_in_range,
-      "activity.match_taken_care_of": matches_taken_care_in_range.with_status([:taking_care, :done]),
-      "activity.match_done": matches_taken_care_in_range.with_status(:done),
-      "activity.match_not_for_me": matches_taken_care_in_range.with_status(:not_for_me),
+      "activity.match_taken_care_of": matches_taken_care_in_range.where(status: [:taking_care, :done]),
+      "activity.match_done": matches_taken_care_in_range.where(status: done),
+      "activity.match_not_for_me": matches_taken_care_in_range.where(status: not_for_me),
     }
   end
 

--- a/app/models/match.rb
+++ b/app/models/match.rb
@@ -82,7 +82,6 @@ class Match < ApplicationRecord
   ## Scopes
   #
   scope :not_viewed, -> { where(expert_viewed_page_at: nil) }
-  scope :with_status, -> (status) { where(status: status) }
 
   scope :updated_more_than_five_days_ago, -> { where('matches.updated_at < ?', 5.days.ago) }
 

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -133,7 +133,7 @@ class User < ApplicationRecord
     joins(sent_diagnoses: [needs: :matches])
       .merge(Match
         .where(taken_care_of_at: date)
-        .with_status(status))
+        .where(status: status))
       .distinct
   end
 

--- a/spec/models/match_spec.rb
+++ b/spec/models/match_spec.rb
@@ -145,20 +145,6 @@ RSpec.describe Match, type: :model do
       it { is_expected.to eq [match] }
     end
 
-    describe 'with_status' do
-      let!(:match_with_status_quo) { create :match, status: :quo }
-      let!(:match_taken_care_of) { create :match, status: :taking_care }
-      let!(:match_with_status_done) { create :match, status: :done }
-      let!(:match_not_for_expert) { create :match, status: :not_for_me }
-
-      it do
-        expect(Match.with_status(:quo)).to eq [match_with_status_quo]
-        expect(Match.with_status(:taking_care)).to eq [match_taken_care_of]
-        expect(Match.with_status(:done)).to eq [match_with_status_done]
-        expect(Match.with_status(:not_for_me)).to eq [match_not_for_expert]
-      end
-    end
-
     describe 'updated_more_than_five_days_ago' do
       subject { Match.updated_more_than_five_days_ago }
 


### PR DESCRIPTION
Just use `where(status: <status>)` which has the same number of characters 🤷‍♂ 