### PR TITLE
Update the correct element after saving an expert reminders notes

### DIFF
--- a/app/views/reminders/reminders_notes.js.haml
+++ b/app/views/reminders/reminders_notes.js.haml
@@ -1,2 +1,2 @@
 var expert_contents_html = "#{j render('expert_reminders_notes', expert: @expert)}";
-document.getElementById('expert_contents-#{@expert.id}').innerHTML = expert_contents_html;
+document.getElementById('expert_reminders_notes-#{@expert.id}').innerHTML = expert_contents_html;


### PR DESCRIPTION
The bug isn’t noticeable, since the saved textfield has the same contents as the edited textfield, but it’s still bug.


https://sentry.data.gouv.fr/betagouvfr/place-des-entreprises/issues/1850469/