### PR TITLE
Properly validate visitee / visit date attributes in diagnosis step 4

### DIFF
--- a/app/controllers/diagnoses_controller.rb
+++ b/app/controllers/diagnoses_controller.rb
@@ -44,8 +44,13 @@ class DiagnosesController < ApplicationController
       redirect_to action: :step3, id: @diagnosis
     else
       flash.alert = @diagnosis.errors.full_messages.to_sentence
-      @themes = Theme.all.includes(:subjects)
-      render action: :step2
+      respond_to do |format|
+        format.js { render 'application/flashes' }
+        format.html do
+          @themes = Theme.all.includes(:subjects)
+          render action: :step2
+        end
+      end
     end
   end
 
@@ -62,7 +67,10 @@ class DiagnosesController < ApplicationController
       redirect_to action: :step4, id: @diagnosis
     else
       flash.alert = @diagnosis.errors.full_messages.to_sentence
-      render action: :step3
+      respond_to do |format|
+        format.js { render 'application/flashes' }
+        format.html { render action: :step3 }
+      end
     end
   end
 
@@ -77,7 +85,10 @@ class DiagnosesController < ApplicationController
       redirect_to besoin_path(@diagnosis)
     else
       flash.alert = @diagnosis.errors.full_messages.to_sentence
-      render action: :step4, status: :bad_request
+      respond_to do |format|
+        format.js { render 'application/flashes' }
+        format.html { render action: :step4, status: :bad_request }
+      end
     end
   end
 
@@ -95,11 +106,6 @@ class DiagnosesController < ApplicationController
 
   def params_for_visite
     permitted = params.require(:diagnosis).permit(:happened_on, visitee_attributes: [:full_name, :role, :email, :phone_number, :id])
-    permitted.require(:happened_on)
-    permitted.require(:visitee_attributes).require(:full_name)
-    permitted.require(:visitee_attributes).require(:role)
-    permitted.require(:visitee_attributes).require(:email)
-    permitted.require(:visitee_attributes).require(:phone_number)
     permitted
   end
 

--- a/app/models/diagnosis.rb
+++ b/app/models/diagnosis.rb
@@ -49,6 +49,7 @@ class Diagnosis < ApplicationRecord
   #
   validates :advisor, :facility, presence: true
   validates :step, inclusion: { in: AUTHORIZED_STEPS }
+  validate :step_4_has_visit_attributes
   validate :last_step_has_matches
   after_update :last_step_notify, if: :saved_change_to_step?
 
@@ -148,8 +149,19 @@ class Diagnosis < ApplicationRecord
 
   private
 
+  def step_4_has_visit_attributes
+    if step == 4
+      if visitee.nil?
+        errors.add(:visitee, :blank)
+      end
+      if happened_on.nil?
+        errors.add(:happened_on, :blank)
+      end
+    end
+  end
+
   def last_step_has_matches
-    if step == 5 && needs&.flat_map(&:matches)&.empty? # Note: we can’t rely on `self.matches` (a :through association) before the objects are actually saved
+    if step == LAST_STEP && needs&.flat_map(&:matches)&.empty? # Note: we can’t rely on `self.matches` (a :through association) before the objects are actually saved
       errors.add(:step, 'can’t be step 5 with no matches')
     end
   end

--- a/app/views/application/flashes.js.haml
+++ b/app/views/application/flashes.js.haml
@@ -1,0 +1,5 @@
+var flashes = "#{j render('layouts/flashes')}";
+document.getElementById('flashes').innerHTML = flashes;
+
+:ruby
+  flash.clear

--- a/app/views/layouts/_flashes.html.haml
+++ b/app/views/layouts/_flashes.html.haml
@@ -1,7 +1,8 @@
-- if alert
-  .ui.warning.message
-    %p= alert
+%p#flashes
+  - if alert
+    .ui.warning.message
+      %p= alert
 
-- if notice
-  .ui.info.message
-    %p= notice
+  - if notice
+    .ui.info.message
+      %p= notice

--- a/spec/factories/diagnoses.rb
+++ b/spec/factories/diagnoses.rb
@@ -4,6 +4,7 @@ FactoryBot.define do
   factory :diagnosis do
     association :advisor, factory: :user
     association :facility
+    association :visitee, factory: :contact_with_email
     content { Faker::Lorem.sentence }
     step { 1 }
     happened_on { 3.days.from_now }

--- a/spec/models/diagnosis_spec.rb
+++ b/spec/models/diagnosis_spec.rb
@@ -29,6 +29,27 @@ RSpec.describe Diagnosis, type: :model do
         it { is_expected.to be_valid }
       end
     end
+
+    describe 'step_4_has_visit_attributes' do
+      subject(:diagnosis) { build :diagnosis, step: 4, visitee: visitee, happened_on: happened_on }
+
+      context 'missing attributes' do
+        let(:visitee) { nil }
+        let(:happened_on) { nil }
+
+        before { diagnosis.validate }
+
+        it { is_expected.not_to be_valid }
+        it { expect(diagnosis.errors.details.keys).to match_array [:visitee, :happened_on] }
+      end
+
+      context 'with matches' do
+        let(:visitee) { build :contact_with_email }
+        let(:happened_on) { Date.today }
+
+        it { is_expected.to be_valid }
+      end
+    end
   end
 
   describe 'callbacks' do


### PR DESCRIPTION
Some diagnoses have no happened_on (which is why I’m sorting by created_at in _diagnoses.haml).

This happens when the user passes invalid data in step 3 and the browser doesn’t block them. This conditionally validates the presence of :happened_on, as well as :visitee for good measure.

Additionally, this revealed another issue in the diagnosis form where we don’t properly display flash messages because requests are made through ujs.