### PR TITLE
Drop user.institution

### DIFF
--- a/app/admin/expert.rb
+++ b/app/admin/expert.rb
@@ -5,7 +5,7 @@ ActiveAdmin.register Expert do
 
   # Index
   #
-  includes :antenne_institution, :antenne, :users, :skills, :received_matches
+  includes :institution, :antenne, :users, :skills, :received_matches
   config.sort_order = 'full_name_asc'
 
   scope :all, default: true
@@ -22,7 +22,7 @@ ActiveAdmin.register Expert do
       div '✆ ' + e.phone_number
     end
     column(:institution) do |e|
-      div admin_link_to(e, :antenne_institution)
+      div admin_link_to(e, :institution)
       div admin_link_to(e, :antenne)
     end
     column(:intervention_zone) do |e|
@@ -58,7 +58,7 @@ ActiveAdmin.register Expert do
   filter :role
   filter :email
   filter :phone_number
-  filter :antenne_institution, as: :ajax_select, data: { url: :admin_institutions_path, search_fields: [:name] }
+  filter :institution, as: :ajax_select, data: { url: :admin_institutions_path, search_fields: [:name] }
   filter :antenne, as: :ajax_select, data: { url: :admin_antennes_path, search_fields: [:name] }
   filter :antenne_territories, as: :ajax_select, data: { url: :admin_territories_path, search_fields: [:name] }
   filter :antenne_communes, as: :ajax_select, data: { url: :admin_communes_path, search_fields: [:insee_code] }
@@ -71,7 +71,7 @@ ActiveAdmin.register Expert do
     column :role
     column :email
     column :phone_number
-    column :antenne_institution
+    column :institution
     column :antenne
     column_count :antenne_territories
     column_count :antenne_communes
@@ -93,7 +93,7 @@ ActiveAdmin.register Expert do
       row :role
       row :email
       row :phone_number
-      row :antenne_institution
+      row :institution
       row :antenne
       row :reminders_notes
       row(:intervention_zone) do |e|

--- a/app/admin/user.rb
+++ b/app/admin/user.rb
@@ -34,7 +34,6 @@ ActiveAdmin.register User do
         div admin_link_to(u, :antenne_institution)
       else
         status_tag 'sans antenne', class: 'warning'
-        span u.institution
       end
     end
     column(:experts) do |u|
@@ -76,7 +75,7 @@ ActiveAdmin.register User do
     column :role
     column :antenne
     column :antenne_institution do |u|
-      u.antenne_institution || "sans antenne: #{u.institution}"
+      u.antenne_institution || "(sans antenne)"
     end
     column_list :experts
     column_count :searches
@@ -100,7 +99,6 @@ ActiveAdmin.register User do
           div admin_link_to(u, :antenne_institution)
         else
           status_tag 'sans antenne', class: 'warning'
-          span u.institution
         end
       end
       row(:experts) do |u|
@@ -156,7 +154,6 @@ ActiveAdmin.register User do
   form do |f|
     f.inputs I18n.t('active_admin.user.user_info') do
       f.input :full_name
-      f.input :institution
       f.input :antenne, as: :ajax_select, data: {
         url: :admin_antennes_path,
         search_fields: [:name],

--- a/app/admin/user.rb
+++ b/app/admin/user.rb
@@ -5,7 +5,7 @@ ActiveAdmin.register User do
 
   # Index
   #
-  includes :antenne, :antenne_institution, :experts, :searches,
+  includes :antenne, :institution, :experts, :searches,
            :sent_diagnoses, :sent_needs, :sent_matches
   config.sort_order = 'created_at_desc'
 
@@ -31,7 +31,7 @@ ActiveAdmin.register User do
       div u.role
       if u.antenne.present?
         div admin_link_to(u, :antenne)
-        div admin_link_to(u, :antenne_institution)
+        div admin_link_to(u, :institution)
       else
         status_tag 'sans antenne', class: 'warning'
       end
@@ -59,7 +59,7 @@ ActiveAdmin.register User do
   filter :email
   filter :role
   filter :antenne, as: :ajax_select, data: { url: :admin_antennes_path, search_fields: [:name] }
-  filter :antenne_institution, as: :ajax_select, data: { url: :admin_institutions_path, search_fields: [:name] }
+  filter :institution, as: :ajax_select, data: { url: :admin_institutions_path, search_fields: [:name] }
   filter :antenne_territories, as: :ajax_select, data: { url: :admin_territories_path, search_fields: [:name] }
   filter :antenne_communes, as: :ajax_select, data: { url: :admin_communes_path, search_fields: [:insee_code] }
 
@@ -74,9 +74,7 @@ ActiveAdmin.register User do
     column :is_approved?
     column :role
     column :antenne
-    column :antenne_institution do |u|
-      u.antenne_institution || "(sans antenne)"
-    end
+    column :institution
     column_list :experts
     column_count :searches
     column_count :sent_diagnoses
@@ -96,7 +94,7 @@ ActiveAdmin.register User do
         div u.role
         if u.antenne.present?
           div admin_link_to(u, :antenne)
-          div admin_link_to(u, :antenne_institution)
+          div admin_link_to(u, :institution)
         else
           status_tag 'sans antenne', class: 'warning'
         end

--- a/app/helpers/users/registrations_helper.rb
+++ b/app/helpers/users/registrations_helper.rb
@@ -3,7 +3,7 @@
 module Users
   module RegistrationsHelper
     def form_default_values_for_resource(resource)
-      %w[full_name institution role phone_number email].each do |attribute|
+      %w[full_name role phone_number email].each do |attribute|
         string = "default_#{attribute}"
         param = params[string.to_sym]
         resource.send("#{attribute}=", param)
@@ -12,7 +12,7 @@ module Users
 
     def new_registration_params(params)
       hash = {}
-      %w[full_name institution role phone_number email].each do |attribute|
+      %w[full_name role phone_number email].each do |attribute|
         string = "default_#{attribute}"
         hash[string.to_sym] = params[attribute.to_sym]
       end

--- a/app/models/diagnosis.rb
+++ b/app/models/diagnosis.rb
@@ -71,11 +71,11 @@ class Diagnosis < ApplicationRecord
 
   # :advisor
   has_one :advisor_antenne, through: :advisor, source: :antenne, inverse_of: :sent_diagnoses
-  has_one :advisor_institution, through: :advisor, source: :antenne_institution, inverse_of: :sent_diagnoses
+  has_one :advisor_institution, through: :advisor, source: :institution, inverse_of: :sent_diagnoses
 
   # :expert
   has_many :expert_antennes, through: :experts, source: :antenne, inverse_of: :received_diagnoses
-  has_many :expert_institutions, through: :experts, source: :antenne_institution, inverse_of: :received_diagnoses
+  has_many :expert_institutions, through: :experts, source: :institution, inverse_of: :received_diagnoses
   has_many :contacted_users, through: :experts, source: :users, inverse_of: :received_diagnoses
 
   ## Scopes

--- a/app/models/expert.rb
+++ b/app/models/expert.rb
@@ -55,7 +55,7 @@ class Expert < ApplicationRecord
   has_many :territories, -> { distinct.bassins_emploi }, through: :communes, inverse_of: :direct_experts
 
   # :antenne
-  has_one :antenne_institution, through: :antenne, source: :institution, inverse_of: :experts
+  has_one :institution, through: :antenne, source: :institution, inverse_of: :experts
   has_many :antenne_communes, through: :antenne, source: :communes, inverse_of: :antenne_experts
   has_many :antenne_territories, -> { distinct }, through: :antenne, source: :territories, inverse_of: :antenne_experts
 
@@ -89,7 +89,7 @@ class Expert < ApplicationRecord
   end
 
   scope :ordered_by_institution, -> do
-    joins(:antenne, :antenne_institution)
+    joins(:antenne, :institution)
       .select('experts.*', 'antennes.name', 'institutions.name')
       .order('institutions.name', 'antennes.name', :full_name)
   end

--- a/app/models/institution.rb
+++ b/app/models/institution.rb
@@ -22,8 +22,8 @@ class Institution < ApplicationRecord
   ## Through Associations
   #
   # :antennes
-  has_many :experts, through: :antennes, inverse_of: :antenne_institution
-  has_many :advisors, through: :antennes, inverse_of: :antenne_institution
+  has_many :experts, through: :antennes, inverse_of: :institution
+  has_many :advisors, through: :antennes, inverse_of: :institution
   has_many :sent_diagnoses, through: :antennes, inverse_of: :advisor_institution
   has_many :sent_needs, through: :antennes, inverse_of: :advisor_institution
   has_many :sent_matches, through: :antennes, inverse_of: :advisor_institution

--- a/app/models/match.rb
+++ b/app/models/match.rb
@@ -66,11 +66,11 @@ class Match < ApplicationRecord
 
   # :advisor
   has_one :advisor_antenne, through: :advisor, source: :antenne, inverse_of: :sent_matches
-  has_one :advisor_institution, through: :advisor, source: :antenne_institution, inverse_of: :sent_matches
+  has_one :advisor_institution, through: :advisor, source: :institution, inverse_of: :sent_matches
 
   # :expert
   has_one :expert_antenne, through: :expert, source: :antenne, inverse_of: :received_matches
-  has_one :expert_institution, through: :expert, source: :antenne_institution, inverse_of: :received_matches
+  has_one :expert_institution, through: :expert, source: :institution, inverse_of: :received_matches
   has_many :contacted_users, through: :expert, source: :users, inverse_of: :received_matches
 
   # :facility

--- a/app/models/need.rb
+++ b/app/models/need.rb
@@ -55,11 +55,11 @@ class Need < ApplicationRecord
 
   # :advisor
   has_one :advisor_antenne, through: :advisor, source: :antenne, inverse_of: :sent_needs
-  has_one :advisor_institution, through: :advisor, source: :antenne_institution, inverse_of: :sent_needs
+  has_one :advisor_institution, through: :advisor, source: :institution, inverse_of: :sent_needs
 
   # :experts
   has_many :expert_antennes, through: :experts, source: :antenne, inverse_of: :received_needs
-  has_many :expert_institutions, through: :experts, source: :antenne_institution, inverse_of: :received_needs
+  has_many :expert_institutions, through: :experts, source: :institution, inverse_of: :received_needs
   has_many :contacted_users, through: :experts, source: :users, inverse_of: :received_needs
 
   # :subject

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -80,7 +80,7 @@ class User < ApplicationRecord
   ## “Through” Associations
   #
   # :antenne
-  has_one :antenne_institution, through: :antenne, source: :institution, inverse_of: :advisors # TODO Should be named :institution when we remove the :institution text field.
+  has_one :institution, through: :antenne, source: :institution, inverse_of: :advisors
   has_many :antenne_communes, through: :antenne, source: :communes, inverse_of: :advisors
   has_many :antenne_territories, through: :antenne, source: :territories, inverse_of: :advisors
 
@@ -107,7 +107,7 @@ class User < ApplicationRecord
       .distinct
   }
   scope :ordered_by_institution, -> do
-    joins(:antenne, :antenne_institution)
+    joins(:antenne, :institution)
       .select('users.*', 'antennes.name', 'institutions.name')
       .order('institutions.name', 'antennes.name', :full_name)
   end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -13,7 +13,6 @@
 #  email                  :string           default(""), not null
 #  encrypted_password     :string           default(""), not null
 #  full_name              :string
-#  institution            :string
 #  is_admin               :boolean          default(FALSE), not null
 #  is_approved            :boolean          default(FALSE), not null
 #  last_sign_in_at        :datetime
@@ -180,11 +179,6 @@ class User < ApplicationRecord
       return self.experts.first.antenne
     end
 
-    antennes = Antenne.where('name ILIKE ?', "%#{self.institution}%")
-    if antennes.one?
-      return antennes.first
-    end
-
     antennes = Antenne.joins(:experts)
       .distinct
       .where('experts.email ILIKE ?', "%#{self.email.split('@').last}")
@@ -217,7 +211,7 @@ class User < ApplicationRecord
     if antenne.present?
       "#{role} - #{antenne.name}"
     else
-      "#{role} - #{institution}"
+      "#{role}"
     end
   end
 

--- a/app/views/devise/registrations/edit.html.haml
+++ b/app/views/devise/registrations/edit.html.haml
@@ -10,7 +10,7 @@
     %div
       = t('.waiting_confirmation_for', unconfirmed_email: resource.unconfirmed_email)
 
-  - %i[full_name institution role phone_number].each do |attribute|
+  - %i[full_name role phone_number].each do |attribute|
     .field
       = f.label attribute
       = f.text_field attribute

--- a/app/views/devise/registrations/new.html.haml
+++ b/app/views/devise/registrations/new.html.haml
@@ -11,9 +11,6 @@
     = f.label :full_name
     = f.text_field :full_name, autofocus: true, placeholder: t('.placeholders.full_name'), required: true
   .field.required
-    = f.label :institution
-    = f.text_field :institution, placeholder: t('.placeholders.institution'), required: true
-  .field.required
     = f.label :role
     = f.text_field :role, placeholder: t('.placeholders.role'), required: true
   .field.required

--- a/app/views/needs/_team.html.haml
+++ b/app/views/needs/_team.html.haml
@@ -3,8 +3,8 @@
     = expert.full_name
   .ui.segment
     %strong #{[t('activerecord.attributes.expert.role'), t('attributes.institution')].to_sentence} :
-    = institution_image(expert.antenne_institution.name, class: 'ui mini right spaced image')
-    #{expert.role}, #{expert.antenne.name}, #{expert.antenne_institution.name}
+    = institution_image(expert.institution.name, class: 'ui mini right spaced image')
+    #{expert.role}, #{expert.antenne.name}, #{expert.institution.name}
   - if expert.phone_number.present?
     .ui.segment
       %strong #{t('attributes.phone_number')} :

--- a/app/views/users/show.html.haml
+++ b/app/views/users/show.html.haml
@@ -1,6 +1,6 @@
 #profile
   .ui.segments
-    - %i[full_name institution role phone_number email].each do |attribute|
+    - %i[full_name role phone_number email].each do |attribute|
       .ui.attached.segment
         %strong #{User.human_attribute_name(attribute)} :
         = @user.send(attribute)

--- a/config/locales/models.fr.yml
+++ b/config/locales/models.fr.yml
@@ -265,7 +265,6 @@ fr:
     antenne_experts:
       one: Référent
       other: Référents
-    antenne_institution: Institution
     archived_at: Date d’archivage
     communes: Communes
     community: Communauté

--- a/config/locales/views.fr.yml
+++ b/config/locales/views.fr.yml
@@ -218,7 +218,6 @@ fr:
       new:
         placeholders:
           full_name: 'ex: Marie Dupont'
-          institution: Pôle emploi, Maison des Entreprises…
           role: Conseiller entreprise, Chargé de mission…
         warning_message: L’inscription est réservé aux conseillers d’entreprise et référents des organismes publics. Merci de bien vouloir utiliser votre adresse e-mail professionnelle afin que votre compte soit validé.
       signed_up: Bienvenue, vous êtes connecté.

--- a/db/migrate/20190809151052_remove_user_institution.rb
+++ b/db/migrate/20190809151052_remove_user_institution.rb
@@ -1,0 +1,5 @@
+class RemoveUserInstitution < ActiveRecord::Migration[5.2]
+  def change
+    remove_column :users, :institution, :string
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2019_08_09_124307) do
+ActiveRecord::Schema.define(version: 2019_08_09_151052) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -316,7 +316,6 @@ ActiveRecord::Schema.define(version: 2019_08_09_124307) do
     t.integer "contact_page_order"
     t.string "contact_page_role"
     t.string "phone_number"
-    t.string "institution"
     t.string "role"
     t.string "full_name"
     t.bigint "antenne_id"

--- a/spec/factories/users.rb
+++ b/spec/factories/users.rb
@@ -1,14 +1,11 @@
 # frozen_string_literal: true
 
 FactoryBot.define do
-  institutions = %w[Direccte MDE CCI]
-
   factory :user do
     full_name { Faker::Name.name }
     email { Faker::Internet.email }
     phone_number { Faker::PhoneNumber.phone_number }
     role { Faker::Job.title }
-    institution { institutions.sample }
     password { 'password' }
     password_confirmation { 'password' }
     confirmed_at { Time.zone.now }

--- a/spec/features/users/registrations_controller_spec.rb
+++ b/spec/features/users/registrations_controller_spec.rb
@@ -22,7 +22,6 @@ describe 'registrations', type: :feature do
       visit edit_user_registration_path
 
       fill_in id: 'user_full_name', with: 'John Doe'
-      fill_in id: 'user_institution', with: 'CIA'
       fill_in id: 'user_role', with: 'Detective'
       fill_in id: 'user_phone_number', with: '0987654321'
       fill_in id: 'user_current_password', with: 'password'
@@ -32,7 +31,6 @@ describe 'registrations', type: :feature do
 
     it 'updates the first name, last name, institution, role and phone number' do
       expect(current_user.reload.full_name).to eq 'John Doe'
-      expect(current_user.reload.institution).to eq 'CIA'
       expect(current_user.reload.role).to eq 'Detective'
       expect(current_user.reload.phone_number).to eq '0987654321'
     end

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -156,7 +156,7 @@ RSpec.describe User, type: :model do
   describe '#corresponding_antenne' do
     subject { user.corresponding_antenne }
 
-    let(:user) { create(:user, email: 'user@example.com', institution: 'DINSIC') }
+    let(:user) { create(:user, email: 'user@example.com') }
     let!(:antenne) { create :antenne, name: antenne_name }
 
     context ('matching by experts email') do
@@ -180,34 +180,6 @@ RSpec.describe User, type: :model do
         let(:expert_email) { 'user@example.com' }
 
         before { create(:expert, email: expert_email, antenne: create(:antenne)) }
-
-        it { is_expected.to be_nil }
-      end
-    end
-
-    context ('matching by antenne name') do
-      context ('with a corresponding name') do
-        let(:antenne_name) { 'DINSIC' }
-
-        it { is_expected.to eq antenne }
-      end
-
-      context ('with a partially matching name') do
-        let(:antenne_name) { 'DINSIC (Services du PM)' }
-
-        it { is_expected.to eq antenne }
-      end
-
-      context ('with a different name') do
-        let(:antenne_name) { 'other' }
-
-        it { is_expected.to be_nil }
-      end
-
-      context ('with several matching names') do
-        let(:antenne_name) { 'DINSIC' }
-
-        before { create :antenne, name: 'DINSIC 2' }
 
         it { is_expected.to be_nil }
       end


### PR DESCRIPTION
`user.antenne.institution.name` should be used instead (or the shortcut `user.institution.name`)

We only have few users remaining that are not linked to an institution, and as we plan to add a lot of users in the next months, let’s make this future-proof.