### PR TITLE
Prevent a crash when viewing a needs page when not connected

### DIFF
--- a/app/views/needs/_more_matches.haml
+++ b/app/views/needs/_more_matches.haml
@@ -1,5 +1,5 @@
 :ruby
-  return unless current_user.is_admin?
+  return unless current_user&.is_admin?
 
 :ruby
   additional_skills = ExpertSkill.additional_for(need)


### PR DESCRIPTION
e.g. experts with an access_token.