### PR TITLE
Fix date formatting for IE11 for diagnosis date

### DIFF
--- a/app/views/diagnoses/step3.html.haml
+++ b/app/views/diagnoses/step3.html.haml
@@ -56,7 +56,10 @@
     disableYear: true,
     formatter: {
       date: function (date, settings) {
-        return date.toLocaleDateString('fr-FR');
+        var d = date.getDate();
+        var m = date.getMonth() + 1;
+        var y = date.getFullYear();
+        return ("0"+d).slice(-2) + "/" + ("0"+m).slice(-2) + "/" + y;
       }
     },
     parser: {


### PR DESCRIPTION
IE11 adds `left-to-right` marks around the `/`, which then breaks the date parsing on ruby’s side. Let’s just format it manually.

This is a quick and dirty fix, until we
- use a proper date library
- refactor this form to not use the same formatter for display and for data. 😓

This is ugly, but not as bad as it seems. As a matter of fact, we require french formatting when used as text input, and the placeholder reads 'jj/mm/aaaa'.