### PR TITLE
Only include active needs in the “taking care” scope

### DIFF
--- a/app/models/concerns/involvement_concern.rb
+++ b/app/models/concerns/involvement_concern.rb
@@ -4,6 +4,7 @@ module InvolvementConcern
   def needs_taking_care
     received_needs
       .where(matches: received_matches.status_taking_care)
+      .active
       .archived(false)
   end
 


### PR DESCRIPTION
(reopen !519)
