### PR TITLE
Add Cache-Control headers for static assets

### DIFF
--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -19,6 +19,9 @@ Rails.application.configure do
   # Disable serving static files from the `/public` folder by default since
   # Apache or NGINX already handles this.
   config.public_file_server.enabled = ENV['RAILS_SERVE_STATIC_FILES'].present?
+  config.public_file_server.headers = {
+    'Cache-Control' => 'public, s-maxage=31536000, max-age=15552000'
+  }
 
   # Compress JavaScripts and CSS.
   config.assets.js_compressor = :uglifier

--- a/config/environments/staging.rb
+++ b/config/environments/staging.rb
@@ -19,6 +19,9 @@ Rails.application.configure do
   # Disable serving static files from the `/public` folder by default since
   # Apache or NGINX already handles this.
   config.public_file_server.enabled = ENV['RAILS_SERVE_STATIC_FILES'].present?
+  config.public_file_server.headers = {
+    'Cache-Control' => 'public, s-maxage=31536000, max-age=15552000'
+  }
 
   # Compress JavaScripts and CSS.
   config.assets.js_compressor = :uglifier


### PR DESCRIPTION
Properly add Cache-Control headers for static assets.

Add some point between Rails 4 and 5, Scalingo and rails_12factor, the proper configuration settings were lost.