### PR TITLE
Improve the “additional experts” flow

### DIFF
--- a/app/controllers/needs_controller.rb
+++ b/app/controllers/needs_controller.rb
@@ -31,6 +31,7 @@ class NeedsController < ApplicationController
 
     @experts = Expert.omnisearch(@query)
       .where.not(id: @need.experts)
+      .limit(15)
       .includes(:antenne, experts_skills: :skill)
   end
 

--- a/app/models/match.rb
+++ b/app/models/match.rb
@@ -142,6 +142,11 @@ class Match < ApplicationRecord
     ALLOWED_STATUS_TRANSITIONS[self.status.to_sym]
   end
 
+  def additional_match?
+    delay_after_first_match = (created_at - need.initial_matches_at)
+    delay_after_first_match > 5.minutes
+  end
+
   def expert_full_role
     "#{expert_full_name} - #{expert_institution_name}"
   end

--- a/app/models/need.rb
+++ b/app/models/need.rb
@@ -155,6 +155,10 @@ class Need < ApplicationRecord
     "#{company} : #{subject}"
   end
 
+  def initial_matches_at
+    matches.pluck(:created_at).min
+  end
+
   def last_activity_at
     dates = [updated_at, matches.pluck(:updated_at), feedbacks.pluck(:updated_at)].flatten
     dates.max

--- a/app/views/needs/_additional_experts.haml
+++ b/app/views/needs/_additional_experts.haml
@@ -7,21 +7,28 @@
     .ui.field.mini
       .ui.action.input.small
         = f.hidden_field :need, value: need.id
-        = f.text_field :query, value: local_assigns[:query], required: true, placeholder: t('.add_other_experts')
-        = f.button t('search'), class: 'ui button green basic small'
+        = f.text_field :query, value: local_assigns[:query],
+          autofocus: local_assigns[:query].present?,
+          required: true, minlength: 3, placeholder: t('.add_other_experts')
+        = f.button t('search'), data: { disable_with: t('search') }, class: 'ui button green basic small'
 
-  - if local_assigns[:experts].present?
-    .ui.list
-      - local_assigns[:experts].each do |expert|
+  - if !local_assigns[:experts].nil?
+    - if local_assigns[:experts].empty?
+      .ui.list
         .item
-          .header
-            = expert.full_name
-          .description
-            = expert.antenne
-          .list
-            - expert.experts_skills.each do |expert_skill|
-              .item
-                %i.angle.right.icon
-                .content
-                  - confirm_message = t('.add_match_with', name: expert.full_name, subject: need.subject)
-                  = link_to expert_skill.skill.title, add_match_need_path(expert_skill: expert_skill, need: need), method: :post, remote: true, data: { confirm: confirm_message }
+          = t('.no_expert_found')
+    - else
+      .ui.list
+        - local_assigns[:experts].each do |expert|
+          .item
+            .header
+              = expert.full_name
+            .description
+              = expert.antenne
+            .list
+              - expert.experts_skills.each do |expert_skill|
+                .item
+                  %i.angle.right.icon
+                  .content
+                    - confirm_message = t('.add_match_with', name: expert.full_name, subject: need.subject)
+                    = link_to expert_skill.skill.title, add_match_need_path(expert_skill: expert_skill, need: need), method: :post, remote: true, data: { confirm: confirm_message }

--- a/app/views/needs/_match.haml
+++ b/app/views/needs/_match.haml
@@ -1,5 +1,7 @@
 .ui.segment.clearing{ id: "match-#{match.id}", class: highlight ? 'match-highlighted' : '' }
   .needs-match
+    - if match.additional_match?
+      %h5= t('.additional_match', date: l(match.created_at.to_date, format: :long))
     - if match.expert.present?
       = person_block(match.expert, suffix: match.skill&.title)
     - else

--- a/config/locales/fr.yml
+++ b/config/locales/fr.yml
@@ -164,6 +164,7 @@ fr:
     additional_experts:
       add_match_with: Voulez-vous contacter %{name} au sujet de ce besoin (%{subject}) ?
       add_other_experts: Rechercher d’autres référents à mettre en relation
+      no_expert_found: Aucun résultat
   next_step: Passer à la suite
   'no': non
   number:

--- a/config/locales/views.fr.yml
+++ b/config/locales/views.fr.yml
@@ -464,6 +464,7 @@ fr:
       needs_taking_care: Besoins pris en charge
       title: Demandes reçues
     match:
+      additional_match: Mise en relation ultérieure (%{date})
       deleted_expert: Compte supprimé
     show:
       discussion: Discussion


### PR DESCRIPTION
Following #539

- limit queries
 - 3 characters minimum
 - 15 results max
 - disable button during request
- display “no results” when relevant
- indicate that a match has been made after the initial matches