### PR TITLE
Make sure semantic-ui popups in /besoins are activated

### DIFF
--- a/app/assets/javascripts/needs.js
+++ b/app/assets/javascripts/needs.js
@@ -1,3 +1,3 @@
-window.onload = function() {
+addEventListener('turbolinks:load', function(event) {
   $('.need-section .feed .event .user').popup({ hoverable: true });
-}
+});


### PR DESCRIPTION
`window.onload` doesn’t fire when navigating via turbolinks. (We had the same issue with matomo.)