### PR TITLE
Remove User::contact_page attributes

### DIFF
--- a/app/admin/user.rb
+++ b/app/admin/user.rb
@@ -119,8 +119,6 @@ ActiveAdmin.register User do
   sidebar I18n.t('active_admin.user.admin'), only: :show do
     attributes_table_for user do
       row :is_admin
-      row :contact_page_order
-      row :contact_page_role
     end
   end
 
@@ -145,7 +143,6 @@ ActiveAdmin.register User do
   # Form
   #
   permit_params :full_name, :email, :institution, :role, :phone_number, :is_approved,
-                :contact_page_order, :contact_page_role,
                 :is_admin, :password, :password_confirmation,
                 :antenne_id, expert_ids: []
 
@@ -175,8 +172,6 @@ ActiveAdmin.register User do
 
     f.inputs I18n.t('active_admin.user.admin') do
       f.input :is_admin, as: :boolean
-      f.input :contact_page_order
-      f.input :contact_page_role
     end
 
     f.actions

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -6,8 +6,6 @@
 #  confirmation_sent_at   :datetime
 #  confirmation_token     :string
 #  confirmed_at           :datetime
-#  contact_page_order     :integer
-#  contact_page_role      :string
 #  current_sign_in_at     :datetime
 #  current_sign_in_ip     :inet
 #  email                  :string           default(""), not null
@@ -102,12 +100,7 @@ class User < ApplicationRecord
   scope :approved, -> { where(is_approved: true) }
   scope :not_approved, -> { where(is_approved: false) }
   scope :email_not_confirmed, -> { where(confirmed_at: nil) }
-  scope :project_team, -> { admin.where.not(contact_page_order: nil) }
 
-  scope :ordered_for_contact, -> {
-    order(:contact_page_order, :full_name)
-      .distinct
-  }
   scope :ordered_by_institution, -> do
     joins(:antenne, :institution)
       .select('users.*', 'antennes.name', 'institutions.name')

--- a/config/locales/models.fr.yml
+++ b/config/locales/models.fr.yml
@@ -145,8 +145,6 @@ fr:
         confirmation_sent_at: Date d’envoi de l’e-mail de confirmation
         confirmation_token: Token de confirmation d’e-mail
         confirmed_at: Date de confirmation d’e-mail
-        contact_page_order: Ordre sur la page Contact
-        contact_page_role: Role sur la page Contact
         created_at: Date d’inscription
         current_password: Mot de passe actuel
         current_sign_in_at: Date de connexion

--- a/db/migrate/20191010145528_remove_user_contact_page_order.rb
+++ b/db/migrate/20191010145528_remove_user_contact_page_order.rb
@@ -1,0 +1,6 @@
+class RemoveUserContactPageOrder < ActiveRecord::Migration[5.2]
+  def change
+    remove_column :users, :contact_page_order, :integer
+    remove_column :users, :contact_page_role, :string
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2019_09_27_063512) do
+ActiveRecord::Schema.define(version: 2019_10_10_145528) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -319,8 +319,6 @@ ActiveRecord::Schema.define(version: 2019_09_27_063512) do
     t.datetime "updated_at", null: false
     t.boolean "is_admin", default: false, null: false
     t.boolean "is_approved", default: false, null: false
-    t.integer "contact_page_order"
-    t.string "contact_page_role"
     t.string "phone_number"
     t.string "role"
     t.string "full_name"

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -47,17 +47,6 @@ RSpec.describe User, type: :model do
   end
 
   describe 'scopes' do
-    describe 'ordered_for_contact' do
-      it do
-        user1 = create :user, contact_page_order: 1
-        user2 = create :user, contact_page_order: 2
-        user3 = create :user, contact_page_order: 3
-        user4 = create :user, contact_page_order: 4
-
-        expect(User.ordered_for_contact).to eq [user1, user2, user3, user4]
-      end
-    end
-
     describe 'not_admin' do
       it do
         create :user, is_admin: true


### PR DESCRIPTION
The “Team” info has been removed from the public pages for a while.