### PR TITLE
Add a honeypot field to the solicitation form

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -52,6 +52,7 @@ gem 'jbuilder'
 gem 'mailjet'
 gem 'turbolinks'
 gem 'rails-i18n'
+gem 'honeypot-captcha'
 
 # Notifiers
 gem 'sentry-raven'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -187,6 +187,7 @@ GEM
     highcharts-rails (6.0.3)
       railties (>= 3.1)
     highline (2.0.3)
+    honeypot-captcha (1.0.1)
     html2haml (2.2.0)
       erubis (~> 2.7.0)
       haml (>= 4.0, < 6)
@@ -510,6 +511,7 @@ DEPENDENCIES
   haml-rails
   haml_lint
   highcharts-rails
+  honeypot-captcha
   http
   i18n-tasks
   jbuilder

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -49,6 +49,12 @@ class ApplicationController < ActionController::Base
     current_expert.present? || not_found
   end
 
+  ## Configuration for honeypot-captcha
+  #
+  def honeypot_fields
+    { :commentaire => 'Laissez ce champ vide !' }
+  end
+
   private
 
   def render_error(exception)

--- a/app/views/solicitations/_form.haml
+++ b/app/views/solicitations/_form.haml
@@ -1,6 +1,6 @@
 #solicitation-form
   %h2.section__title= t('.title')
-  = form_with(model: @solicitation, url: solicitation_path, scope: 'solicitation', method: :post) do |f|
+  = form_with(model: @solicitation, url: solicitation_path, scope: 'solicitation', method: :post, html: { honeypot: true }) do |f|
     - @solicitation.form_info.each do |k,v|
       = f.hidden_field "form_info[#{k}]", value: v
     .form__group


### PR DESCRIPTION
We don’t have a spam problem — yet. This is a basically free solution; if/when it’s not enough, we’ll start looking for more.

Note: this gem adds inline CSS, that _might_ be an issue for CSP. We’ll see. In the worse case, it’s not really hard to add a honeypot field ourselves.