### PR TITLE
Stop using Devise:confirmable for Users

### DIFF
--- a/app/admin/user.rb
+++ b/app/admin/user.rb
@@ -16,7 +16,6 @@ ActiveAdmin.register User do
   scope :admin
   scope :without_antenne
   scope :deactivated
-  scope :email_not_confirmed
   scope :not_invited_yet, group: :invitations
   scope :invitation_not_accepted, group: :invitations
 

--- a/app/models/antenne.rb
+++ b/app/models/antenne.rb
@@ -13,7 +13,8 @@
 #
 # Indexes
 #
-#  index_antennes_on_institution_id  (institution_id)
+#  index_antennes_on_institution_id           (institution_id)
+#  index_antennes_on_name_and_institution_id  (name,institution_id) UNIQUE
 #
 # Foreign Keys
 #

--- a/app/models/institution.rb
+++ b/app/models/institution.rb
@@ -9,6 +9,10 @@
 #  created_at     :datetime         not null
 #  updated_at     :datetime         not null
 #
+# Indexes
+#
+#  index_institutions_on_name  (name) UNIQUE
+#
 
 class Institution < ApplicationRecord
   ## Associations

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -50,10 +50,6 @@
 #
 
 class User < ApplicationRecord
-  ## Constants
-  #
-  WHITELISTED_DOMAINS = %w[beta.gouv.fr direccte.gouv.fr pole-emploi.fr pole-emploi.net cma-hautsdefrance.fr].freeze
-
   ##
   #
   include PersonConcern

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -54,7 +54,7 @@ class User < ApplicationRecord
   #
   include PersonConcern
   include InvolvementConcern
-  devise :database_authenticatable, :confirmable, :registerable, :recoverable, :rememberable, :trackable, :async,
+  devise :database_authenticatable, :registerable, :recoverable, :rememberable, :trackable, :async,
          :validatable,
          :invitable, invited_by_class_name: 'User', validate_on_invite: true
 
@@ -93,14 +93,8 @@ class User < ApplicationRecord
   scope :admin, -> { where(is_admin: true) }
   scope :not_admin, -> { where(is_admin: false) }
   scope :deactivated, -> { where.not(deactivated_at: nil) }
-  scope :email_not_confirmed, -> { where(confirmed_at: nil) }
 
-  # Invitations scopes: TODO: `confirmable` is to be removed, related queries will be adjusted
-  scope :not_invited_yet, -> do
-    where(invitation_created_at: nil)
-      .where(confirmation_sent_at: nil) # This will be removed
-      .where(confirmed_at: nil)         # This will be removed
-  end
+  scope :not_invited_yet, -> { where(invitation_sent_at: nil) }
   # :invitation_not_accepted and :invitation_accepted are declared in devise_invitable/model.rb
 
   scope :ordered_by_institution, -> do

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -66,7 +66,7 @@ class User < ApplicationRecord
   has_many :searches, dependent: :destroy, inverse_of: :user
   has_many :feedbacks, dependent: :destroy, inverse_of: :user
   belongs_to :inviter, class_name: 'User', inverse_of: :invitees, optional: true
-  has_many :invitees, class_name: 'User', foreign_key: 'inviter_id', inverse_of: :inviter
+  has_many :invitees, class_name: 'User', foreign_key: 'inviter_id', inverse_of: :inviter, counter_cache: :invitations_count
 
   ## Validations
   #

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -8,6 +8,7 @@
 #  confirmed_at           :datetime
 #  current_sign_in_at     :datetime
 #  current_sign_in_ip     :inet
+#  deactivated_at         :datetime
 #  email                  :string           default(""), not null
 #  encrypted_password     :string           default(""), not null
 #  full_name              :string
@@ -18,7 +19,6 @@
 #  invitation_token       :string
 #  invitations_count      :integer          default(0)
 #  is_admin               :boolean          default(FALSE), not null
-#  is_approved            :boolean          default(FALSE), not null
 #  last_sign_in_at        :datetime
 #  last_sign_in_ip        :inet
 #  phone_number           :string
@@ -41,7 +41,6 @@
 #  index_users_on_invitation_token      (invitation_token) UNIQUE
 #  index_users_on_invitations_count     (invitations_count)
 #  index_users_on_inviter_id            (inviter_id)
-#  index_users_on_is_approved           (is_approved)
 #  index_users_on_reset_password_token  (reset_password_token) UNIQUE
 #
 # Foreign Keys

--- a/config/locales/models.fr.yml
+++ b/config/locales/models.fr.yml
@@ -33,7 +33,6 @@ fr:
       deactivated: Désactivés
       diagnosis_completed: Analyses terminées
       done: Clôturé
-      email_not_confirmed: Email non confirmé
       invitation_not_accepted: Invitations pas encore acceptées
       not_invited_yet: Invitations à envoyer
       not_taken_after_3_weeks: 3 semaines sans réponse


### PR DESCRIPTION
We’re only relying on invitations from now on : users can’t change their email on their own.

This is almost the last step regarding invitations management; we’ll actually drop the confirmable-related column in a moment.