### PR TITLE
Send relevant emails (or not) when the user resets their password

### DIFF
--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -147,6 +147,20 @@ class User < ApplicationRecord
     end
   end
 
+  # Override from Devise::Models::Recoverable:
+  # * Prevent sending reset emails to users that were imported, but not even invited yet
+  # * If the user has been invited, but hasn’t clicked the invitation link yet, resend them the invitation.
+  # We also want Devise.paranoid to be true to prevent user enumeration.
+  def send_reset_password_instructions
+    if invitation_sent_at.nil?
+      return
+    elsif invitation_accepted_at.nil?
+      invite!
+    else
+      super
+    end
+  end
+
   ## Deactivation
   #
   def active_for_authentication?

--- a/config/initializers/devise.rb
+++ b/config/initializers/devise.rb
@@ -77,7 +77,7 @@ Devise.setup do |config|
   # It will change confirmation, password recovery and other workflows
   # to behave the same regardless if the e-mail provided was right or wrong.
   # Does not affect registerable.
-  # config.paranoid = true
+  config.paranoid = true
 
   # By default Devise will store the user in session. You can skip storage for
   # particular strategies by setting this option.

--- a/config/locales/devise.fr.yml
+++ b/config/locales/devise.fr.yml
@@ -53,7 +53,7 @@ fr:
       new:
         send_me_reset_password_instructions: Envoyer les instructions de réinitialisation
       no_token: Vous ne pouvez accéder à cette page sans passer par un e-mail de réinitialisation de mot de passe. Si vous êtes passé par un e-mail de ce type, assurez-vous d’utiliser l’URL complète.
-      send_instructions: Vous allez recevoir les instructions de réinitialisation du mot de passe dans quelques instants.
+      send_paranoid_instructions: Si votre adresse est présente dans notre système, vous allez recevoir les instructions de réinitialisation du mot de passe dans quelques instants.
       updated: Votre nouveau mot de passe a bien été enregistré, vous êtes maintenant connecté.
       updated_not_active: Votre nouveau mot de passe a bien été enregistré.
     registrations:


### PR DESCRIPTION
* Email unknown: send nothing (obv)
* User imported, but not yet invited : send nothing
* User invited, but invitation not accepted yet: re-invite
* User with accepted invitation: send the regular reset email

In all cases: do not indicate whether the email is known.