### PR TITLE
Display 3 landing per row on the home page

### DIFF
--- a/app/views/landings/_landings.haml
+++ b/app/views/landings/_landings.haml
@@ -1,5 +1,5 @@
 %h2.section__title= t('.title')
-- landings.each_slice(4) do |landings|
+- landings.each_slice(3) do |landings|
   .row
     = render landings, links_tracking_params: links_tracking_params
 


### PR DESCRIPTION
We have 9 landings now 🤷🏻‍♂️.

I’d use a grid but it would fail on IE11.