### PR TITLE
Revert erroneous search-and-replace in a9b562

### DIFF
--- a/db/migrate/20190325142929_add_archived_at_to_question.rb
+++ b/db/migrate/20190325142929_add_archived_at_to_question.rb
@@ -1,6 +1,6 @@
 class AddArchivedAtToQuestion < ActiveRecord::Migration[5.2]
   def change
-    add_column :subjects, :archived_at, :datetime
-    add_index :subjects, :archived_at
+    add_column :questions, :archived_at, :datetime
+    add_index :questions, :archived_at
   end
 end


### PR DESCRIPTION
🤷🏻‍♂️ hopefully this will let migrations pass from scratch (and will allow scalingo review apps to run)