### PR TITLE
Soft-delete users and clear personal information

### DIFF
--- a/app/admin/user.rb
+++ b/app/admin/user.rb
@@ -5,6 +5,18 @@ require 'admin/user_importer.rb'
 ActiveAdmin.register User do
   menu priority: 3
 
+  controller do
+    def scoped_collection
+      # We don’t use a default_scope in User, but do we want to hide delete users in /admin/users …
+      User.not_deleted
+    end
+
+    def find_resource
+      # … however, when clicking the advisor of a diagnosis, we want to see it even if it is soft-deleted.
+      User.where(id: params[:id]).first!
+    end
+  end
+
   # Index
   #
   includes :antenne, :institution, :experts, :searches,

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -9,7 +9,8 @@
 #  current_sign_in_at     :datetime
 #  current_sign_in_ip     :inet
 #  deactivated_at         :datetime
-#  email                  :string           default(""), not null
+#  deleted_at             :datetime
+#  email                  :string           default("")
 #  encrypted_password     :string           default(""), not null
 #  full_name              :string
 #  invitation_accepted_at :datetime
@@ -36,8 +37,9 @@
 # Indexes
 #
 #  index_users_on_antenne_id            (antenne_id)
-#  index_users_on_confirmation_token    (confirmation_token)
-#  index_users_on_email                 (email) UNIQUE
+#  index_users_on_confirmation_token    (confirmation_token) UNIQUE
+#  index_users_on_deleted_at            (deleted_at)
+#  index_users_on_email                 (email) UNIQUE WHERE ((email)::text <> NULL::text)
 #  index_users_on_invitation_token      (invitation_token) UNIQUE
 #  index_users_on_invitations_count     (invitations_count)
 #  index_users_on_inviter_id            (inviter_id)
@@ -63,14 +65,14 @@ class User < ApplicationRecord
   belongs_to :antenne, counter_cache: :advisors_count, inverse_of: :advisors, optional: true
   has_and_belongs_to_many :experts, inverse_of: :users
   has_many :sent_diagnoses, class_name: 'Diagnosis', foreign_key: 'advisor_id', inverse_of: :advisor
-  has_many :searches, dependent: :destroy, inverse_of: :user
-  has_many :feedbacks, dependent: :destroy, inverse_of: :user
+  has_many :searches, inverse_of: :user
+  has_many :feedbacks, inverse_of: :user
   belongs_to :inviter, class_name: 'User', inverse_of: :invitees, optional: true
   has_many :invitees, class_name: 'User', foreign_key: 'inviter_id', inverse_of: :inviter, counter_cache: :invitations_count
 
   ## Validations
   #
-  validates :full_name, :phone_number, presence: true
+  validates :full_name, :phone_number, presence: true, unless: :deleted?
 
   ## “Through” Associations
   #
@@ -90,9 +92,11 @@ class User < ApplicationRecord
 
   ## Scopes
   #
+  scope :not_deleted, -> { where(deleted_at: nil) }
+  scope :deactivated, -> { where.not(deactivated_at: nil) }
+
   scope :admin, -> { where(is_admin: true) }
   scope :not_admin, -> { where(is_admin: false) }
-  scope :deactivated, -> { where.not(deactivated_at: nil) }
 
   scope :not_invited_yet, -> { where(invitation_sent_at: nil) }
   # :invitation_not_accepted and :invitation_accepted are declared in devise_invitable/model.rb
@@ -161,13 +165,13 @@ class User < ApplicationRecord
     end
   end
 
-  ## Deactivation
+  ## Deactivation and soft deletion
   #
   def active_for_authentication?
-    super && !deactivated?
+    super && !deactivated? && !deleted?
   end
 
-  def inactive_message
+  def inactive_message # override for Devise::Authenticatable
     deactivated_at.present? ? :deactivated : super
   end
 
@@ -181,6 +185,33 @@ class User < ApplicationRecord
 
   def reactivate!
     update(deactivated_at: nil)
+  end
+
+  def delete
+    update(deleted_at: Time.zone.now,
+      email: nil,
+      full_name: nil,
+      phone_number: nil)
+  end
+
+  def destroy
+    # Don’t really destroy!
+    # callbacks for :destroy are not run
+    delete
+  end
+
+  def deleted?
+    deleted_at.present?
+  end
+
+  def email_required? # Override from Devise::Validatable
+    !deleted?
+  end
+
+  def full_name
+    # Overriding this getter has a side-effect: :full_name is required to be present by PersonConcern.
+    # In #delete we set it to nil, but the result of this getter is used for the validation, which then passes.
+    deleted? ? I18n.t('deleted_user.full_name') : self[:full_name]
   end
 
   ## Administration helpers

--- a/config/locales/models.fr.yml
+++ b/config/locales/models.fr.yml
@@ -387,3 +387,5 @@ fr:
     user: Conseiller
     visit: Visite
     visitee: Personne rencontrée
+  deleted_user:
+    full_name: "(Compte supprimé)"

--- a/db/migrate/20191108085610_add_deleted_at_to_user.rb
+++ b/db/migrate/20191108085610_add_deleted_at_to_user.rb
@@ -1,0 +1,11 @@
+class AddDeletedAtToUser < ActiveRecord::Migration[5.2]
+  def change
+    add_column :users, :deleted_at, :datetime
+    add_index :users, :deleted_at
+
+    # We want emails to be unique, but allow nil values: let’s use a partial index
+    change_column_null :users, :email, true
+    remove_index :users, :email
+    add_index :users, :email, unique: true, where: 'email != NULL'
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2019_11_05_094826) do
+ActiveRecord::Schema.define(version: 2019_11_08_085610) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -302,7 +302,7 @@ ActiveRecord::Schema.define(version: 2019_11_05_094826) do
   end
 
   create_table "users", id: :serial, force: :cascade do |t|
-    t.string "email", default: "", null: false
+    t.string "email", default: ""
     t.string "encrypted_password", default: "", null: false
     t.string "reset_password_token"
     t.datetime "reset_password_sent_at"
@@ -312,6 +312,10 @@ ActiveRecord::Schema.define(version: 2019_11_05_094826) do
     t.datetime "last_sign_in_at"
     t.inet "current_sign_in_ip"
     t.inet "last_sign_in_ip"
+    t.string "confirmation_token"
+    t.datetime "confirmed_at"
+    t.datetime "confirmation_sent_at"
+    t.string "unconfirmed_email"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.boolean "is_admin", default: false, null: false
@@ -327,13 +331,11 @@ ActiveRecord::Schema.define(version: 2019_11_05_094826) do
     t.bigint "inviter_id"
     t.integer "invitations_count", default: 0
     t.datetime "deactivated_at"
-    t.string "unconfirmed_email"
-    t.datetime "confirmed_at"
-    t.string "confirmation_token"
-    t.datetime "confirmation_sent_at"
+    t.datetime "deleted_at"
     t.index ["antenne_id"], name: "index_users_on_antenne_id"
-    t.index ["confirmation_token"], name: "index_users_on_confirmation_token"
-    t.index ["email"], name: "index_users_on_email", unique: true
+    t.index ["confirmation_token"], name: "index_users_on_confirmation_token", unique: true
+    t.index ["deleted_at"], name: "index_users_on_deleted_at"
+    t.index ["email"], name: "index_users_on_email", unique: true, where: "((email)::text <> NULL::text)"
     t.index ["invitation_token"], name: "index_users_on_invitation_token", unique: true
     t.index ["invitations_count"], name: "index_users_on_invitations_count"
     t.index ["inviter_id"], name: "index_users_on_inviter_id"

--- a/spec/factories/feedbacks.rb
+++ b/spec/factories/feedbacks.rb
@@ -2,6 +2,13 @@ FactoryBot.define do
   factory :feedback do
     description { Faker::Lorem.paragraph }
     association :need
-    association :expert
+
+    trait :of_expert do
+      association :expert
+    end
+
+    trait :of_user do
+      association :user
+    end
   end
 end

--- a/spec/models/feedback_spec.rb
+++ b/spec/models/feedback_spec.rb
@@ -19,7 +19,7 @@ RSpec.describe Feedback, type: :model do
   describe 'can_be_modified_by?' do
     subject { feedback.can_be_modified_by?(expert) }
 
-    let(:feedback) { create :feedback }
+    let(:feedback) { create :feedback, :of_expert }
     let(:expert) { create :expert }
 
     context 'expert is the expert of the match' do


### PR DESCRIPTION
refs #641

Instead of actually destroying users from DB, we now:
* timestamp the deletion date, which makes them invalid for login
* blank the personal information (name, email and phone number)

That way, in the diagnoses and feedbacks of that user, we no longer indicate the user’s name but still know their Institution and Antenne.