### PR TITLE
Create Experts placeholder Users

### DIFF
--- a/app/admin/expert.rb
+++ b/app/admin/expert.rb
@@ -48,9 +48,6 @@ ActiveAdmin.register Expert do
     end
     actions dropdown: true do |expert|
       item t('active_admin.person.normalize_values'), normalize_values_admin_expert_path(expert)
-      if expert.users.empty?
-        item t('active_admin.expert.create_matching_user', count: 1), create_matching_user_admin_expert_path(expert)
-      end
     end
   end
 
@@ -125,10 +122,6 @@ ActiveAdmin.register Expert do
     link_to t('active_admin.person.normalize_values'), normalize_values_admin_expert_path(expert)
   end
 
-  action_item :create_matching_user, only: :show, if: -> { expert.users.empty? } do
-    link_to t('active_admin.expert.create_matching_user', count: 1), create_matching_user_admin_expert_path(expert)
-  end
-
   ## Form
   #
   permit_params [
@@ -190,22 +183,10 @@ ActiveAdmin.register Expert do
     redirect_back fallback_location: collection_path, alert: t('active_admin.person.normalize_values_done')
   end
 
-  member_action :create_matching_user do
-    resource.create_matching_user!
-    redirect_back fallback_location: collection_path, alert: t('active_admin.expert.create_matching_user_done', count: 1)
-  end
-
   batch_action I18n.t('active_admin.person.normalize_values') do |ids|
     batch_action_collection.find(ids).each do |expert|
       expert.normalize_values!
     end
     redirect_back fallback_location: collection_path, notice: I18n.t('active_admin.person.normalize_values_done')
-  end
-
-  batch_action I18n.t('active_admin.expert.create_matching_user', count: 2) do |ids|
-    batch_action_collection.find(ids).each do |expert|
-      expert.create_matching_user!
-    end
-    redirect_back fallback_location: collection_path, notice: I18n.t('active_admin.expert.create_matching_user_done', count: 2)
   end
 end

--- a/app/models/expert.rb
+++ b/app/models/expert.rb
@@ -7,7 +7,7 @@
 #  email           :string
 #  full_name       :string
 #  is_global_zone  :boolean          default(FALSE)
-#  phone_number    :string
+#  phone_number    :string           not null
 #  reminders_notes :text
 #  role            :string
 #  created_at      :datetime         not null
@@ -46,7 +46,7 @@ class Expert < ApplicationRecord
 
   ## Validations
   #
-  validates :antenne, :email, :access_token, presence: true
+  validates :antenne, :email, :phone_number, :access_token, presence: true
   validates :access_token, uniqueness: true
 
   before_validation :generate_access_token!, on: :create

--- a/app/models/expert.rb
+++ b/app/models/expert.rb
@@ -156,7 +156,6 @@ class Expert < ApplicationRecord
       antenne: antenne,
       role: role
     }
-    params[:password] = SecureRandom.base64(8)
 
     User.create!(params)
   end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -147,13 +147,11 @@ class User < ApplicationRecord
   end
 
   # Override from Devise::Models::Recoverable:
-  # * Prevent sending reset emails to users that were imported, but not even invited yet
   # * If the user has been invited, but hasn’t clicked the invitation link yet, resend them the invitation.
-  # We also want Devise.paranoid to be true to prevent user enumeration.
+  # * Otherwise just send a password reset email.
+  # (We also want Devise.paranoid to be true to prevent user enumeration.)
   def send_reset_password_instructions
-    if invitation_sent_at.nil?
-      return
-    elsif invitation_accepted_at.nil?
+    if invitation_sent_at.present? && invitation_accepted_at.nil?
       invite!
     else
       super

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -160,6 +160,10 @@ class User < ApplicationRecord
     end
   end
 
+  def placeholder_for_expert?
+    invitation_sent_at.nil? && encrypted_password.blank?
+  end
+
   ## Deactivation and soft deletion
   #
   def active_for_authentication?

--- a/app/views/devise/mailer/reset_password_instructions.html.haml
+++ b/app/views/devise/mailer/reset_password_instructions.html.haml
@@ -1,9 +1,13 @@
 %p= t('devise.mailer.hello', user_full_name: @resource.full_name)
 
-%p= t('.someone_has_requested_a_link_html', date: l(@resource.reset_password_sent_at, format: :long_sentence), email: @resource.email)
+- if @resource.placeholder_for_expert?
+  %p= t('.account_but_never_connected_html')
+- else
+  %p= t('.someone_has_requested_a_link_html', date: l(@resource.reset_password_sent_at, format: :long_sentence), email: @resource.email)
 
 %p
   .button
-    %a{ href: edit_password_url(@resource, reset_password_token: @token) }= t('.change_my_password')
+    %a{ href: edit_password_url(@resource, reset_password_token: @token) }
+      = @resource.placeholder_for_expert? ? t('.choose_my_password') : t('.change_my_password')
 
 %p.text-grey= t('.ignore')

--- a/app/views/devise/passwords/edit.html.haml
+++ b/app/views/devise/passwords/edit.html.haml
@@ -1,18 +1,18 @@
-%h2= t('.change_own_password')
+%h2= t('.password_reset')
 
-- url = password_path(resource_name)
-= form_for resource, as: resource_name, url: url, html: { method: :put, class: 'ui form' } do |f|
-  = render "devise/shared/error_messages", resource: resource
-  = f.hidden_field :reset_password_token
-  .field
-    = f.label :password, t('.new_password')
-    - if @minimum_password_length
-      %em= t('devise.password_minimum_characters', count: @minimum_password_length)
-    = f.password_field :password, autofocus: true, autocomplete: 'off'
-  .field
-    = f.label :password_confirmation
-    = f.password_field :password_confirmation, autocomplete: 'off'
-  .actions
-    = f.submit t('.change_own_password'), class: 'ui button green'
+.ui.very.padded.segment.shadow-less
+  = form_for resource, as: resource_name, url: password_path(resource_name), html: { method: :put, class: 'ui form' } do |f|
+    = render "devise/shared/error_messages", resource: resource
+    = f.hidden_field :reset_password_token
+    %p= t('.password_reset_description')
+    .field
+      = f.label :password, t('.new_password')
+      - placeholder = t('devise.password_minimum_characters', count: @minimum_password_length)
+      = f.password_field :password, placeholder: placeholder, autofocus: true, autocomplete: 'new-password'
+    .field
+      = f.label :password_confirmation
+      = f.password_field :password_confirmation, autocomplete: 'new-password'
+    .actions
+      = f.submit t('.change_own_password'), class: 'ui button green'
 
-= render 'devise/shared/links'
+  = render 'devise/shared/links'

--- a/app/views/devise/passwords/new.html.haml
+++ b/app/views/devise/passwords/new.html.haml
@@ -1,12 +1,13 @@
 %h2= t('devise.forgot_password')
 
-- url = password_path(resource_name)
-= form_for resource, as: resource_name, url: url, html: { method: :post, class: 'ui form' } do |f|
-  = render "devise/shared/error_messages", resource: resource
-  .field
-    = f.label :email
-    = f.email_field :email, autofocus: true
-  .actions
-    = f.submit t('.send_me_reset_password_instructions'), class: 'ui button green'
+.ui.very.padded.segment.shadow-less
+  = form_for resource, as: resource_name, url: password_path(resource_name), html: { method: :post, class: 'ui form' } do |f|
+    = render "devise/shared/error_messages", resource: resource
+    .field
+      = f.label :email
+      = f.email_field :email, autofocus: true
+    %p= t('.password_unknown_description')
+    .actions
+      = f.submit t('.send_me_reset_password_instructions'), class: 'ui button green'
 
-= render 'devise/shared/links'
+  = render 'devise/shared/links'

--- a/app/views/devise/sessions/new.html.haml
+++ b/app/views/devise/sessions/new.html.haml
@@ -1,4 +1,5 @@
 %h2= t('sign_in')
+
 .ui.very.padded.segment.shadow-less
   = form_for resource, as: resource_name, url: session_path(resource_name), html: { class: 'ui form' } do |f|
     .field

--- a/app/views/devise/shared/_links.html.haml
+++ b/app/views/devise/shared/_links.html.haml
@@ -1,5 +1,6 @@
 .devise-links
-  - if controller_name != 'sessions'
-    %p= link_to t('sign_in'), new_session_path(resource_name)
   - if devise_mapping.recoverable? && controller_name != 'passwords' && controller_name != 'registrations'
-    %p= link_to t('devise.forgot_password'), new_password_path(resource_name)
+    %p
+      = link_to new_password_path(resource_name) do
+        %i.icon.question.circle.outline
+        = t('devise.forgot_password')

--- a/config/locales/devise.fr.yml
+++ b/config/locales/devise.fr.yml
@@ -35,10 +35,12 @@ fr:
         someone_invited_you_html: "%{inviter} (%{mail_to_inviter}) vous invite à rejoindre l’équipe de <b>%{antenne_name}</b>."
         subject: Invitation sur Place des Entreprises
       reset_password_instructions:
+        account_but_never_connected_html: "<p>Vous disposez d’un accès à Place des Entreprises mais vous n’êtes pas encore connecté.</p><p>Pour définir votre mot de passe et activer votre compte, cliquez sur ce bouton.</p><p>Une fois connecté, vous pourrez accéder à toutes les demandes qui vous ont été transmises; vous pourrez aussi faire vous même des mises en relation.</p>"
         change_my_password: Changer de mot de passe
+        choose_my_password: Choisir mon mot de passe
         ignore: Si vous n’êtes pas à l’origine de cette demande, vous pouvez ignorer cet e-mail. Votre mot de passe ne sera pas modifié.
-        someone_has_requested_a_link_html: Le %{date}, une demande de réinitalisation du mot de passe a été faite pour votre compte (<code>%{email}</code>). Cliquez sur le bouton ci-dessous pour choisir un nouveau mot de passe.
-        subject: Instructions pour changer le mot de passe
+        someone_has_requested_a_link_html: "<p>Le %{date}, une demande de réinitalisation du mot de passe a été faite pour votre compte (<code>%{email}</code>).</p><p>Cliquez sur le bouton ci-dessous pour choisir un nouveau mot de passe.</p>"
+        subject: 'Place des Entreprises : choisissez un mot de passe pour votre compte'
     omniauth_callbacks:
       failure: 'Nous n’avons pas pu vous authentifier via %{kind} : ''%{reason}''.'
       success: Authentifié avec succès via %{kind}.

--- a/config/locales/devise.fr.yml
+++ b/config/locales/devise.fr.yml
@@ -9,7 +9,7 @@ fr:
       not_found_in_database: E-mail ou mot de passe invalide.
       timeout: Votre session est expirée. Veuillez vous reconnecter pour continuer.
       unauthenticated: Vous devez vous connecter ou vous inscrire pour continuer.
-    forgot_password: Mot de passe oublié ?
+    forgot_password: Mot de passe oublié ou inconnu ?
     invitations:
       edit:
         header: Bienvenue sur Place des Entreprises
@@ -44,13 +44,16 @@ fr:
     omniauth_callbacks:
       failure: 'Nous n’avons pas pu vous authentifier via %{kind} : ''%{reason}''.'
       success: Authentifié avec succès via %{kind}.
-    password_minimum_characters: "(%{count} caractères minimum)"
+    password_minimum_characters: "%{count} caractères minimum"
     passwords:
       edit:
-        change_own_password: Changer son mot de passe
+        change_own_password: Enregistrer le mot de passe
         new_password: Nouveau mot de passe
+        password_reset: Choix du mot de passe
+        password_reset_description: 'Choisissez le nouveau mot de passe pour votre compte Place des Entreprises :'
       new:
-        send_me_reset_password_instructions: Envoyer les instructions de réinitialisation
+        password_unknown_description: Si vous ne connaissez pas ou plus votre mot de passe, saisissez l’e-mail de votre compte pour recevoir les instructions de choix de mot de passe.
+        send_me_reset_password_instructions: Envoyer les instructions
       no_token: Vous ne pouvez accéder à cette page sans passer par un e-mail de réinitialisation de mot de passe. Si vous êtes passé par un e-mail de ce type, assurez-vous d’utiliser l’URL complète.
       send_paranoid_instructions: Si votre adresse est présente dans notre système, vous allez recevoir les instructions de réinitialisation du mot de passe dans quelques instants.
       updated: Votre nouveau mot de passe a bien été enregistré, vous êtes maintenant connecté.

--- a/config/locales/models.fr.yml
+++ b/config/locales/models.fr.yml
@@ -1,13 +1,6 @@
 ---
 fr:
   active_admin:
-    expert:
-      create_matching_user:
-        one: Créer un utilisateur
-        other: Créer les utilisateurs
-      create_matching_user_done:
-        one: Utilisateur créé
-        other: Utilisateurs créés
     matches:
       deleted: Supprimé
     move: Déplacer

--- a/db/migrate/20191115134923_make_expert_phone_number_nonnull.rb
+++ b/db/migrate/20191115134923_make_expert_phone_number_nonnull.rb
@@ -1,0 +1,5 @@
+class MakeExpertPhoneNumberNonnull < ActiveRecord::Migration[5.2]
+  def change
+    change_column_null :experts, :phone_number, false
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2019_11_14_104842) do
+ActiveRecord::Schema.define(version: 2019_11_15_134923) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -129,7 +129,7 @@ ActiveRecord::Schema.define(version: 2019_11_14_104842) do
 
   create_table "experts", force: :cascade do |t|
     t.string "email"
-    t.string "phone_number"
+    t.string "phone_number", null: false
     t.string "role"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false

--- a/lib/tasks/create_experts_matching_users.rake
+++ b/lib/tasks/create_experts_matching_users.rake
@@ -1,0 +1,6 @@
+# Create users for experts with no user. See Expert#create_matching_user!
+task :create_experts_matching_users do
+  Expert.without_users.each do |expert|
+    expert.create_matching_user!
+  end
+end

--- a/spec/factories/experts.rb
+++ b/spec/factories/experts.rb
@@ -4,11 +4,8 @@ FactoryBot.define do
   factory :expert do
     full_name { Faker::Name.name }
     email { Faker::Internet.email }
+    phone_number { Faker::PhoneNumber.phone_number }
     role { Faker::Job.title }
     association :antenne
-
-    trait :with_phone_number do
-      phone_number { Faker::PhoneNumber.phone_number }
-    end
   end
 end

--- a/spec/factories/experts.rb
+++ b/spec/factories/experts.rb
@@ -7,5 +7,9 @@ FactoryBot.define do
     phone_number { Faker::PhoneNumber.phone_number }
     role { Faker::Job.title }
     association :antenne
+
+    trait :with_user do
+      users { [create(:user)] }
+    end
   end
 end

--- a/spec/mailers/previews/devise_mailer_preview.rb
+++ b/spec/mailers/previews/devise_mailer_preview.rb
@@ -11,6 +11,13 @@ class DeviseMailerPreview < ActionMailer::Preview
     Devise::Mailer.reset_password_instructions(user, 'faketoken')
   end
 
+  def reset_password_instructions_placeholder
+    user = User.all.sample
+    user.invitation_sent_at = nil
+    user.encrypted_password = nil
+    Devise::Mailer.reset_password_instructions(user, 'faketoken')
+  end
+
   # Other Devise emails never used:
   # confirmation_instructions: Signup is invite-only, and we don’t let users change their email themselves. If we allow it, we’ll use send_reconfirmation_instructions.
   # email_changed: config.send_email_change_notification is false

--- a/spec/models/expert_spec.rb
+++ b/spec/models/expert_spec.rb
@@ -21,6 +21,7 @@ RSpec.describe Expert, type: :model do
         is_expected.to validate_presence_of(:role)
         is_expected.to validate_presence_of(:antenne)
         is_expected.to validate_presence_of(:email)
+        is_expected.to validate_presence_of(:phone_number)
       end
     end
 

--- a/spec/models/expert_spec.rb
+++ b/spec/models/expert_spec.rb
@@ -71,6 +71,16 @@ RSpec.describe Expert, type: :model do
         it { is_expected.to match_array [expert_without_custom_communes] }
       end
     end
+
+    describe 'without_user' do
+      subject { described_class.without_users }
+
+      let!(:experts_without_users) { create_list :expert, 2 }
+
+      before { create_list :expert, 4, :with_user }
+
+      it { is_expected.to match_array experts_without_users }
+    end
   end
 
   describe 'to_s' do
@@ -108,6 +118,27 @@ RSpec.describe Expert, type: :model do
       end
 
       it { expect(expert.access_token).to eq 'access_token' }
+    end
+  end
+
+  describe 'create_matching_user!' do
+    context 'expert with no existing user' do
+      let(:expert) { create :expert }
+
+      it do
+        expect { expert.create_matching_user! }.to change(User, :count).by(1)
+        expect(expert.users).not_to be_empty
+        expect(expert.users.first).to be_placeholder_for_expert
+      end
+    end
+
+    context 'expert with preexisting user' do
+      let(:expert) { create :expert, :with_user }
+
+      it do
+        expect(expert.users).not_to be_empty
+        expect { expert.create_matching_user! }.not_to change(User, :count)
+      end
     end
   end
 end


### PR DESCRIPTION
* ⚠️  merge #649 and #650 first

* Add a rake task to create all Users for Experts without users
* These users are created without a password; they can’t be used to sign in.
* Reword and tweak the “reset password” email and forms to properly handle these new User accounts.

refs #638 