### PR TITLE
Don’t show deleted accounts when selecting users in admin

### DIFF
--- a/app/admin/antenne.rb
+++ b/app/admin/antenne.rb
@@ -87,19 +87,23 @@ ActiveAdmin.register Antenne do
     end
 
     f.inputs do
-      f.input :advisors, label: t('attributes.advisors'), as: :ajax_select, data: {
-        url: :admin_users_path,
-        search_fields: [:full_name],
-        limit: 999
-      }
+      f.input :advisors,
+              as: :ajax_select,
+              collection: [],
+              data: {
+                url: :admin_users_path,
+                search_fields: [:full_name]
+              }
     end
 
     f.inputs do
-      f.input :experts, label: t('attributes.experts'), as: :ajax_select, data: {
-        url: :admin_experts_path,
-        search_fields: [:full_name],
-        limit: 999
-      }
+      f.input :experts,
+              as: :ajax_select,
+              collection: [],
+              data: {
+                url: :admin_experts_path,
+                search_fields: [:full_name]
+              }
     end
 
     f.actions

--- a/app/admin/expert.rb
+++ b/app/admin/expert.rb
@@ -140,22 +140,26 @@ ActiveAdmin.register Expert do
   form do |f|
     f.inputs do
       f.input :full_name
-      f.input :antenne, as: :ajax_select, data: {
-        url: :admin_antennes_path,
-        search_fields: [:name],
-        limit: 999,
-      }
+      f.input :antenne,
+              as: :ajax_select,
+              collection: [],
+              data: {
+                url: :admin_antennes_path,
+                search_fields: [:name]
+              }
       f.input :role
       f.input :email
       f.input :phone_number
     end
 
     f.inputs t('activerecord.attributes.expert.users') do
-      f.input :users, label: t('activerecord.models.user.other'), as: :ajax_select, data: {
-        url: :admin_users_path,
-        search_fields: [:full_name],
-        limit: 999,
-      }
+      f.input :users, label: t('activerecord.models.user.other'),
+              as: :ajax_select,
+              collection: [],
+              data: {
+                url: :admin_users_path,
+                search_fields: [:full_name],
+              }
     end
 
     f.inputs t('attributes.custom_communes') do

--- a/app/admin/institution.rb
+++ b/app/admin/institution.rb
@@ -67,11 +67,13 @@ ActiveAdmin.register Institution do
       f.input :show_icon
     end
     f.inputs do
-      f.input :antennes, label: t('activerecord.attributes.institution.antennes'), as: :ajax_select, data: {
-        url: :admin_antennes_path,
-        search_fields: [:name],
-        limit: 999
-      }
+      f.input :antennes,
+              as: :ajax_select,
+              collection: [],
+              data: {
+                url: :admin_antennes_path,
+                search_fields: [:name]
+              }
     end
 
     f.actions

--- a/app/admin/user.rb
+++ b/app/admin/user.rb
@@ -183,16 +183,18 @@ ActiveAdmin.register User do
   form do |f|
     f.inputs I18n.t('active_admin.user.user_info') do
       f.input :full_name
-      f.input :antenne, as: :ajax_select, data: {
-        url: :admin_antennes_path,
-        search_fields: [:name],
-        limit: 999,
-      }
-      f.input :experts, as: :ajax_select, data: {
-        url: :admin_experts_path,
-        search_fields: [:full_name],
-        limit: 999,
-      }
+      f.input :antenne, as: :ajax_select,
+              collection: [],
+              data: {
+                url: :admin_antennes_path,
+                search_fields: [:name]
+              }
+      f.input :experts, as: :ajax_select,
+              collection: [],
+              data: {
+                url: :admin_experts_path,
+                search_fields: [:full_name]
+              }
       f.input :role
       f.input :email
       f.input :phone_number


### PR DESCRIPTION
Before:
<img width="558" alt="Capture d’écran 2019-11-21 à 10 34 29" src="https://user-images.githubusercontent.com/139391/69325663-c62a5e00-0c4a-11ea-927f-46d0b05776d6.png">

After:
<img width="525" alt="Capture d’écran 2019-11-21 à 10 35 14" src="https://user-images.githubusercontent.com/139391/69325669-c88cb800-0c4a-11ea-82b7-e09a5328171b.png">

---

Tweak “ajax_select” inputs in ActiveAdmin:

* For :users (and :advisors) inputs: specifying an empty collection prevents AA to preload the deleted accounts in the menu. The `scoped_collection` in admin/user.rb is respected by the actual ajax queries; however the initial content of the menu includes any Users, which made the deleted accounts available. (This is arguably a bug in the activeadmin-ajax_filter gem)
* For other :ajax_select inputs: remove the `limit: 999` I used to specify trying to make it look better. When the selected item is not present in the collection, AA will just display an empty field until the ajax query is actually made, which is weird and may take a few seconds in the worst scenarios. However, this is 1. fighting the framework, 2. plain ugly and 3. loads a bunch of stuff for nothing. Let’s just remove this quirk.