### PR TITLE
Shorten the meta-title so that “TPE et PME” fits in the google results

### DIFF
--- a/config/locales/views.fr.yml
+++ b/config/locales/views.fr.yml
@@ -131,7 +131,7 @@ fr:
       long_description_html: "<p>Patrons de TPE et PME, <strong>plus de 2 000 aides et accompagnements publics</strong> existent pour vous aider à grandir ou surmonter une difficulté.</p><p>Comment s’y retrouver parmi tous les organismes publics qui gèrent ces aides ? À quoi avez-vous droit ?</p><p>Le service <strong>Place des Entreprises</strong> trouve pour vous <strong>le bon conseiller public</strong> pour une aide personnalisée.</p>"
       meta:
         description: Financement de projets, difficultés financières, cession reprise, formation, recrutement… Service public rapide et gratuit pour accéder au bon conseiller.
-        title: Place des Entreprises, le guichet public d’accompagnement des TPE et PME
+        title: Place des Entreprises, le guichet public des TPE et PME
     institutions:
       title: '50 partenaires publics à votre service :'
     landing:


### PR DESCRIPTION
fixes #593