### PR TITLE
Display the same “advisors“ count in stats and ministats

### DIFF
--- a/app/views/stats/_ministats.haml
+++ b/app/views/stats/_ministats.haml
@@ -3,4 +3,4 @@
     - stats = Stats::Stats.new
     %p.stats__item= t('stats.series.companies_html', count: stats.companies.count)
     %p.stats__item= t('stats.series.needs_html', count: stats.needs.count)
-    %p.stats__item= t('stats.series.experts_html', count: stats.experts.count)
+    %p.stats__item= t('stats.series.advisors_html', count: stats.advisors.count)

--- a/app/views/stats/_stats_charts.haml
+++ b/app/views/stats/_stats_charts.haml
@@ -1,5 +1,5 @@
 - cache("stats_charts-#{stats.params}", expires_in: 1.hour) do
   .grid#stats-charts
-    - names = [:companies, :needs, :matches, :advisors, :experts, :solicitations]
+    - names = [:companies, :needs, :matches, :advisors, :solicitations]
     - names.each do |name|
       = render 'stats_chart', stats: stats, name: name

--- a/config/locales/views.fr.yml
+++ b/config/locales/views.fr.yml
@@ -360,9 +360,9 @@ fr:
       title: Merci !
   stats:
     series:
-      advisors_html: <span class="count">%{count}</span> conseillers inscrits
+      advisors_html: <span class="count">%{count}</span> conseillers publics
       companies_html: <span class="count">%{count}</span> entreprises aidées
-      experts_html: <span class="count">%{count}</span> conseillers publics
+      experts_html: <span class="count">%{count}</span> référents
       matches_html: <span class="count">%{count}</span> mises en relation
       needs_html: <span class="count">%{count}</span> demandes transmises
       solicitations_html: <span class="count">%{count}</span> sollicitations directes


### PR DESCRIPTION
fixes #590