### PR TITLE
Fix Admin to-many inputs forgetting relations

### DIFF
--- a/app/admin/antenne.rb
+++ b/app/admin/antenne.rb
@@ -89,7 +89,7 @@ ActiveAdmin.register Antenne do
     f.inputs do
       f.input :advisors,
               as: :ajax_select,
-              collection: [],
+              collection: resource.advisors,
               data: {
                 url: :admin_users_path,
                 search_fields: [:full_name]
@@ -99,7 +99,7 @@ ActiveAdmin.register Antenne do
     f.inputs do
       f.input :experts,
               as: :ajax_select,
-              collection: [],
+              collection: resource.experts,
               data: {
                 url: :admin_experts_path,
                 search_fields: [:full_name]

--- a/app/admin/expert.rb
+++ b/app/admin/expert.rb
@@ -142,7 +142,7 @@ ActiveAdmin.register Expert do
       f.input :full_name
       f.input :antenne,
               as: :ajax_select,
-              collection: [],
+              collection: [resource.antenne],
               data: {
                 url: :admin_antennes_path,
                 search_fields: [:name]
@@ -155,7 +155,7 @@ ActiveAdmin.register Expert do
     f.inputs t('activerecord.attributes.expert.users') do
       f.input :users, label: t('activerecord.models.user.other'),
               as: :ajax_select,
-              collection: [],
+              collection: resource.users,
               data: {
                 url: :admin_users_path,
                 search_fields: [:full_name],

--- a/app/admin/institution.rb
+++ b/app/admin/institution.rb
@@ -69,7 +69,7 @@ ActiveAdmin.register Institution do
     f.inputs do
       f.input :antennes,
               as: :ajax_select,
-              collection: [],
+              collection: resource.antennes,
               data: {
                 url: :admin_antennes_path,
                 search_fields: [:name]

--- a/app/admin/user.rb
+++ b/app/admin/user.rb
@@ -184,13 +184,13 @@ ActiveAdmin.register User do
     f.inputs I18n.t('active_admin.user.user_info') do
       f.input :full_name
       f.input :antenne, as: :ajax_select,
-              collection: [],
+              collection: [resource.antenne],
               data: {
                 url: :admin_antennes_path,
                 search_fields: [:name]
               }
       f.input :experts, as: :ajax_select,
-              collection: [],
+              collection: resource.experts,
               data: {
                 url: :admin_experts_path,
                 search_fields: [:full_name]


### PR DESCRIPTION
fixes #668

@LucienMLD est-ce que ça vaudrait la peine d‘écrire un mini-helper activeadmin pour ne pas réécrire ces 5 lignes à chaque fois qu’on utilise ajax_select? (dans une PR suivante, je préfèrerais merger ça rapidement pour éviter les accidents en prod)