### PR TITLE
Do not crash when sending an invitation with no inviter

### DIFF
--- a/app/views/devise/mailer/invitation_instructions.html.haml
+++ b/app/views/devise/mailer/invitation_instructions.html.haml
@@ -1,15 +1,17 @@
 %p= t('devise.mailer.hello', user_full_name: @resource.full_name)
 
-
 %p= t('.description_html', link_to_root: link_to(t('app_name'), root_url))
 
 %h3= t('.details_title')
 %p= t('.details_html')
 
-- someone_invited_you_html_params = { inviter: @resource.inviter.full_name,
-  mail_to_inviter: mail_to(@resource.inviter.email),
-  antenne_name: @resource.antenne.name }
-%p= t(".someone_invited_you_html", someone_invited_you_html_params)
+- if @resource.inviter.present?
+  %p= t(".someone_invited_you_html",
+    inviter: @resource.inviter.full_name,
+    mail_to_inviter: mail_to(@resource.inviter.email),
+    antenne_name: @resource.antenne.name)
+- else
+  %p= t(".anonymous_invited_you_html", antenne_name: @resource.antenne.name)
 
 %p
   .button

--- a/config/locales/devise.fr.yml
+++ b/config/locales/devise.fr.yml
@@ -28,6 +28,7 @@ fr:
       hello: Bonjour %{user_full_name},
       invitation_instructions:
         accept: Accepter l’invitation
+        anonymous_invited_you_html: Vous êtes invité à rejoindre l’équipe de <b>%{antenne_name}</b>.
         description_html: Vous êtes invité·e à rejoindre le nouveau service public %{link_to_root}, dédié à l’accompagnement des TPE et PME.
         details_html: Place des Entreprises permet de mettre en relation un nombre inédit d’administrations et d’organismes publics. Les besoins d’entreprises, déposés en ligne ou détectés par un conseiller, vous sont automatiquement adressés selon votre champ d’intervention. Vous pouvez aussi adresser facilement des besoin d’entreprises à l’ensemble des partenaires de Place des Entreprises.
         details_title: Qu’est-ce que c’est ?

--- a/spec/mailers/previews/devise_mailer_preview.rb
+++ b/spec/mailers/previews/devise_mailer_preview.rb
@@ -5,6 +5,11 @@ class DeviseMailerPreview < ActionMailer::Preview
     Devise::Mailer::invitation_instructions(user, 'faketoken')
   end
 
+  def invitation_instructions_anonymous
+    user = User.all.sample
+    Devise::Mailer::invitation_instructions(user, 'faketoken')
+  end
+
   def reset_password_instructions
     user = User.all.sample
     user.reset_password_sent_at = Time.now.utc


### PR DESCRIPTION
This happens when requesting a password reset before actually having received the invitation: an invitation is sent, but there is no inviter.

fixes #684