### PR TITLE
Fix Need::abandoned scope to only take human activity into account

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -4,7 +4,7 @@ require:
   - rubocop-rails
 
 AllCops:
-  TargetRubyVersion: 2.4
+  TargetRubyVersion: 2.6
   Exclude:
     - 'db/schema.rb'
     - 'tmp/**/*'

--- a/app/models/need.rb
+++ b/app/models/need.rb
@@ -100,9 +100,11 @@ class Need < ApplicationRecord
   scope :no_activity_after, -> (date) do
     where.not("needs.updated_at > ?", date)
       .left_outer_joins(:matches)
-      .where.not(matches: Match.where('updated_at > ?', date))
+      .where.not(matches: Match.where(created_at: date..)
+                          .or(Match.where(taken_care_of_at: date..))
+                          .or(Match.where(closed_at: date..)))
       .left_outer_joins(:feedbacks)
-      .where.not(feedbacks: Feedback.where('updated_at > ?', date))
+      .where.not(feedbacks: Feedback.where(created_at: date..))
       .distinct
   end
 
@@ -160,8 +162,12 @@ class Need < ApplicationRecord
   end
 
   def last_activity_at
-    dates = [updated_at, matches.pluck(:updated_at), feedbacks.pluck(:updated_at)].flatten
-    dates.max
+    dates = [
+      updated_at,
+      matches.pluck(:created_at, :taken_care_of_at, :closed_at),
+      feedbacks.pluck(:created_at)
+    ].flatten
+    dates.compact.max
   end
 
   def abandoned?


### PR DESCRIPTION
After #676, all matches were updated to link to the new subjects. This inadvertently changed the `udpated_at` values. Fortunately, using the other datetime values should yield pretty much the same result.

fixes #683

Also use ruby 2.6-style endless ranges for ActiveRecord queries :)