### PR TITLE
Fix crashes in /admin/themes

### DIFF
--- a/app/admin/theme.rb
+++ b/app/admin/theme.rb
@@ -6,7 +6,7 @@ ActiveAdmin.register Theme do
   ## Index
   #
   config.sort_order = 'interview_sort_order_asc'
-  includes :subjects, :institutions_subjects
+  includes :subjects, :institutions
 
   index do
     selectable_column
@@ -16,7 +16,7 @@ ActiveAdmin.register Theme do
     column :interview_sort_order
     column(:subjects) do |t|
       div admin_link_to(t, :subjects)
-      div admin_link_to(t, :institutions_subjects)
+      div admin_link_to(t, :institutions)
     end
     column(:needs) do |t|
       div admin_link_to(t, :needs)
@@ -43,7 +43,7 @@ ActiveAdmin.register Theme do
       row :label
       row :interview_sort_order
       row(:subjects) { |t| admin_link_to(t, :subjects) }
-      row(:institutions_subjects) { |t| admin_link_to(t, :institutions_subjects) }
+      row(:institutions) { |t| admin_link_to(t, :institutions) }
     end
     attributes_table do
       row(:needs) { |t| admin_link_to(t, :needs) }

--- a/app/models/institution.rb
+++ b/app/models/institution.rb
@@ -28,6 +28,7 @@ class Institution < ApplicationRecord
   #
   # :institutions_subjects
   has_many :subjects, through: :institutions_subjects, inverse_of: :institutions, dependent: :destroy
+  has_many :themes, through: :institutions_subjects, inverse_of: :institutions
 
   # :antennes
   has_many :experts, through: :antennes, inverse_of: :institution

--- a/app/models/institution_subject.rb
+++ b/app/models/institution_subject.rb
@@ -21,14 +21,15 @@
 #
 
 class InstitutionSubject < ApplicationRecord
+  ## Associations
+  #
   belongs_to :institution, inverse_of: :institutions_subjects
   belongs_to :subject, inverse_of: :institutions_subjects
-
   has_many :experts_subjects, dependent: :destroy
 
-  # :theme
+  # :subject
   #
-  has_one :theme, through: :subject, inverse_of: :institution_subject
+  has_one :theme, through: :subject, inverse_of: :institutions_subjects
 
   # :experts_subjects
   #

--- a/app/models/subject.rb
+++ b/app/models/subject.rb
@@ -33,6 +33,9 @@ class Subject < ApplicationRecord
   has_many :needs, inverse_of: :subject
   has_many :institutions_subjects, inverse_of: :subject
 
+  # :institutions_subjects
+  has_many :institutions, through: :institutions_subjects, inverse_of: :subjects
+
   ## Validations
   #
   validates :theme, presence: true

--- a/app/models/theme.rb
+++ b/app/models/theme.rb
@@ -20,9 +20,13 @@ class Theme < ApplicationRecord
 
   ## Through Associations
   #
+  # :subjects
   has_many :needs, through: :subjects, inverse_of: :theme
   has_many :matches, through: :subjects, inverse_of: :theme
   has_many :institutions_subjects, through: :subjects, inverse_of: :theme
+
+  # :institutions_subjects
+  has_many :institutions, through: :institutions_subjects, inverse_of: :themes
 
   ## Scopes
   #


### PR DESCRIPTION
Actually similar to #693; additionally, associations between theme and institutions were missing in the models.