### PR TITLE
Fix duplicate rows in ActiveAdmin

### DIFF
--- a/app/admin/patches/data_access.rb
+++ b/app/admin/patches/data_access.rb
@@ -1,0 +1,14 @@
+module Admin
+  module Patches
+    module DataAccess
+      ## !! Monkey-patch override !!
+      # When filtering for “has_many through” associations, AA  may yield duplicate rows in ActiveAdmin
+      # See #691
+      def scoped_collection
+        super.distinct
+      end
+    end
+
+    ActiveAdmin::ResourceController.prepend DataAccess
+  end
+end

--- a/app/admin/user.rb
+++ b/app/admin/user.rb
@@ -8,7 +8,7 @@ ActiveAdmin.register User do
   controller do
     def scoped_collection
       # We don’t use a default_scope in User, but do we want to hide delete users in /admin/users …
-      User.not_deleted
+      super.merge(User.not_deleted)
     end
 
     def find_resource


### PR DESCRIPTION
fixes #691

(This is actually a rerun of a (dirty) patch that was removed when migrating to Rails 6.)

Properly override the scoped_collection in a module.
ℹ️ The overriding module needs to be in a path that is watched by zeitwerk if we want autoreload to work.