### PR TITLE
Fix the import_dump task for postgres 12

### DIFF
--- a/lib/tasks/import_dump.rake
+++ b/lib/tasks/import_dump.rake
@@ -17,7 +17,7 @@ namespace :import_dump do
     pg_url = env.find{ |i| i[/SCALINGO_POSTGRESQL_URL=/] }
     pw = pg_url[/.*:(.*)@/,1]
 
-    sh "PGPASSWORD=#{pw} pg_dump --no-owner --no-acl e_conseils_2947 > tmp/export.pgsql  -h localhost -p 10000 -U e_conseils_2947 -o"
+    sh "PGPASSWORD=#{pw} pg_dump --no-owner --no-acl e_conseils_2947 > tmp/export.pgsql  -h localhost -p 10000 -U e_conseils_2947"
 
     kill_tunnel
   end


### PR DESCRIPTION
The -o option doesn’t exist anymore; I suspect we never actually needed it, it’s probably been copypasted since the beginning.