### PR TITLE
More fixes for activeadmin and zeitwerk

### DIFF
--- a/app/admin/concerns/admin_archivable.rb
+++ b/app/admin/concerns/admin_archivable.rb
@@ -1,7 +1,7 @@
+## Support for :archive and :unarchive actions in /admin
+#
 module AdminArchivable
   def self.included(dsl)
-    ## Actions
-    #
     ## Using `.send` because the ResourceDSL methods are (wrongly) private
     # See https://github.com/activeadmin/activeadmin/issues/3673#issuecomment-291267819
     dsl.send(:member_action, :archive) do
@@ -37,7 +37,7 @@ module AdminArchivable
     end
   end
 
-  ::ActiveAdmin::Views::IndexAsTable::IndexTableFor.module_eval do
+  module ArchivableIndexActions
     def index_row_archive_actions(resource)
       if resource.is_archived
         item t('archivable.unarchive'), polymorphic_path([:unarchive, :admin, resource])
@@ -46,4 +46,5 @@ module AdminArchivable
       end
     end
   end
+  ActiveAdmin::Views::IndexAsTable::IndexTableFor.include ArchivableIndexActions
 end

--- a/app/admin/helpers/admin_link_to.rb
+++ b/app/admin/helpers/admin_link_to.rb
@@ -1,0 +1,59 @@
+module Admin
+  module Helpers
+    ## Additional helpers for the objects links and attributes within /admin
+    #
+    module AdminLinkTo
+      def admin_link_to(object, association = nil, options = {})
+        if association.nil?
+          return link_to(object, polymorphic_path([:admin, object]))
+        end
+
+        klass = object.class
+        reflection = klass.reflect_on_association(association)
+
+        if reflection.collection?
+          if options[:list]
+            foreign_objects = object.send(association)
+            if foreign_objects.present?
+              links = foreign_objects.map { |foreign_object| link_to(foreign_object, polymorphic_path([:admin, foreign_object])) }
+              links.join('</br>').html_safe
+            else
+              '-'
+            end
+          else # single link to list
+            count = object.send(association).size
+            text = "#{count} #{klass.human_attribute_name(association, count: count).downcase}"
+            foreign_klass = reflection.klass
+            if reflection.options[:through].present?
+              # I’m not using `reflection.through_reflection` on purpose:
+              # when the through association is a HABTM, the reflectio returned by
+              # `reflection.through_reflection` is missing the :inverse_of option that we need.
+              # If we query the original klass for the reflection on the through association,
+              # we get all the declared options.
+              through_reflection = klass.reflect_on_association(reflection.options[:through])
+              names = [reflection.inverse_of.options[:through], through_reflection.options[:inverse_of]]
+              inverse_path = names.compact.join('_')
+            else
+              inverse_path = reflection.inverse_of.name
+            end
+            link_to(text, polymorphic_path([:admin, foreign_klass], "q[#{inverse_path}_id_eq]": object))
+          end
+        else
+          foreign_object = object.send(association)
+          if foreign_object.present?
+            link_to(foreign_object, polymorphic_path([:admin, foreign_object]))
+          else
+            '-'
+          end
+        end
+      end
+
+      def admin_attr(object, attribute)
+        klass = object.class
+        "#{klass.human_attribute_name(attribute)} : #{object.send(attribute)}"
+      end
+    end
+
+    Arbre::Element.include AdminLinkTo
+  end
+end

--- a/app/admin/helpers/csv_builder.rb
+++ b/app/admin/helpers/csv_builder.rb
@@ -1,0 +1,17 @@
+module Admin
+  module Helpers
+    ## Additional helpers for the :csv blocks
+    #
+    module CSVBuilderHelpers
+      def column_count(attribute)
+        column(attribute) { |object| object.send(attribute).size }
+      end
+
+      def column_list(association)
+        column(association) { |object| object.send(association).map(&:to_s).join('/') }
+      end
+    end
+
+    ActiveAdmin::CSVBuilder.include CSVBuilderHelpers
+  end
+end

--- a/app/admin/helpers/intervention_zone_description.rb
+++ b/app/admin/helpers/intervention_zone_description.rb
@@ -1,0 +1,38 @@
+module Admin
+  module Helpers
+    module InterventionZoneDescription
+      def intervention_zone_description(many_communes)
+        summary = many_communes.intervention_zone_summary
+
+        descriptions = summary[:territories].map do |hash|
+          territory = hash[:territory]
+          link = link_to(territory, admin_territory_path(territory))
+          description = "#{link} : #{hash[:included]} / #{territory.communes.count}"
+
+          if hash[:included] < territory.communes.count
+            params = many_communes.is_a?(Antenne) ? { antenne: many_communes } : { expert: many_communes }
+            confirm_message = I18n.t('active_admin.territory.confirm_assign_entire_territory', territory: territory, many_communes: many_communes)
+            use_entire_territory_link = link_to(
+              I18n.t('active_admin.territory.assign_entire_territory'),
+              assign_entire_territory_admin_territory_path(territory, params),
+              method: :post,
+              data: { confirm: confirm_message }
+            )
+            description = "#{description} — #{use_entire_territory_link}"
+          end
+
+          description.html_safe
+        end
+
+        other = summary[:other]
+        if other > 0
+          descriptions << "#{I18n.t('other')} : #{other}"
+        end
+
+        descriptions.join("<br/>").html_safe
+      end
+    end
+
+    Arbre::Element.include InterventionZoneDescription
+  end
+end

--- a/app/admin/helpers/status_status_tag.rb
+++ b/app/admin/helpers/status_status_tag.rb
@@ -1,0 +1,16 @@
+module Admin
+  module Helpers
+    module StatusStatusTag
+      ## status_tag for a Match.status
+      # Note: “status” is a property of Match and Need, but status_tag is also an ActiveAdmin helper
+      def status_status_tag(status)
+        css_class = { taking_care: 'warning', done: 'ok', not_for_me: 'error' }[status.to_sym]
+        title = StatusHelper::status_description(status, :short)
+
+        status_tag(title, class: css_class)
+      end
+    end
+
+    Arbre::Element.include StatusStatusTag
+  end
+end

--- a/app/admin/match.rb
+++ b/app/admin/match.rb
@@ -17,13 +17,13 @@ ActiveAdmin.register Match do
     selectable_column
     column :match, sortable: :status do |m|
       div admin_link_to(m)
-      status_tag(*status_tag_status_params(m.status))
+      status_status_tag(m.status)
     end
     column :updated_at
     column :need, sortable: :created_at do |m|
       div admin_link_to(m, :need)
       div I18n.l(m.created_at, format: '%Y-%m-%d %H:%M')
-      status_tag(*status_tag_status_params(m.need.status))
+      status_status_tag(m.need.status)
     end
     column :advisor do |m|
       div admin_link_to(m, :advisor)
@@ -93,13 +93,13 @@ ActiveAdmin.register Match do
   #
   show do
     attributes_table do
-      row(:status) { |m| status_tag(*status_tag_status_params(m.status)) }
+      row(:status) { |m| status_status_tag(m.status) }
       row :need
       row :created_at
       row :updated_at
       row :taken_care_of_at
       row :closed_at
-      row(:need) { |m| status_tag(*status_tag_status_params(m.need.status)) }
+      row(:need) { |m| status_status_tag(m.need.status) }
       row :advisor
       row :advisor_antenne
       row :contacted_expert do |m|

--- a/app/admin/need.rb
+++ b/app/admin/need.rb
@@ -23,7 +23,7 @@ ActiveAdmin.register Need do
     column :created_at
     column :last_activity_at
     column :status do |d|
-      status_tag(*status_tag_status_params(d.status))
+      status_status_tag(d.status)
       status_tag t('activerecord.attributes.need.is_archived') if d.is_archived
     end
     column(:matches) do |d|
@@ -80,7 +80,7 @@ ActiveAdmin.register Need do
       row :last_activity_at
       row :archived_at
       row :content
-      row(:status) { |d| status_tag(*status_tag_status_params(d.status)) }
+      row(:status) { |d| status_status_tag(d.status) }
       row(:matches) do |d|
         div admin_link_to(d, :matches)
         div admin_link_to(d, :matches, list: true)

--- a/app/admin/patches/scopes.rb
+++ b/app/admin/patches/scopes.rb
@@ -1,6 +1,8 @@
-module ActiveAdmin
-  module LayoutHacks
-    module ScopesWithTooltips
+module Admin
+  module Patches
+    module Scopes
+      ## !! Monkey-patch override !!
+      # Add a :title html attribute to the top-level scopes
       def build_scope(scope, options)
         element = super
 
@@ -11,6 +13,6 @@ module ActiveAdmin
       end
     end
 
-    ActiveAdmin::Views::Scopes.prepend ScopesWithTooltips
+    ActiveAdmin::Views::Scopes.prepend Scopes
   end
 end

--- a/app/helpers/admin_helper.rb
+++ b/app/helpers/admin_helper.rb
@@ -30,56 +30,6 @@ module AdminHelper
     descriptions.join("<br/>").html_safe
   end
 
-  def admin_link_to(object, association = nil, options = {})
-    if association.nil?
-      return link_to(object, polymorphic_path([:admin, object]))
-    end
-
-    klass = object.class
-    reflection = klass.reflect_on_association(association)
-
-    if reflection.collection?
-      if options[:list]
-        foreign_objects = object.send(association)
-        if foreign_objects.present?
-          links = foreign_objects.map { |foreign_object| link_to(foreign_object, polymorphic_path([:admin, foreign_object])) }
-          links.join('</br>').html_safe
-        else
-          '-'
-        end
-      else # single link to list
-        count = object.send(association).size
-        text = "#{count} #{klass.human_attribute_name(association, count: count).downcase}"
-        foreign_klass = reflection.klass
-        if reflection.options[:through].present?
-          # I’m not using `reflection.through_reflection` on purpose:
-          # when the through association is a HABTM, the reflectio returned by
-          # `reflection.through_reflection` is missing the :inverse_of option that we need.
-          # If we query the original klass for the reflection on the through association,
-          # we get all the declared options.
-          through_reflection = klass.reflect_on_association(reflection.options[:through])
-          names = [reflection.inverse_of.options[:through], through_reflection.options[:inverse_of]]
-          inverse_path = names.compact.join('_')
-        else
-          inverse_path = reflection.inverse_of.name
-        end
-        link_to(text, polymorphic_path([:admin, foreign_klass], "q[#{inverse_path}_id_eq]": object))
-      end
-    else
-      foreign_object = object.send(association)
-      if foreign_object.present?
-        link_to(foreign_object, polymorphic_path([:admin, foreign_object]))
-      else
-        '-'
-      end
-    end
-  end
-
-  def admin_attr(object, attribute)
-    klass = object.class
-    "#{klass.human_attribute_name(attribute)} : #{object.send(attribute)}"
-  end
-
   def status_tag_status_params(status)
     # Note: “status” is a property of Match and Need, but status_tag is also an ActiveAdmin helper
     css_class = { taking_care: 'warning', done: 'ok', not_for_me: 'error' }[status.to_sym]

--- a/app/helpers/admin_helper.rb
+++ b/app/helpers/admin_helper.rb
@@ -1,35 +1,4 @@
 module AdminHelper
-  def intervention_zone_description(many_communes)
-    summary = many_communes.intervention_zone_summary
-
-    descriptions = summary[:territories].map do |hash|
-      territory = hash[:territory]
-      link = link_to(territory, admin_territory_path(territory))
-      description = "#{link} : #{hash[:included]} / #{territory.communes.count}"
-
-      if hash[:included] < territory.communes.count
-        params = many_communes.is_a?(Antenne) ? { antenne: many_communes } : { expert: many_communes }
-        confirm_message = I18n.t('active_admin.territory.confirm_assign_entire_territory', territory: territory, many_communes: many_communes)
-        use_entire_territory_link = link_to(
-          I18n.t('active_admin.territory.assign_entire_territory'),
-          assign_entire_territory_admin_territory_path(territory, params),
-          method: :post,
-          data: { confirm: confirm_message }
-        )
-        description = "#{description} — #{use_entire_territory_link}"
-      end
-
-      description.html_safe
-    end
-
-    other = summary[:other]
-    if other > 0
-      descriptions << "#{I18n.t('other')} : #{other}"
-    end
-
-    descriptions.join("<br/>").html_safe
-  end
-
   def status_tag_status_params(status)
     # Note: “status” is a property of Match and Need, but status_tag is also an ActiveAdmin helper
     css_class = { taking_care: 'warning', done: 'ok', not_for_me: 'error' }[status.to_sym]

--- a/app/helpers/admin_helper.rb
+++ b/app/helpers/admin_helper.rb
@@ -1,8 +1,0 @@
-module AdminHelper
-  def status_tag_status_params(status)
-    # Note: “status” is a property of Match and Need, but status_tag is also an ActiveAdmin helper
-    css_class = { taking_care: 'warning', done: 'ok', not_for_me: 'error' }[status.to_sym]
-    title = StatusHelper::status_description(status, :short)
-    [title, class: css_class]
-  end
-end

--- a/app/helpers/admin_helper.rb
+++ b/app/helpers/admin_helper.rb
@@ -86,14 +86,4 @@ module AdminHelper
     title = StatusHelper::status_description(status, :short)
     [title, class: css_class]
   end
-
-  ::ActiveAdmin::CSVBuilder.module_eval do
-    def column_count(attribute)
-      column(attribute) { |object| object.send(attribute).size }
-    end
-
-    def column_list(association)
-      column(association) { |object| object.send(association).map(&:to_s).join('/') }
-    end
-  end
 end


### PR DESCRIPTION
Following #697, move around activeadmin helper methods.

In rails <6, there was a class (re)loading issue deep in ActiveAdmin, that lead to a massive leak when tweaking and reloading /admin pages, that became slower and slower to respond. Additionally, custom helper methods (i.e. `admin_link_to`) were actually _not_ reloaded at all. I’m not sure exactly what the bug was, and if the fix is just in zeitwerk working differently than the old loading mechanism. Anyway, things look better now.

Also, I spent too much time making #697 work properly; I felt this deserved more than a 3-line patch.