### PR TITLE
Send a distinct email to the advisor when sending notifications

### DIFF
--- a/app/mailers/expert_mailer.rb
+++ b/app/mailers/expert_mailer.rb
@@ -11,7 +11,6 @@ class ExpertMailer < ApplicationMailer
 
     mail(
       to: @expert.email_with_display_name,
-      cc: @diagnosis.advisor.email_with_display_name,
       subject: t('mailers.expert_mailer.notify_company_needs.subject', company_name: @diagnosis.company.name),
       reply_to: [
         SENDER,

--- a/app/mailers/user_mailer.rb
+++ b/app/mailers/user_mailer.rb
@@ -11,6 +11,13 @@ class UserMailer < ApplicationMailer
     mail(to: @user.email, subject: t('mailers.user_mailer.daily_change_update.subject'))
   end
 
+  def confirm_notifications_sent(diagnosis)
+    @diagnosis = diagnosis
+    @user = @diagnosis.advisor
+    mail(to: @user.email_with_display_name,
+      subject: t('mailers.user_mailer.confirm_notifications_sent.subject', company: @diagnosis.company.name, count: @diagnosis.needs.size))
+  end
+
   def match_feedback(feedback)
     @feedback = feedback
     @author = feedback.author

--- a/app/models/diagnosis.rb
+++ b/app/models/diagnosis.rb
@@ -133,6 +133,7 @@ class Diagnosis < ApplicationRecord
     experts.each do |expert|
       ExpertMailer.delay.notify_company_needs(expert, self)
     end
+    UserMailer.delay.confirm_notifications_sent(self)
   end
 
   private

--- a/app/views/mailers/user_mailer/confirm_notifications_sent.html.haml
+++ b/app/views/mailers/user_mailer/confirm_notifications_sent.html.haml
@@ -1,0 +1,21 @@
+%p= t('mailers.hello_name', name: @user.full_name)
+
+%p= t('.you_met_company_html', visit_date: l(@diagnosis.display_date, format: :long))
+%blockquote
+  %h1= @diagnosis.company
+  .text-grey= @diagnosis.facility.commune_name
+%p= t('.company_expressed_needs', count: @diagnosis.needs.size)
+
+- @diagnosis.needs.each do |need|
+  %h2= need.subject
+  %ul
+    .text-grey= t('.contacted_experts', count: need.experts.size)
+    - need.experts.each do |expert|
+      %li #{expert.full_name} — #{expert.role} — #{expert.antenne.name}
+
+%h2
+  .button
+    %a{ href: need_url(@diagnosis) }= t('.show_details')
+
+%p= t('.thank_you')
+%p= t('mailers.see_you_on_place_des_entreprises_html', link_to_root: link_to(t('app_name'), root_url))

--- a/config/locales/views.fr.yml
+++ b/config/locales/views.fr.yml
@@ -257,6 +257,19 @@ fr:
         blurb: 'Place des Entreprises : le guichet public et gratuit d’accompagnement des TPE & PME.'
         contact_us_html: N’hésitez pas à <a href="mailto:%{email}">nous contacter</a> pour toute question, nous sommes à votre service.
     user_mailer:
+      confirm_notifications_sent:
+        company_expressed_needs:
+          one: qui a exprimé un besoin.
+          other: qui a exprimé %{count} besoins.
+        contacted_experts:
+          one: 'Mise en relation :'
+          other: 'Mises en relations :'
+        show_details: Afficher les détails
+        subject:
+          one: "[Place des Entreprises] Confirmation de notification du besoin de l’entreprise %{company}"
+          other: "[Place des Entreprises] Confirmation de notification des besoins de l’entreprise %{company}"
+        thank_you: "Merci ! \U0001F44D"
+        you_met_company_html: Le %{visit_date}, vous avez rencontré
       daily_change_update:
         context: "%{expert_name}, %{expert_institution}, contacté·e pour le besoin %{subject_title} de l’entreprise %{company_name} le %{start_date},"
         nice_day: Bonne journée,

--- a/spec/mailers/previews/user_mailer_preview.rb
+++ b/spec/mailers/previews/user_mailer_preview.rb
@@ -3,6 +3,10 @@ class UserMailerPreview < ActionMailer::Preview
     UserMailer.daily_change_update(user, Array.new(3) { change_hash })
   end
 
+  def confirm_notifications_sent
+    UserMailer.confirm_notifications_sent(Diagnosis.completed.sample)
+  end
+
   def match_feedback
     UserMailer.match_feedback(Feedback.all.sample)
   end


### PR DESCRIPTION
⚠️ merge #713 first

This refs #600 but is actually done as cleanup for #638: 

In the main notification email to experts, we will add some optional warning if the expert needs to activate their user account. Sending this email (as cc:) to the advisor would be but confusing for the them. Let’s send a distinct email.