### PR TITLE
No access token in notifications emails

### DIFF
--- a/app/controllers/concerns/flash_to_review_subjects.rb
+++ b/app/controllers/concerns/flash_to_review_subjects.rb
@@ -6,8 +6,6 @@ module FlashToReviewSubjects
   end
 
   def flash_to_review_subjects_if_needed
-    return
-
     expert_to_review = current_user.experts.find(&:should_review_subjects?)
     if expert_to_review.present?
       message = I18n.t('experts.flash.review_your_subjects_html',

--- a/app/mailers/expert_mailer.rb
+++ b/app/mailers/expert_mailer.rb
@@ -6,22 +6,16 @@ class ExpertMailer < ApplicationMailer
 
   def notify_company_needs(expert, diagnosis)
     @expert = expert
-    @access_token = expert.access_token
     @diagnosis = diagnosis
 
     mail(
       to: @expert.email_with_display_name,
-      subject: t('mailers.expert_mailer.notify_company_needs.subject', company_name: @diagnosis.company.name),
-      reply_to: [
-        SENDER,
-        @diagnosis.advisor.email_with_display_name
-      ]
+      subject: t('mailers.expert_mailer.notify_company_needs.subject', company_name: @diagnosis.company.name)
     )
   end
 
   def remind_involvement(expert)
     @expert = expert
-    @access_token = expert.access_token
 
     @needs_quo = expert.needs_quo
     @needs_taking_care = expert.needs_taking_care

--- a/app/models/diagnosis.rb
+++ b/app/models/diagnosis.rb
@@ -132,6 +132,10 @@ class Diagnosis < ApplicationRecord
   def notify_experts!
     experts.each do |expert|
       ExpertMailer.delay.notify_company_needs(expert, self)
+      # also send a reset link if the expert is solo and has never used his user account
+      if expert.solo? && expert.users.first.never_used_account?
+        expert.send_reset_password_instructions
+      end
     end
     UserMailer.delay.confirm_notifications_sent(self)
   end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -158,7 +158,7 @@ class User < ApplicationRecord
     end
   end
 
-  def placeholder_for_expert?
+  def never_used_account?
     invitation_sent_at.nil? && encrypted_password.blank?
   end
 

--- a/app/views/devise/mailer/reset_password_instructions.html.haml
+++ b/app/views/devise/mailer/reset_password_instructions.html.haml
@@ -10,4 +10,7 @@
     %a{ href: edit_password_url(@resource, reset_password_token: @token) }
       = @resource.never_used_account? ? t('.choose_my_password') : t('.change_my_password')
 
-%p.text-grey= t('.ignore')
+- if @resource.never_used_account?
+  %p.text-grey= t('.once_connected')
+- else
+  %p.text-grey= t('.ignore')

--- a/app/views/devise/mailer/reset_password_instructions.html.haml
+++ b/app/views/devise/mailer/reset_password_instructions.html.haml
@@ -1,6 +1,6 @@
 %p= t('devise.mailer.hello', user_full_name: @resource.full_name)
 
-- if @resource.placeholder_for_expert?
+- if @resource.never_used_account?
   %p= t('.account_but_never_connected_html')
 - else
   %p= t('.someone_has_requested_a_link_html', date: l(@resource.reset_password_sent_at, format: :long_sentence), email: @resource.email)
@@ -8,6 +8,6 @@
 %p
   .button
     %a{ href: edit_password_url(@resource, reset_password_token: @token) }
-      = @resource.placeholder_for_expert? ? t('.choose_my_password') : t('.change_my_password')
+      = @resource.never_used_account? ? t('.choose_my_password') : t('.change_my_password')
 
 %p.text-grey= t('.ignore')

--- a/app/views/mailers/expert_mailer/_never_used_solo_account_warning.html.haml
+++ b/app/views/mailers/expert_mailer/_never_used_solo_account_warning.html.haml
@@ -1,0 +1,2 @@
+- if @expert.solo? && @expert.users.first.never_used_account?
+  %p.warning= t('.you_need_to_use_your_user_account')

--- a/app/views/mailers/expert_mailer/_remind_received_needs.html.haml
+++ b/app/views/mailers/expert_mailer/_remind_received_needs.html.haml
@@ -1,18 +1,15 @@
 - return if received_needs.blank?
 
 %h2= title
-= local_assigns[:subtitle]
+%p= local_assigns[:subtitle]
 - diagnoses = Diagnosis.where(needs: received_needs).distinct.order!(happened_on: :desc)
-%ul
-  - diagnoses.each do |diagnosis|
-    %li
-      - path = need_url(diagnosis, access_token: access_token)
-      %strong
-        %a{ href: path }= diagnosis.company.name
-      —
-      = t('mailers.expert_mailer.remind_involvement.visited_at', date: I18n.l(diagnosis.display_date, format: :long))
-      %ul
-        - diagnosis.needs.merge(received_needs).each do |need|
-          %li
-            %strong= need.subject
-            = "(#{need.matches.human_count})"
+- diagnoses.each do |diagnosis|
+  %h3
+    %a{ href: need_url(diagnosis) }= diagnosis.company.name
+  = t('mailers.expert_mailer.remind_involvement.visited_at', date: I18n.l(diagnosis.display_date, format: :long))
+  %ul
+    - diagnosis.needs.merge(received_needs).each do |need|
+      %li
+        = need.subject
+  .button
+    %a{ href: need_url(diagnosis) }= t('mailers.expert_mailer.remind_involvement.reply')

--- a/app/views/mailers/expert_mailer/notify_company_needs.html.haml
+++ b/app/views/mailers/expert_mailer/notify_company_needs.html.haml
@@ -1,32 +1,28 @@
 %p= t('mailers.hello_name', name: @expert.full_name)
 
-:ruby
-  link_to_root = link_to t('app_name'), root_url
+- needs = @diagnosis.needs.merge(@expert.received_needs)
+
+%p= t('.this_company')
+%blockquote
+  %h1= @diagnosis.company
+  .text-grey= @diagnosis.facility.commune_name
+%p= t('.needs_you')
 
 %p
-  = t('.this_company_needs_you_html', company_description: @diagnosis.facility)
   = t('.advisor_met_company',
    advisor_name_with_role: @diagnosis.advisor.full_name_with_role,
-   visit_date: I18n.l(@diagnosis.display_date))
+   visit_date: I18n.l(@diagnosis.display_date, format: :long))
+  = t('.company_expressed_needs', count: needs.size)
 
-%p= t('.company_expressed_needs')
-
-- @diagnosis.needs.merge(@expert.received_needs).ordered_for_interview.each do |need|
-  %h3.subject= need.subject
+- needs.ordered_for_interview.each do |need|
+  %h2.subject= need.subject
   - if need.content.present?
     %blockquote
       %p= simple_format(need.content)
 
-%p= t('.details_on_place_des_entreprises')
-
-:ruby
-  more_info_url = if @access_token
-    need_url(@diagnosis, access_token: @access_token)
-  else
-    need_url(@diagnosis)
-  end
-
 .button
-  %a{ href: more_info_url }= t('.click_here')
+  %a{ href: need_url(@diagnosis) }= t('.reply')
 
-%p= t('mailers.see_you_on_place_des_entreprises_html', link_to_root: link_to_root)
+= render 'mailers/expert_mailer/never_used_solo_account_warning'
+
+%p= t('mailers.see_you_on_place_des_entreprises_html', link_to_root: link_to(t('app_name'), root_url))

--- a/app/views/mailers/expert_mailer/remind_involvement.html.haml
+++ b/app/views/mailers/expert_mailer/remind_involvement.html.haml
@@ -5,19 +5,18 @@
 
 = render 'mailers/expert_mailer/remind_received_needs',
   received_needs: @needs_quo,
-  access_token: @access_token,
   title: t('.needs_quo'),
   subtitle: t('.needs_quo_details')
 
 = render 'mailers/expert_mailer/remind_received_needs',
   received_needs: @needs_taking_care,
-  access_token: @access_token,
   title: t('.needs_taking_care'),
   subtitle: t('.needs_taking_care_details')
 
 = render 'mailers/expert_mailer/remind_received_needs',
   received_needs: @needs_others_taking_care,
-  access_token: @access_token,
   title: t('.needs_others_taking_care')
+
+= render 'mailers/expert_mailer/never_used_solo_account_warning'
 
 %p= t('mailers.see_you_on_place_des_entreprises_html', link_to_root: link_to_root)

--- a/config/locales/devise.fr.yml
+++ b/config/locales/devise.fr.yml
@@ -36,10 +36,11 @@ fr:
         someone_invited_you_html: "%{inviter} (%{mail_to_inviter}) vous invite à rejoindre l’équipe de <b>%{antenne_name}</b>."
         subject: Invitation sur Place des Entreprises
       reset_password_instructions:
-        account_but_never_connected_html: "<p>Vous disposez d’un accès à Place des Entreprises mais vous n’êtes pas encore connecté.</p><p>Pour définir votre mot de passe et activer votre compte, cliquez sur ce bouton.</p><p>Une fois connecté, vous pourrez accéder à toutes les demandes qui vous ont été transmises; vous pourrez aussi faire vous même des mises en relation.</p>"
+        account_but_never_connected_html: "<p>Vous disposez d’un accès à Place des Entreprises mais vous n’êtes pas encore connecté. Cliquez sur le bouton ci-dessous pour définir votre mot de passe et activer votre compte.</p>"
         change_my_password: Changer de mot de passe
         choose_my_password: Choisir mon mot de passe
         ignore: Si vous n’êtes pas à l’origine de cette demande, vous pouvez ignorer cet e-mail. Votre mot de passe ne sera pas modifié.
+        once_connected: Une fois connecté, vous pourrez accéder à toutes les demandes qui vous ont été transmises; vous pourrez aussi faire vous même des mises en relation.
         someone_has_requested_a_link_html: "<p>Le %{date}, une demande de réinitalisation du mot de passe a été faite pour votre compte (<code>%{email}</code>).</p><p>Cliquez sur le bouton ci-dessous pour choisir un nouveau mot de passe.</p>"
         subject: 'Place des Entreprises : choisissez un mot de passe pour votre compte'
     omniauth_callbacks:

--- a/config/locales/views.fr.yml
+++ b/config/locales/views.fr.yml
@@ -232,13 +232,17 @@ fr:
           other: "%{count} analyses mises à jour :"
           zero: Aucune analyse mise à jour.
     expert_mailer:
+      never_used_solo_account_warning:
+        you_need_to_use_your_user_account: Attention ! Place des entreprises nécessite désormais de se connecter à son compte utilisateur pour accéder au informations des entreprises. Vous allez recevoir un email expliquant comment activer votre compte et choisir votre mot de passe.
       notify_company_needs:
         advisor_met_company: "%{advisor_name_with_role} l’a rencontrée le %{visit_date}."
-        click_here: Voir les détails de la visite
-        company_expressed_needs: 'L’entreprise a exprimé des besoins qui correspondent à vos compétences :'
-        details_on_place_des_entreprises: Rendez vous sur Place des Entreprises pour prendre en charge ou répondre à cette mise en relation.
+        company_expressed_needs:
+          one: 'L’entreprise a exprimé un besoin qui correspond à vos compétences :'
+          other: 'L’entreprise a exprimé des besoins qui correspondent à vos compétences :'
+        needs_you: a besoin de votre expertise.
+        reply: Répondre sur Place des entreprises
         subject: "[Place des Entreprises] L’entreprise %{company_name} a besoin de vous"
-        this_company_needs_you_html: L’entreprise <b>%{company_description}</b> a besoin de votre expertise.
+        this_company: L’entreprise
       remind_involvement:
         needs_for_you: 'Voici la liste des demandes reçues sur Place des Entreprises :'
         needs_others_taking_care: Besoins pris en charge par d’autres référents
@@ -246,6 +250,7 @@ fr:
         needs_quo_details: Personne n’a encore répondu à ces besoins. Avez-vous une solution ?
         needs_taking_care: Besoins pris en charge
         needs_taking_care_details: Vous avez indiqué prendre en charge ces besoins. Y a-t-il du nouveau ?
+        reply: Répondre sur Place des entreprises
         subject: "[Place des Entreprises] Rappel: Des entreprises ont besoin de vous !"
         visited_at: Visitée le %{date}
     hello: Bonjour,

--- a/spec/mailers/previews/devise_mailer_preview.rb
+++ b/spec/mailers/previews/devise_mailer_preview.rb
@@ -16,7 +16,7 @@ class DeviseMailerPreview < ActionMailer::Preview
     Devise::Mailer.reset_password_instructions(user, 'faketoken')
   end
 
-  def reset_password_instructions_placeholder
+  def reset_password_instructions_never_used
     user = User.all.sample
     user.invitation_sent_at = nil
     user.encrypted_password = nil

--- a/spec/views/mailers/expert_mailer/notify_company_needs.html.haml_spec.rb
+++ b/spec/views/mailers/expert_mailer/notify_company_needs.html.haml_spec.rb
@@ -13,33 +13,25 @@ RSpec.describe 'mailers/expert_mailer/notify_company_needs.html.haml', type: :vi
     before do
       assign(:expert, expert)
       assign(:diagnosis, diagnosis)
+
+      render
     end
 
-    context 'when diagnosis has a date, there is an access token and there are two subjects' do
+    context 'when diagnosis has a date and there are two subjects' do
       let(:diagnosis) { create :diagnosis, advisor: user, visitee: contact, needs: [need1, need2] }
 
-      before do
-        assign(:access_token, 'random_access_token')
-        render
-      end
-
       it 'displays the date, phone number and 2 list items' do
-        expect(rendered).to include "besoins/#{diagnosis.id}?access_token=random_access_token"
-        assert_select 'h3.subject', count: 2
+        expect(rendered).to include "besoins/#{diagnosis.id}"
+        assert_select 'h2.subject', count: 2
       end
     end
 
-    context 'when there is no access token and there is one subject' do
+    context 'when there is one subject' do
       let(:diagnosis) { create :diagnosis, advisor: user, visitee: contact, needs: [need1] }
-
-      before do
-        assign(:access_token, nil)
-        render
-      end
 
       it 'does not display the date, but displays email and one list item' do
         expect(rendered).to include "besoins/#{diagnosis.id}"
-        assert_select 'h3.subject', count: 1
+        assert_select 'h2.subject', count: 1
       end
     end
   end


### PR DESCRIPTION
refs #638 

* Send notifications emails without an access_token
* Do not cc the advisor
* Send a password reset link to notified experts with unused accounts

* [x] ⚠️ merge #710, #713 first
* [x] ⚠️ enable the “review subjects” flash message first (revert the last commit in #709, 7fd78ba7afb3a053c7d016cca020ca3ea3f09e89)