### PR TITLE
Mail G - Information du conseiller sur le commentaire d’un référent

### DIFF
--- a/app/controllers/feedbacks_controller.rb
+++ b/app/controllers/feedbacks_controller.rb
@@ -7,7 +7,7 @@ class FeedbacksController < ApplicationController
     @feedback = Feedback.create(feedback_params.merge(user: current_user, expert: current_expert))
     @current_roles = current_roles
     if @feedback.persisted?
-      @feedback.notify!
+      UserMailer.delay.match_feedback(@feedback)
     else
       flash.alert = @feedback.errors.full_messages.to_sentence
       redirect_back(fallback_location: root_path)

--- a/app/mailers/user_mailer.rb
+++ b/app/mailers/user_mailer.rb
@@ -18,11 +18,11 @@ class UserMailer < ApplicationMailer
       subject: t('mailers.user_mailer.confirm_notifications_sent.subject', company: @diagnosis.company.name, count: @diagnosis.needs.size))
   end
 
-  def match_feedback(feedback, person)
+  def match_feedback(feedback)
     @feedback = feedback
-    @person = person
+    @advisor = feedback.need.diagnosis.advisor
     @author = feedback.author
-    mail(to: @person.email_with_display_name,
+    mail(to: @advisor.email_with_display_name,
          reply_to: @author.email_with_display_name,
          subject: t('mailers.user_mailer.match_feedback.subject', company: feedback.need.company))
   end

--- a/app/models/feedback.rb
+++ b/app/models/feedback.rb
@@ -41,16 +41,6 @@ class Feedback < ApplicationRecord
     expert || user
   end
 
-  def notify!
-    persons_to_notify.each do |person|
-      UserMailer.delay.match_feedback(self, person)
-    end
-  end
-
-  def persons_to_notify
-    need.experts + [need.advisor] - [author]
-  end
-
   private
 
   def expert_or_user_author

--- a/app/views/mailers/user_mailer/match_feedback.html.haml
+++ b/app/views/mailers/user_mailer/match_feedback.html.haml
@@ -1,4 +1,4 @@
-%p= t('mailers.hello_name', name: @person.full_name)
+%p= t('mailers.hello_name', name: @advisor.full_name)
 
 %p= t('.new_comment_html', author: @author.full_name, antenne: @author.antenne, company: @feedback.need.company, date: I18n.l(@feedback.need.diagnosis.display_date))
 

--- a/spec/mailers/previews/user_mailer_preview.rb
+++ b/spec/mailers/previews/user_mailer_preview.rb
@@ -9,7 +9,7 @@ class UserMailerPreview < ActionMailer::Preview
 
   def match_feedback
     feedback = Feedback.all.sample
-    UserMailer.match_feedback(feedback, feedback.need.advisor)
+    UserMailer.match_feedback(feedback)
   end
 
   def update_match_notify


### PR DESCRIPTION
Après discussion il en est ressortie qu'on enverrait l'email de notification quand il y a un nouveau commentaire uniquement au conseillé qui a créé le besoin