### PR TITLE
New rake task `push_to_production`

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,6 +85,8 @@ Staging emails are sent on [Mailtrap](https://mailtrap.io/) in order to test ema
 
 ## Deployment
 
+### Branches and setup
+
 Place des Entreprises is deployed on [Scalingo](http://doc.scalingo.com/languages/ruby/getting-started-with-rails/), with two distinct environment, ``reso-staging`` and `reso-production.
 
 * `reso-staging` is served at https://reso-staging.scalingo.io.
@@ -100,6 +102,26 @@ In case of emergency, you can always run rails migrations manually using the `sc
     
     $ scalingo -a reso-staging run rails db:migrate
     $ scalingo -a reso-production run rails db:migrate 
+
+### rake push_to_production`
+``
+Use `rake push_to_production` to review the changed before pushing to production:
+```
+$ rake push_to_production
+Updating master and production…
+Last production commit is ebe7d79c4149c3ae64af917e0ccd09bb7c473cc8
+About to merge 5 PRs and push to production:
+🚀 
+* [#718](https://github.com/betagouv/place-des-entreprises/pull/718) display created_at date instead of visit date
+* [#720](https://github.com/betagouv/place-des-entreprises/pull/720) Bump rack from 2.0.7 to 2.0.8
+* [#714](https://github.com/betagouv/place-des-entreprises/pull/714) Do not cc everyone in UserMailer#match_feedback
+* [#710](https://github.com/betagouv/place-des-entreprises/pull/710) Send a distinct email to the advisor when sending notifications
+* [#713](https://github.com/betagouv/place-des-entreprises/pull/713) Redesign email css
+Proceed?
+y
+Basculement sur la branche 'production'
+Done!
+```
 
 ## Contributing
 

--- a/lib/tasks/push_to_production.rake
+++ b/lib/tasks/push_to_production.rake
@@ -1,0 +1,81 @@
+desc 'Setup and push reviewed code to production'
+task :push_to_production do
+  require 'json'
+  require 'rest-client'
+  require 'highline/import'
+
+  def fetch_master_and_production
+    puts 'Updating master and production…'
+    `git fetch origin -u master:master production:production`
+    exit unless $?.success?
+  end
+
+  def find_last_production_commit_on_master
+    commit = `git show -s --pretty=%P production | cut -d " " -f 2`.strip
+    exit unless $?.success?
+    puts "Last production commit is #{commit}"
+    commit
+  end
+
+  def retrieve_merge_commits_messages(last_commit)
+    separator = '--------'
+    messages = `git log --merges --pretty=%B#{separator} #{last_commit}..master`
+    messages.split(separator)
+  end
+
+  def format_commit_messages(messages)
+    def pr_number_and_title(message)
+      message.match(/.*pull request #(?<pr>\d+).*\n*(?<title>.*)/)
+    end
+
+    def format_parts(parts)
+      pull_request_url = 'https://github.com/betagouv/place-des-entreprises/pull/'
+      "* [##{parts['pr']}](#{pull_request_url}#{parts['pr']}) #{parts['title'].strip}"
+    end
+
+    messages
+      .map{ |message| pr_number_and_title(message) }
+      .compact
+      .map{ |parts| format_parts(parts) }
+  end
+
+  def prompt_for_confirmation(formatted)
+    puts "About to merge #{formatted.count} PRs and push to production:"
+    puts '🚀 '
+    puts formatted.join("\n")
+    if !agree("Proceed?")
+      exit
+    end
+  end
+
+  def ensure_clean_working_tree
+    `git diff-index --quiet HEAD --`
+    if !$?.success?
+      puts 'Current working tree is dirty. Exiting.'
+      exit
+    end
+  end
+
+  def merge_master_to_production
+    `git checkout production && git merge master --no-edit`
+    exit unless $?.success?
+  end
+
+  def push_to_production
+    `git push origin production`
+    exit unless $?.success?
+    puts 'Done!'
+  end
+
+  ensure_clean_working_tree
+  fetch_master_and_production
+
+  last_commit = find_last_production_commit_on_master
+  merge_messages = retrieve_merge_commits_messages(last_commit)
+  formatted = format_commit_messages(merge_messages)
+  prompt_for_confirmation(formatted)
+
+  ensure_clean_working_tree
+  merge_master_to_production
+  push_to_production
+end


### PR DESCRIPTION
It looks like this:

```
$ rake push_to_production
Updating master and production…
Depuis github.com:betagouv/place-des-entreprises
Last production commit is ebe7d79c4149c3ae64af917e0ccd09bb7c473cc8
About to merge 5 PRs and push to production:
🚀 
* [#718](https://github.com/betagouv/place-des-entreprises/pull/718) display created_at date instead of visit date
* [#720](https://github.com/betagouv/place-des-entreprises/pull/720) Bump rack from 2.0.7 to 2.0.8
* [#714](https://github.com/betagouv/place-des-entreprises/pull/714) Do not cc everyone in UserMailer#match_feedback
* [#710](https://github.com/betagouv/place-des-entreprises/pull/710) Send a distinct email to the advisor when sending notifications
* [#713](https://github.com/betagouv/place-des-entreprises/pull/713) Redesign email css
Proceed?
y
Basculement sur la branche 'production'
Done!
```