### PR TITLE
Add a “unread“ badge for unresponded matches in the navbar

### DIFF
--- a/app/views/layouts/_navbar.html.haml
+++ b/app/views/layouts/_navbar.html.haml
@@ -8,8 +8,10 @@
         = t('.diagnoses')
       - if current_user.experts.present?
         = active_link_to needs_path, class: 'item' do
-          %i.bullseye.icon
+          %i.inbox.icon
           = t('needs.index.title')
+          - if current_user.needs_quo.exists?
+            .ui.orange.empty.circular.horizontal.label
       - if current_user.is_admin?
         = active_link_to reminders_path, class: 'item' do
           %i.ambulance.icon


### PR DESCRIPTION
No number, just a colored circle:
<img width="369" alt="image" src="https://user-images.githubusercontent.com/139391/71245533-3c3ae700-2315-11ea-96a4-fcc7203a6a74.png">