### PR TITLE
Send advisor feedback emails to all experts

### DIFF
--- a/app/controllers/feedbacks_controller.rb
+++ b/app/controllers/feedbacks_controller.rb
@@ -7,7 +7,7 @@ class FeedbacksController < ApplicationController
     @feedback = Feedback.create(feedback_params.merge(user: current_user, expert: current_expert))
     @current_roles = current_roles
     if @feedback.persisted?
-      UserMailer.delay.match_feedback(@feedback)
+      @feedback.notify!
     else
       flash.alert = @feedback.errors.full_messages.to_sentence
       redirect_back(fallback_location: root_path)

--- a/app/mailers/user_mailer.rb
+++ b/app/mailers/user_mailer.rb
@@ -18,11 +18,11 @@ class UserMailer < ApplicationMailer
       subject: t('mailers.user_mailer.confirm_notifications_sent.subject', company: @diagnosis.company.name, count: @diagnosis.needs.size))
   end
 
-  def match_feedback(feedback)
+  def match_feedback(feedback, person)
     @feedback = feedback
-    @advisor = feedback.need.diagnosis.advisor
+    @person = person
     @author = feedback.author
-    mail(to: @advisor.email_with_display_name,
+    mail(to: @person.email_with_display_name,
          reply_to: @author.email_with_display_name,
          subject: t('mailers.user_mailer.match_feedback.subject', company_name: feedback.need.company))
   end

--- a/app/models/feedback.rb
+++ b/app/models/feedback.rb
@@ -41,6 +41,14 @@ class Feedback < ApplicationRecord
     expert || user
   end
 
+  def author=(person)
+    if person.is_a? User
+      self.user = person
+    elsif person.is_a? Expert
+      self.expert = person
+    end
+  end
+
   def notify!
     persons_to_notify.each do |person|
       UserMailer.delay.match_feedback(self, person)
@@ -48,7 +56,11 @@ class Feedback < ApplicationRecord
   end
 
   def persons_to_notify
-    need.experts + [need.advisor] - [author]
+    if author == need.advisor
+      need.experts
+    else
+      [need.advisor]
+    end
   end
 
   private

--- a/app/models/feedback.rb
+++ b/app/models/feedback.rb
@@ -41,6 +41,16 @@ class Feedback < ApplicationRecord
     expert || user
   end
 
+  def notify!
+    persons_to_notify.each do |person|
+      UserMailer.delay.match_feedback(self, person)
+    end
+  end
+
+  def persons_to_notify
+    need.experts + [need.advisor] - [author]
+  end
+
   private
 
   def expert_or_user_author

--- a/app/views/mailers/user_mailer/match_feedback.html.haml
+++ b/app/views/mailers/user_mailer/match_feedback.html.haml
@@ -1,4 +1,4 @@
-%p= t('mailers.hello_name', name: @advisor.full_name)
+%p= t('mailers.hello_name', name: @person.full_name)
 
 %p= t('.new_comment_html', author: @author.full_name, antenne: @author.antenne, company: @feedback.need.company, date: I18n.l(@feedback.need.diagnosis.display_date))
 

--- a/spec/mailers/previews/user_mailer_preview.rb
+++ b/spec/mailers/previews/user_mailer_preview.rb
@@ -9,7 +9,7 @@ class UserMailerPreview < ActionMailer::Preview
 
   def match_feedback
     feedback = Feedback.all.sample
-    UserMailer.match_feedback(feedback)
+    UserMailer.match_feedback(feedback, feedback.need.advisor)
   end
 
   def update_match_notify

--- a/spec/models/feedback_spec.rb
+++ b/spec/models/feedback_spec.rb
@@ -15,4 +15,27 @@ RSpec.describe Feedback, type: :model do
       end
     end
   end
+
+  describe 'persons_to_notify' do
+    let(:advisor) { create :user }
+    let(:expert1) { create :expert }
+    let(:expert2) { create :expert }
+    let(:matches) { [create(:match, expert: expert1), create(:match, expert: expert2)] }
+    let(:need) { create :need, advisor: advisor, matches: matches }
+    let(:feedback) { create :feedback, need: need, author: author }
+
+    subject { feedback.persons_to_notify }
+
+    context 'when the author is the one of the contacted experts' do
+      let(:author) { expert1 }
+
+      it{ is_expected.to eq [advisor] }
+    end
+
+    context 'when the author is the diagnosis advisor' do
+      let(:author) { advisor }
+
+      it{ is_expected.to match_array [expert1, expert2] }
+    end
+  end
 end


### PR DESCRIPTION
Send match_feedback email **from experts** to the diagnosis advisor only.
On the other way, send feedback emails from the advisor to all the experts.

fixup after #719 and #714