### PR TITLE
Stop using access_token

### DIFF
--- a/app/admin/expert.rb
+++ b/app/admin/expert.rb
@@ -87,7 +87,6 @@ ActiveAdmin.register Expert do
   show do
     attributes_table do
       row :full_name
-      row :access_token
       row :role
       row :email
       row :phone_number

--- a/app/admin/match.rb
+++ b/app/admin/match.rb
@@ -34,7 +34,7 @@ ActiveAdmin.register Match do
       if m.expert.present?
         div admin_link_to(m, :expert)
         div admin_link_to(m, :expert_antenne)
-        div link_to('Page Référent', need_path(m.diagnosis, access_token: m.expert.access_token))
+        div link_to('Page Analyse', need_path(m.diagnosis))
       else
         div m.expert_full_role
         status_tag I18n.t('active_admin.matches.deleted'), class: 'error'
@@ -88,7 +88,7 @@ ActiveAdmin.register Match do
     column(:status_description) { |m| m.need.status_short_description }
     column :taken_care_of_at
     column :closed_at
-    column('Page Référent') { |m| need_url(m.diagnosis, access_token: m.expert.access_token) if m.expert.present? }
+    column('Page Analyse') { |m| need_url(m.diagnosis) if m.expert.present? }
   end
 
   ## Show
@@ -108,7 +108,7 @@ ActiveAdmin.register Match do
         if m.expert.present?
           div admin_link_to(m, :expert)
           div admin_link_to(m, :expert_antenne)
-          div link_to('Page Référent', need_path(m.diagnosis, access_token: m.expert.access_token))
+          div link_to('Page Analyse', need_path(m.diagnosis))
         else
           div m.expert_full_role
           status_tag I18n.t('active_admin.matches.deleted'), class: 'error'

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -35,10 +35,6 @@ class ApplicationController < SharedController
     current_expert.present? || not_found
   end
 
-  def pundit_user
-    UserContext.new(current_user, current_expert)
-  end
-
   def check_current_user_access_to(resource)
     http_method = request.request_method
     access_method = if %w[GET HEAD].include?(http_method)

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -20,21 +20,6 @@ class ApplicationController < SharedController
     root_path
   end
 
-  def current_expert
-    Expert.find_by(access_token: params[:access_token])
-  end
-
-  def current_roles
-    current_roles = [current_user]
-    current_roles += current_user&.experts || []
-    current_roles += [current_expert]
-    current_roles.compact
-  end
-
-  def authenticate_expert!
-    current_expert.present? || not_found
-  end
-
   def check_current_user_access_to(resource)
     http_method = request.request_method
     access_method = if %w[GET HEAD].include?(http_method)

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -47,7 +47,7 @@ class ApplicationController < SharedController
       :can_be_modified_by?
     end
 
-    if current_roles.any? { |role| resource.send(access_method, role) }
+    if resource.send(access_method, current_user)
       return
     end
     # can not be viewed:

--- a/app/controllers/feedbacks_controller.rb
+++ b/app/controllers/feedbacks_controller.rb
@@ -1,11 +1,6 @@
 class FeedbacksController < ApplicationController
-  skip_before_action :authenticate_user!
-  before_action :authenticate_user!, unless: -> { params[:access_token].present? }
-  before_action :authenticate_expert!, if: -> { params[:access_token].present? }
-
   def create
-    @feedback = Feedback.create(feedback_params.merge(user: current_user, expert: current_expert))
-    @current_roles = current_roles
+    @feedback = Feedback.create(feedback_params.merge(user: current_user))
     if @feedback.persisted?
       @feedback.notify!
     else

--- a/app/controllers/matches_controller.rb
+++ b/app/controllers/matches_controller.rb
@@ -3,7 +3,6 @@
 class MatchesController < ApplicationController
   def update
     @match = retrieve_match
-    @current_roles = current_roles
     previous_status = @match.status
     @match.update status: params[:status]
     UserMailer.update_match_notify(@match, current_user, previous_status).deliver_later

--- a/app/controllers/matches_controller.rb
+++ b/app/controllers/matches_controller.rb
@@ -1,10 +1,6 @@
 # frozen_string_literal: true
 
 class MatchesController < ApplicationController
-  skip_before_action :authenticate_user!
-  before_action :authenticate_user!, unless: -> { params[:access_token].present? }
-  before_action :authenticate_expert!, if: -> { params[:access_token].present? }
-
   def update
     @match = retrieve_match
     @current_roles = current_roles

--- a/app/controllers/needs_controller.rb
+++ b/app/controllers/needs_controller.rb
@@ -1,16 +1,12 @@
 # frozen_string_literal: true
 
 class NeedsController < ApplicationController
-  skip_before_action :authenticate_user!
-  before_action :authenticate_user!, unless: -> { params[:access_token].present? }
-  before_action :authenticate_expert!, if: -> { params[:access_token].present? }
-
   include FlashToReviewSubjects
 
   def index
-    @needs_quo = current_involved.needs_quo
-    @needs_taking_care = current_involved.needs_taking_care
-    @needs_others_taking_care = current_involved.needs_others_taking_care
+    @needs_quo = current_user.needs_quo
+    @needs_taking_care = current_user.needs_taking_care
+    @needs_others_taking_care = current_user.needs_others_taking_care
   end
 
   def index_antenne
@@ -20,9 +16,9 @@ class NeedsController < ApplicationController
   end
 
   def archives
-    @needs_rejected = current_involved.needs_rejected
-    @needs_done = current_involved.needs_done
-    @needs_archived = current_involved.needs_archived
+    @needs_rejected = current_user.needs_rejected
+    @needs_done = current_user.needs_done
+    @needs_archived = current_user.needs_archived
   end
 
   def archives_antenne
@@ -64,10 +60,6 @@ class NeedsController < ApplicationController
   end
 
   private
-
-  def current_involved
-    current_user || current_expert
-  end
 
   def highlighted_experts
     begin

--- a/app/controllers/needs_controller.rb
+++ b/app/controllers/needs_controller.rb
@@ -30,7 +30,6 @@ class NeedsController < ApplicationController
   def show
     @diagnosis = retrieve_diagnosis
     authorize @diagnosis
-    @current_roles = current_roles
     @highlighted_experts = highlighted_experts
   end
 
@@ -46,7 +45,6 @@ class NeedsController < ApplicationController
 
   def add_match
     @diagnosis = retrieve_diagnosis
-    @current_roles = current_roles
 
     @need = Need.find(params.require(:need))
     expert_subject = ExpertSubject.find(params.require(:expert_subject))

--- a/app/helpers/status_helper.rb
+++ b/app/helpers/status_helper.rb
@@ -35,7 +35,7 @@ module StatusHelper
   def match_actions_buttons(match)
     allowed_actions = match.allowed_new_status
 
-    form_with(model: match, url: match_path(match, access_token: params[:access_token])) do |f|
+    form_with(model: match, url: match_path(match)) do |f|
       allowed_actions.map do |new_status|
         title = StatusHelper::status_description(new_status, :action)
         classes = %w[ui small button] + STATUS_COLORS[new_status]

--- a/app/models/expert.rb
+++ b/app/models/expert.rb
@@ -152,19 +152,19 @@ class Expert < ApplicationRecord
 
   ##
   #
-  def can_be_viewed_by?(role)
-    if role.is_a?(User) && role.is_admin
+  def can_be_viewed_by?(user)
+    if user.is_admin
       return true
     end
 
-    if role.is_a?(Expert) && self == role
+    if self.in?(user.experts)
       return true
     end
 
     false
   end
 
-  def can_be_modified_by?(role)
-    can_be_viewed_by?(role)
+  def can_be_modified_by?(user)
+    can_be_viewed_by?(user)
   end
 end

--- a/app/models/expert.rb
+++ b/app/models/expert.rb
@@ -46,11 +46,8 @@ class Expert < ApplicationRecord
 
   ## Validations
   #
-  validates :antenne, :email, :phone_number, :access_token, presence: true
+  validates :antenne, :email, :phone_number, presence: true
   validates :users, presence: true
-  validates :access_token, uniqueness: true
-
-  before_validation :generate_access_token!, on: :create
 
   ## “Through” Associations
   #
@@ -112,16 +109,6 @@ class Expert < ApplicationRecord
     joins(:antenne)
       .where('experts.full_name ILIKE ?', "%#{query}%")
       .or(Expert.joins(:antenne).where('antennes.name ILIKE ?', "%#{query}%"))
-  end
-
-  ##
-  #
-  def generate_access_token!
-    self.access_token = SecureRandom.hex(32)
-
-    if Expert.exists?(access_token: access_token)
-      generate_access_token!
-    end
   end
 
   ## Description

--- a/app/models/match.rb
+++ b/app/models/match.rb
@@ -146,12 +146,12 @@ class Match < ApplicationRecord
 
   ##
   #
-  def can_be_viewed_by?(role)
-    diagnosis.can_be_viewed_by?(role)
+  def can_be_viewed_by?(user)
+    diagnosis.can_be_viewed_by?(user)
   end
 
-  def can_be_modified_by?(role)
-    role.present? && expert == role
+  def can_be_modified_by?(user)
+    expert.in?(user.experts)
   end
 
   private

--- a/app/models/user_context.rb
+++ b/app/models/user_context.rb
@@ -1,8 +1,0 @@
-class UserContext
-  attr_reader :user, :expert
-
-  def initialize(user, expert)
-    @user = user
-    @expert = expert
-  end
-end

--- a/app/policies/application_policy.rb
+++ b/app/policies/application_policy.rb
@@ -1,13 +1,8 @@
 class ApplicationPolicy
-  attr_reader :context, :params
-
-  def initialize(context, record)
-    @context = context
+  def initialize(user, record)
+    @user = user
     @record = record
   end
-
-  delegate :user, to: :context
-  delegate :expert, to: :context
 
   def index?
     true
@@ -44,7 +39,7 @@ class ApplicationPolicy
   end
 
   def admin?
-    user&.is_admin
+    @user&.is_admin
   end
 
   class Scope

--- a/app/policies/diagnosis_policy.rb
+++ b/app/policies/diagnosis_policy.rb
@@ -1,14 +1,10 @@
 class DiagnosisPolicy < ApplicationPolicy
   def show?
-    if user.present?
-      admin? ||
-          @record.advisor == user ||
-          support?(user, @record) ||
-          @record.advisor.antenne == user.antenne ||
-          @record.in?(user&.received_diagnoses)
-    else
-      @record.in?(expert&.received_diagnoses)
-    end
+    admin? ||
+        @record.advisor == @user ||
+        support?(@user, @record) ||
+        @record.advisor.antenne == @user.antenne ||
+        @record.in?(@user&.received_diagnoses)
   end
 
   def update?

--- a/app/policies/feedback_policy.rb
+++ b/app/policies/feedback_policy.rb
@@ -1,20 +1,10 @@
 class FeedbackPolicy < ApplicationPolicy
   def destroy?
-    if user.present?
-      admin? ||
-        creator? ||
-        @record.expert.in?(user.experts)
-    else
-      creator?
-    end
+    admin? || creator?
   end
 
   def creator?
-    if user.present?
-      @record.user == user
-    else
-      @record.expert == user
-    end
+    @record.user == @user || @record.expert.in?(@user.experts)
   end
 
   class Scope < Scope

--- a/app/views/diagnoses/_diagnosis.haml
+++ b/app/views/diagnoses/_diagnosis.haml
@@ -1,5 +1,5 @@
 .ui.segment.selectable-item
-  - path = diagnosis.completed? ? need_path(diagnosis, params.permit(:access_token), highlighted_expert: local_assigns[:highlighted_expert]) : diagnosis_path(diagnosis)
+  - path = diagnosis.completed? ? need_path(diagnosis, highlighted_expert: local_assigns[:highlighted_expert]) : diagnosis_path(diagnosis)
   %a{ href: path }
     %h3.ui.header
       .sub.header= I18n.l(diagnosis.display_date, format: :long)

--- a/app/views/feedbacks/_feedback.haml
+++ b/app/views/feedbacks/_feedback.haml
@@ -13,6 +13,5 @@
     .extra.text= simple_format(feedback.description)
     - if policy(feedback).destroy?
       .meta= link_to(t('delete'),
-        feedback_path(feedback,
-          params.permit(:access_token)),
+        feedback_path(feedback),
           data: { confirm: t('.delete'), remote: true, method: :delete })

--- a/app/views/feedbacks/_feedback.haml
+++ b/app/views/feedbacks/_feedback.haml
@@ -1,4 +1,4 @@
-- for_me = feedback.author.in? current_roles
+- for_me = feedback.user == current_user || feedback.expert.in?(user.experts)
 - highlight = feedback.author.in? highlighted_experts
 .event{ id: "feedback-#{feedback.id}" }
   .label

--- a/app/views/feedbacks/create.js.haml
+++ b/app/views/feedbacks/create.js.haml
@@ -1,4 +1,4 @@
-- feedback_html = render @feedback, current_roles: @current_roles, highlighted_experts: []
+- feedback_html = render @feedback, highlighted_experts: []
 document.getElementById('feedback_form-#{@feedback.need.id}').insertAdjacentHTML('beforebegin', "#{j feedback_html}");
 
 document.querySelector('#feedback_form-#{@feedback.need.id} .form').reset()

--- a/app/views/matches/_match.haml
+++ b/app/views/matches/_match.haml
@@ -1,4 +1,4 @@
-- for_me = match.expert.in? current_roles
+- for_me = match.in?(current_user.received_matches)
 - highlight = match.expert.in? highlighted_experts
 .event{ id: "match-#{match.id}" }
   .label

--- a/app/views/matches/update.js.haml
+++ b/app/views/matches/update.js.haml
@@ -1,4 +1,4 @@
-- match_html = render @match, current_roles: @current_roles, highlighted_experts: []
+- match_html = render @match, highlighted_experts: []
 document.getElementById('match-#{@match.id}').outerHTML = "#{j match_html}";
 
 - need_header_html = render 'needs/need_header', need: @match.need

--- a/app/views/needs/_feedback_form.haml
+++ b/app/views/needs/_feedback_form.haml
@@ -7,7 +7,7 @@
       .date= t('.subtitle')
     .extra
     = form_with scope: feedback,
-      url: feedbacks_path(feedback, params.permit(:access_token)),
+      url: feedbacks_path(feedback),
       class: 'ui form' do |form|
       = form.hidden_field :need_id
       .field

--- a/app/views/needs/_need.haml
+++ b/app/views/needs/_need.haml
@@ -2,8 +2,8 @@
   = render 'need_header', need: need
 
   .ui.feed
-    = render 'need_content', need: need, current_roles: current_roles, highlighted_experts: highlighted_experts
-    = render need.feedbacks.order(:created_at), current_roles: current_roles, highlighted_experts: highlighted_experts
-    = render 'feedback_form', need: need, current_roles: current_roles
-    = render need.matches.order(:created_at), current_roles: current_roles, highlighted_experts: highlighted_experts
+    = render 'need_content', need: need, highlighted_experts: highlighted_experts
+    = render need.feedbacks.order(:created_at), highlighted_experts: highlighted_experts
+    = render 'feedback_form', need: need
+    = render need.matches.order(:created_at), highlighted_experts: highlighted_experts
     = render 'additional_experts', need: need

--- a/app/views/needs/_need_content.haml
+++ b/app/views/needs/_need_content.haml
@@ -1,6 +1,6 @@
 - return if need.content.empty?
 
-- for_me = need.advisor.in? current_roles
+- for_me = need.advisor == current_user
 - highlight = need.advisor.in? highlighted_experts
 .event{ id: "need_content-#{need.id}" }
   .label

--- a/app/views/needs/add_match.js.haml
+++ b/app/views/needs/add_match.js.haml
@@ -1,4 +1,4 @@
-- match_html = render @match, current_roles: @current_roles, highlighted_experts: []
+- match_html = render @match, highlighted_experts: []
 document.getElementById('additional_experts-#{@need.id}').insertAdjacentHTML('beforebegin', "#{j match_html}");
 
 - html = render 'additional_experts', need: @need

--- a/app/views/needs/show.haml
+++ b/app/views/needs/show.haml
@@ -2,4 +2,4 @@
 
 = render 'visit_summary', diagnosis: @diagnosis
 
-= render @diagnosis.needs.ordered_for_interview, current_roles: @current_roles, highlighted_experts: @highlighted_experts
+= render @diagnosis.needs.ordered_for_interview, highlighted_experts: @highlighted_experts

--- a/config/locales/models.fr.yml
+++ b/config/locales/models.fr.yml
@@ -83,7 +83,6 @@ fr:
         phone_number: Numéro de téléphone de la personne rencontrée
         role: Fonction de la personne rencontrée
       expert:
-        access_token: Token d’accès
         experts_subjects:
           one: Compétence
           other: Compétences

--- a/lib/tasks/import_dump.rake
+++ b/lib/tasks/import_dump.rake
@@ -48,7 +48,6 @@ namespace :import_dump do
   ]
 
   ANONYMIZED_ATTRIBUTES = {
-    'access_token' => -> { SecureRandom.hex(32) },
     'content' => -> { Faker::Lorem.paragraph },
     'description' => -> { Faker::Lorem.paragraph },
     'title' => -> { Faker::Lorem.sentence },

--- a/spec/models/expert_spec.rb
+++ b/spec/models/expert_spec.rb
@@ -76,36 +76,4 @@ RSpec.describe Expert, type: :model do
       it{ is_expected.to be_falsey }
     end
   end
-
-  describe 'generate_access_token' do
-    let(:expert) { create :expert }
-
-    context 'it is a new expert' do
-      context 'there is no expert with this access_token' do
-        before { allow(SecureRandom).to receive(:hex).once.and_return('access_token') }
-
-        it { expect(expert.access_token).to eq 'access_token' }
-      end
-
-      context 'there is already a expert with this access_token' do
-        let!(:expert_with_same_access_token) { create :expert }
-
-        before do
-          expert_with_same_access_token.update access_token: 'access_token'
-          allow(SecureRandom).to receive(:hex).at_least(:once).and_return('access_token', 'other_access_token')
-        end
-
-        it { expect(expert.access_token).to eq 'other_access_token' }
-      end
-    end
-
-    context 'expert is already created' do
-      before do
-        allow(SecureRandom).to receive(:hex).once.and_return('access_token')
-        expert.save
-      end
-
-      it { expect(expert.access_token).to eq 'access_token' }
-    end
-  end
 end

--- a/spec/policies/diagnosis_policy_spec.rb
+++ b/spec/policies/diagnosis_policy_spec.rb
@@ -1,10 +1,7 @@
 require 'rails_helper'
 
 RSpec.describe DiagnosisPolicy, type: :policy do
-
-  let(:context) { UserContext.new(user, expert) }
   let(:user) { nil }
-  let(:expert) { nil }
   let(:diagnosis) { create :diagnosis }
 
   subject { described_class }
@@ -13,19 +10,19 @@ RSpec.describe DiagnosisPolicy, type: :policy do
     context "user is diagnosis advisor" do
       let(:user) { diagnosis.advisor }
 
-      it { is_expected.to permit(context, diagnosis) }
+      it { is_expected.to permit(user, diagnosis) }
     end
 
     context "user in the same antenne" do
       let(:user) { create :user, antenne: diagnosis.advisor.antenne }
 
-      it { is_expected.to permit(context, diagnosis) }
+      it { is_expected.to permit(user, diagnosis) }
     end
 
     context "grants access if user is admin" do
       let(:user) { create :user, is_admin: true }
 
-      it { is_expected.to permit(context, diagnosis) }
+      it { is_expected.to permit(user, diagnosis) }
     end
 
     context "grants access if user is support" do
@@ -35,13 +32,13 @@ RSpec.describe DiagnosisPolicy, type: :policy do
       let!(:expert_subject) { create :expert_subject, expert: expert, institution_subject: institution_subject }
       let(:institution_subject) { create :institution_subject, subject: support_subject }
 
-      it { expect(subject).to permit(context, diagnosis) }
+      it { expect(subject).to permit(user, diagnosis) }
     end
 
     context "denies access if user is another user" do
       let(:user) { create :user, antenne: create(:antenne) }
 
-      it { expect(subject).not_to permit(context, diagnosis) }
+      it { expect(subject).not_to permit(user, diagnosis) }
     end
 
     context "denies access if user is another support_user" do
@@ -51,7 +48,7 @@ RSpec.describe DiagnosisPolicy, type: :policy do
       let(:institution_subject) { create :institution_subject, subject: support_subject }
       let(:support_subject) { create :subject, is_support: true }
 
-      it { expect(subject).not_to permit(context, diagnosis) }
+      it { expect(subject).not_to permit(user, diagnosis) }
     end
   end
 
@@ -59,7 +56,7 @@ RSpec.describe DiagnosisPolicy, type: :policy do
      context "all user can create a diagnosis" do
        let(:user) { create :user }
 
-       it { is_expected.to permit(context, diagnosis) }
+       it { is_expected.to permit(user, diagnosis) }
      end
    end
 
@@ -67,13 +64,13 @@ RSpec.describe DiagnosisPolicy, type: :policy do
      context "grants access if user is diagnosis advisor" do
        let(:user) { diagnosis.advisor }
 
-       it { is_expected.to permit(context, diagnosis) }
+       it { is_expected.to permit(user, diagnosis) }
      end
 
      context "grants access if user is admin" do
        let(:user) { create :user, is_admin: true }
 
-       it { is_expected.to permit(context, diagnosis) }
+       it { is_expected.to permit(user, diagnosis) }
      end
 
      context "grants access if user is support" do
@@ -83,13 +80,13 @@ RSpec.describe DiagnosisPolicy, type: :policy do
        let!(:expert_subject) { create :expert_subject, expert: expert, institution_subject: institution_subject }
        let(:institution_subject) { create :institution_subject, subject: support_subject }
 
-       it { expect(subject).to permit(context, diagnosis) }
+       it { expect(subject).to permit(user, diagnosis) }
      end
 
      context "denies access if user is another user" do
        let(:user) { create :user, antenne: create(:antenne) }
 
-       it { expect(subject).not_to permit(context, diagnosis) }
+       it { expect(subject).not_to permit(user, diagnosis) }
      end
 
      context "denies access if user is another support_user" do
@@ -99,7 +96,7 @@ RSpec.describe DiagnosisPolicy, type: :policy do
        let(:institution_subject) { create :institution_subject, subject: support_subject }
        let(:support_subject) { create :subject, is_support: true }
 
-       it { expect(subject).not_to permit(context, diagnosis) }
+       it { expect(subject).not_to permit(user, diagnosis) }
      end
    end
 
@@ -107,13 +104,13 @@ RSpec.describe DiagnosisPolicy, type: :policy do
      context "denie access if user is diagnosis advisor" do
        let(:user) { diagnosis.advisor }
 
-       it { is_expected.not_to permit(context, diagnosis) }
+       it { is_expected.not_to permit(user, diagnosis) }
      end
 
      context "grants access if user is admin" do
        let(:user) { create :user, is_admin: true }
 
-       it { is_expected.to permit(context, diagnosis) }
+       it { is_expected.to permit(user, diagnosis) }
      end
 
      context "denies access if user is support" do
@@ -123,13 +120,13 @@ RSpec.describe DiagnosisPolicy, type: :policy do
        let!(:expert_subject) { create :expert_subject, expert: expert, institution_subject: institution_subject }
        let(:institution_subject) { create :institution_subject, subject: support_subject }
 
-       it { expect(subject).not_to permit(context, diagnosis) }
+       it { expect(subject).not_to permit(user, diagnosis) }
      end
 
      context "denies access if user is another user" do
        let(:user) { create :user, antenne: create(:antenne) }
 
-       it { expect(subject).not_to permit(context, diagnosis) }
+       it { expect(subject).not_to permit(user, diagnosis) }
      end
    end
 end

--- a/spec/policies/feedback_policy_spec.rb
+++ b/spec/policies/feedback_policy_spec.rb
@@ -1,38 +1,29 @@
 require 'rails_helper'
 
 RSpec.describe FeedbackPolicy, type: :policy do
-  let(:context) { UserContext.new(user, expert) }
   let(:user) { nil }
-  let(:expert) { nil }
   let(:diagnosis) { create :diagnosis }
 
   subject { described_class }
 
   permissions :destroy? do
-    context "grants access if expert is feedback creator" do
-      let(:user) { diagnosis.advisor }
-      let(:expert) { create :expert, users: [user] }
-      let(:feedback) { create :feedback, expert: expert }
-
-      it { expect(subject).to permit(context, feedback) }
-    end
     context "grants access if user is feedback creator" do
       let(:feedback) { create :feedback, user: user }
       let(:user) { diagnosis.advisor }
 
-      it { expect(subject).to permit(context, feedback) }
+      it { expect(subject).to permit(user, feedback) }
     end
     context "grants access if user is admin" do
       let(:feedback) { create :feedback, :of_user }
       let(:user) { create :user, is_admin: true }
 
-      it { expect(subject).to permit(context, feedback) }
+      it { expect(subject).to permit(user, feedback) }
     end
     context "denies access if user is another user" do
       let(:feedback) { create :feedback, :of_user }
       let(:user) { create :user }
 
-      it { expect(subject).not_to permit(context, feedback) }
+      it { expect(subject).not_to permit(user, feedback) }
     end
   end
 end


### PR DESCRIPTION
🔥🔥🔥🔥


* [x] ⚠️ merge #715 first

Stop using `access_token`, `current_expert` and `current_roles` everywhere.

This finally closes #638.
 