### PR TITLE
Remove old /diagnosis/expert route redirection

### DIFF
--- a/config/routes.rb
+++ b/config/routes.rb
@@ -83,9 +83,5 @@ Rails.application.routes.draw do
     end
   end
 
-  get '/experts/diagnoses/:diagnosis', to: (redirect do |params, request|
-    "/besoins/#{params[:diagnosis]}?#{request.params.slice(:access_token).to_query}"
-  end)
-
   resources :experts, only: %i[edit update]
 end


### PR DESCRIPTION
/besoins/:need used to live at /diagnoses/experts/:need, but that was _a long time ago_, before there was even a relation between Users and Experts.

This is tangentially related to #735; we could patch it, but frankly let’s just get rid of it.