### PR TITLE
Display ribbons in `pages`

### DIFF
--- a/app/views/layouts/application.html.haml
+++ b/app/views/layouts/application.html.haml
@@ -5,9 +5,7 @@
   %body
     = render 'navbar'
     = render 'environment_ribbon'
-
-    - if current_staff_user
-      = render 'user_impersonate'
+    = render 'user_impersonate'
 
     %main
       .ui.main.text.container

--- a/app/views/layouts/pages.html.haml
+++ b/app/views/layouts/pages.html.haml
@@ -15,6 +15,8 @@
 
   %body
     = render 'navbar'
+    = render 'environment_ribbon'
+    = render 'user_impersonate'
     = yield
     = render 'footer'
 

--- a/app/views/shared/_user_impersonate.html.haml
+++ b/app/views/shared/_user_impersonate.html.haml
@@ -1,11 +1,13 @@
+- return if current_staff_user.blank?
+
 #impersonating
   .impersonate-info
     Vous (
     %span.admin-name<>= current_staff_user
-    ) utilisez voyez le site en tant que
+    ) voyez le site en tant que
     %span.user-name= current_user
-    = " (ID de l'utilisateur : #{current_user&.id})"
+    = " (ID #{current_user&.id})"
 
   .impersonate-buttons
     = form_with url: impersonate_engine.revert_impersonate_user_url, method: :delete, class: 'revert-form' do |f|
-      = f.submit 'Retourner a l’admin', class: 'ui button green'
+      = f.submit 'Retourner a l’admin'


### PR DESCRIPTION
Display the “development” and “impersonate” partials in `pages` as well as in the main `application`. 

* [x] ⚠️ merge #734 first; this is not related, but it’s just easier to do with the new structure.