### PR TITLE
Fix i18n in the update_match_notify email

### DIFF
--- a/config/locales/views.fr.yml
+++ b/config/locales/views.fr.yml
@@ -299,10 +299,10 @@ fr:
         subject: "[Place des Entreprises] Des nouvelles de l’entreprise %{company_name}"
       update_match_notify:
         expert_and_status:
-          care_html: "<p>%{user} (%{antenne}) a pris en charge ce besoin.</p>"
           done_html: "<p>%{user} (%{antenne}) a clôturé ce besoin.</p>"
           not_for_me_html: "<p>%{user} (%{antenne}) a refusé ce besoin.</p><p>Si aucun expert n’intervient, l’Equipe Place des Entreprises prendra le relai.</p>"
           quo_html: "<p>%{user} (%{antenne}) a annulé sa derniere action (%{previous_status}).</p>"
+          taking_care_html: "<p>%{user} (%{antenne}) a pris en charge ce besoin.</p>"
         need_description_html: Le besoin de l’entreprise <a href='%{path}'>%{company_name}</a> que vous avez adressé le %{date} - %{subject} - a évolué.
         nice_day: Bonne journée,
         subject: "[Place des Entreprises] Des nouvelles de l’entreprise %{company_name}"


### PR DESCRIPTION
The `taking_care` key was incorrect in the yml file, which led to this:

<img width="429" alt="image" src="https://user-images.githubusercontent.com/139391/71882090-03cc4300-3134-11ea-9bdd-9d4425ddcccc.png">
