### PR TITLE
Workaround update_match_notify crashing when there is no current_user

### DIFF
--- a/app/mailers/user_mailer.rb
+++ b/app/mailers/user_mailer.rb
@@ -32,7 +32,7 @@ class UserMailer < ApplicationMailer
     @match = match
     @expert = match.expert
     @previous_status = previous_status
-    @user = user
+    @person = user || match.expert
     @advisor = match.advisor
     @company = match.company
     @need = match.need

--- a/app/views/mailers/user_mailer/update_match_notify.html.haml
+++ b/app/views/mailers/user_mailer/update_match_notify.html.haml
@@ -8,8 +8,8 @@
 
 %blockquote
   = t(".expert_and_status.#{@match.status}_html",
-    user: @user.full_name,
-    antenne: @user.antenne.name,
+    user: @person.full_name,
+    antenne: @person.antenne.name,
     previous_status: t("attributes.statuses_action.#{@previous_status}"))
 
 %p= t('.nice_day')


### PR DESCRIPTION
This is still possible, until we merge #735

fixes PLACE-DES-ENTREPRISES-4D PLACE-DES-ENTREPRISES-4G