### PR TITLE
Switch to fomantic-ui (and to sassc)

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -23,7 +23,7 @@ gem 'puma'
 gem 'haml-rails'
 gem 'jquery-rails'
 gem 'sassc-rails'
-gem 'fomantic-ui-sass', git: 'https://github.com/n-b/Fomantic-UI-SASS.git', branch: 'sassc'
+gem 'fomantic-ui-sass'
 gem 'uglifier'
 gem 'premailer-rails'
 

--- a/Gemfile
+++ b/Gemfile
@@ -23,7 +23,7 @@ gem 'puma'
 gem 'haml-rails'
 gem 'jquery-rails'
 gem 'sassc-rails'
-gem 'fomantic-ui-sass'
+gem 'fomantic-ui-sass', git: 'https://github.com/n-b/Fomantic-UI-SASS.git', branch: 'sassc'
 gem 'uglifier'
 gem 'premailer-rails'
 

--- a/Gemfile
+++ b/Gemfile
@@ -23,7 +23,7 @@ gem 'puma'
 gem 'haml-rails'
 gem 'jquery-rails'
 gem 'sassc-rails'
-gem 'semantic-ui-sass'
+gem 'fomantic-ui-sass'
 gem 'uglifier'
 gem 'premailer-rails'
 

--- a/Gemfile
+++ b/Gemfile
@@ -22,7 +22,7 @@ gem 'puma'
 # Assets
 gem 'haml-rails'
 gem 'jquery-rails'
-gem 'sass-rails'
+gem 'sassc-rails'
 gem 'semantic-ui-sass'
 gem 'uglifier'
 gem 'premailer-rails'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -108,6 +108,8 @@ GEM
     ast (2.4.0)
     audited (4.9.0)
       activerecord (>= 4.2, < 6.1)
+    autoprefixer-rails (9.7.2)
+      execjs
     awesome_print (1.8.0)
     babel-source (5.8.35)
     babel-transpiler (0.7.0)
@@ -190,6 +192,12 @@ GEM
     ffi-compiler (1.0.1)
       ffi (>= 1.0.0)
       rake
+    fomantic-ui-sass (2.8.1)
+      autoprefixer-rails
+      rails (>= 3.2.0)
+      sass (>= 3.2)
+      sass-rails (>= 3.2)
+      sprockets-rails (>= 2.1.3)
     foreman (0.86.0)
     formtastic (3.1.5)
       actionpack (>= 3.2.13)
@@ -431,6 +439,8 @@ GEM
     sass-listen (4.0.0)
       rb-fsevent (~> 0.9, >= 0.9.4)
       rb-inotify (~> 0.9, >= 0.9.7)
+    sass-rails (6.0.0)
+      sassc-rails (~> 2.1, >= 2.1.1)
     sassc (2.2.1)
       ffi (~> 1.9)
     sassc-rails (2.1.2)
@@ -443,8 +453,6 @@ GEM
     selenium-webdriver (3.142.6)
       childprocess (>= 0.5, < 4.0)
       rubyzip (>= 1.2.2)
-    semantic-ui-sass (2.4.2.0)
-      sass (>= 3.2)
     sentry-raven (2.12.3)
       faraday (>= 0.7.6, < 1.0)
     sexp_processor (4.13.0)
@@ -536,6 +544,7 @@ DEPENDENCIES
   dotenv-rails
   factory_bot_rails
   faker
+  fomantic-ui-sass
   foreman
   groupdate
   haml-rails
@@ -567,7 +576,6 @@ DEPENDENCIES
   rubocop-rspec
   sassc-rails
   selenium-webdriver
-  semantic-ui-sass
   sentry-raven
   shoulda-matchers
   spring

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -431,8 +431,6 @@ GEM
     sass-listen (4.0.0)
       rb-fsevent (~> 0.9, >= 0.9.4)
       rb-inotify (~> 0.9, >= 0.9.7)
-    sass-rails (6.0.0)
-      sassc-rails (~> 2.1, >= 2.1.1)
     sassc (2.2.1)
       ffi (~> 1.9)
     sassc-rails (2.1.2)
@@ -567,7 +565,7 @@ DEPENDENCIES
   rubocop-performance
   rubocop-rails
   rubocop-rspec
-  sass-rails
+  sassc-rails
   selenium-webdriver
   semantic-ui-sass
   sentry-raven

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,4 +1,16 @@
 GIT
+  remote: https://github.com/n-b/Fomantic-UI-SASS.git
+  revision: cba63afc66177fd13707538867c54cded6ac7591
+  branch: sassc
+  specs:
+    fomantic-ui-sass (2.8.1)
+      autoprefixer-rails
+      rails (>= 3.2.0)
+      sassc (>= 2.2)
+      sassc-rails (>= 2.1)
+      sprockets-rails (>= 2.1.3)
+
+GIT
   remote: https://github.com/rspec/rspec-rails
   revision: 1a1a2a17cb663474ada9741433ca64899a788656
   branch: 4-0-maintenance
@@ -192,12 +204,6 @@ GEM
     ffi-compiler (1.0.1)
       ffi (>= 1.0.0)
       rake
-    fomantic-ui-sass (2.8.1)
-      autoprefixer-rails
-      rails (>= 3.2.0)
-      sass (>= 3.2)
-      sass-rails (>= 3.2)
-      sprockets-rails (>= 2.1.3)
     foreman (0.86.0)
     formtastic (3.1.5)
       actionpack (>= 3.2.13)
@@ -434,13 +440,6 @@ GEM
       sexp_processor (~> 4.9)
     rubyzip (1.3.0)
     safe_yaml (1.0.5)
-    sass (3.7.4)
-      sass-listen (~> 4.0.0)
-    sass-listen (4.0.0)
-      rb-fsevent (~> 0.9, >= 0.9.4)
-      rb-inotify (~> 0.9, >= 0.9.7)
-    sass-rails (6.0.0)
-      sassc-rails (~> 2.1, >= 2.1.1)
     sassc (2.2.1)
       ffi (~> 1.9)
     sassc-rails (2.1.2)
@@ -544,7 +543,7 @@ DEPENDENCIES
   dotenv-rails
   factory_bot_rails
   faker
-  fomantic-ui-sass
+  fomantic-ui-sass!
   foreman
   groupdate
   haml-rails

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,16 +1,4 @@
 GIT
-  remote: https://github.com/n-b/Fomantic-UI-SASS.git
-  revision: cba63afc66177fd13707538867c54cded6ac7591
-  branch: sassc
-  specs:
-    fomantic-ui-sass (2.8.1)
-      autoprefixer-rails
-      rails (>= 3.2.0)
-      sassc (>= 2.2)
-      sassc-rails (>= 2.1)
-      sprockets-rails (>= 2.1.3)
-
-GIT
   remote: https://github.com/rspec/rspec-rails
   revision: 1a1a2a17cb663474ada9741433ca64899a788656
   branch: 4-0-maintenance
@@ -120,7 +108,7 @@ GEM
     ast (2.4.0)
     audited (4.9.0)
       activerecord (>= 4.2, < 6.1)
-    autoprefixer-rails (9.7.2)
+    autoprefixer-rails (9.7.4)
       execjs
     awesome_print (1.8.0)
     babel-source (5.8.35)
@@ -204,6 +192,12 @@ GEM
     ffi-compiler (1.0.1)
       ffi (>= 1.0.0)
       rake
+    fomantic-ui-sass (2.8.3)
+      autoprefixer-rails
+      rails (>= 3.2.0)
+      sassc (>= 2.2)
+      sassc-rails (>= 2.1)
+      sprockets-rails (>= 2.1.3)
     foreman (0.86.0)
     formtastic (3.1.5)
       actionpack (>= 3.2.13)
@@ -543,7 +537,7 @@ DEPENDENCIES
   dotenv-rails
   factory_bot_rails
   faker
-  fomantic-ui-sass!
+  fomantic-ui-sass
   foreman
   groupdate
   haml-rails


### PR DESCRIPTION
1. change our declared dependencies from sass to sassc - it’s actually the same, the sass-rails gem is now just a frontend to sassc-rails.
2. however, semantic-ui-sass still uses the ruby-based sass; 
  2.1 switch to the community fork, fomantic-ui-sass
  2.2 [make a PR](https://github.com/fomantic/Fomantic-UI-SASS/pull/3) to switch fomantic-ui-sass itself to sassc
  2.3 update fomantic-ui-sass once this PR is merged

This means we’re now using fomantic-ui 2.8.4 (from semantic-ui 2.4.2), with a [handful of features](https://fomantic-ui.com/introduction/new.html); the switch to sassc itself may increase performance a little bit, but at this point, even switching to libsass sounds dated. Anyway.