### PR TITLE
Remove the assets.precompile line in assets.rb

### DIFF
--- a/config/initializers/assets.rb
+++ b/config/initializers/assets.rb
@@ -5,7 +5,3 @@ Rails.application.config.assets.version = '1.0'
 
 # Add additional assets to the asset load path.
 # Rails.application.config.assets.paths << Emoji.images_path
-
-# Precompile additional assets.
-# application.js, application.css, and all non-JS/CSS in app/assets folder are already added.
-Rails.application.config.assets.precompile += ["manifest.js"]


### PR DESCRIPTION
We’re having semi-random crashes in the test suite linking to this issue in sassc:
https://github.com/sass/sassc-rails/issues/122
It is suggested that this line is involved. In any case, it looks like this triggers duplicate precompilation, which (this is a theory) may lead to a race condition.