### PR TITLE
Cleanup routes.rb

### DIFF
--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,17 +1,6 @@
 Rails.application.routes.draw do
-  mount UserImpersonate::Engine => '/impersonate', as: 'impersonate_engine'
-  mount LetterOpenerWeb::Engine, at: "/letter_opener" if Rails.env.development?
-
-  ActiveAdmin.routes(self)
-  devise_for :users, controllers: { registrations: 'users/registrations', invitations: 'users/invitations' }, skip: [:registrations]
-  devise_scope :user do
-    get 'users/edit' => 'users/registrations#edit', :as => 'edit_user_registration'
-    put 'users' => 'users/registrations#update', :as => 'user_registration'
-  end
-
+  # Pages
   root to: 'landings#index'
-
-  get 'profile' => 'users#show'
 
   resource :stats, only: [:show] do
     collection do
@@ -32,6 +21,7 @@ Rails.application.routes.draw do
 
   resource :solicitation, only: %i[create]
 
+  # Application
   resources :diagnoses, only: %i[index new show], path: 'analyses' do
     collection do
       get :archives
@@ -74,8 +64,8 @@ Rails.application.routes.draw do
   end
 
   resources :matches, only: %i[update]
-
   resources :feedbacks, only: %i[create destroy]
+  resources :experts, only: %i[edit update]
 
   resources :relances, as: 'reminders', controller: 'reminders', only: %i[index show] do
     member do
@@ -83,7 +73,28 @@ Rails.application.routes.draw do
     end
   end
 
-  resources :experts, only: %i[edit update]
-
   get '/diagnoses', to: redirect('/analyses')
+
+  # Devise
+  devise_for :users,
+             controllers: {
+               registrations: 'users/registrations',
+               invitations: 'users/invitations'
+             },
+             skip: [:registrations]
+  devise_scope :user do
+    get 'users/edit' => 'users/registrations#edit', :as => 'edit_user_registration'
+    put 'users' => 'users/registrations#update', :as => 'user_registration'
+  end
+
+  get 'profile' => 'users#show'
+
+  # ActiveAdmin
+  ActiveAdmin.routes(self)
+
+  # Impersonate
+  mount UserImpersonate::Engine => '/impersonate', as: 'impersonate_engine'
+
+  # LetterOpener
+  mount LetterOpenerWeb::Engine, at: "/letter_opener" if Rails.env.development?
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -27,8 +27,6 @@ Rails.application.routes.draw do
   get 'cgu', to: 'about#cgu'
   get 'top_5', to: 'about#top_5'
 
-  resource 'conseillers', only: %i[show] # what is it
-
   get 'entreprise/:slug', to: 'landings#show', as: 'landing'
   get 'aide/:slug', to: 'landings#show', as: 'featured_landing'
 

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,4 +1,25 @@
 Rails.application.routes.draw do
+  # ActiveAdmin
+  ActiveAdmin.routes(self)
+
+  # Impersonate
+  mount UserImpersonate::Engine, at: '/impersonate', as: 'impersonate_engine'
+
+  # LetterOpener
+  mount LetterOpenerWeb::Engine, at: '/letter_opener' if Rails.env.development?
+
+  # Devise
+  devise_for :users,
+             controllers: {
+               registrations: 'users/registrations',
+               invitations: 'users/invitations'
+             },
+             skip: [:registrations]
+  devise_scope :user do
+    get 'users/edit' => 'users/registrations#edit', :as => 'edit_user_registration'
+    put 'users' => 'users/registrations#update', :as => 'user_registration'
+  end
+
   # Pages
   controller :landings do
     root action: :index
@@ -76,29 +97,8 @@ Rails.application.routes.draw do
     end
   end
 
-  ## Redirection for compatibility
-  get '/diagnoses', to: redirect('/analyses')
-
-  # Devise
-  devise_for :users,
-             controllers: {
-               registrations: 'users/registrations',
-               invitations: 'users/invitations'
-             },
-             skip: [:registrations]
-  devise_scope :user do
-    get 'users/edit' => 'users/registrations#edit', :as => 'edit_user_registration'
-    put 'users' => 'users/registrations#update', :as => 'user_registration'
-  end
-
   get 'profile' => 'users#show'
 
-  # ActiveAdmin
-  ActiveAdmin.routes(self)
-
-  # Impersonate
-  mount UserImpersonate::Engine, at: '/impersonate', as: 'impersonate_engine'
-
-  # LetterOpener
-  mount LetterOpenerWeb::Engine, at: '/letter_opener' if Rails.env.development?
+  ## Redirection for compatibility
+  get '/diagnoses', to: redirect('/analyses')
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,6 +1,18 @@
 Rails.application.routes.draw do
   # Pages
-  root to: 'landings#index'
+  controller :landings do
+    root action: :index
+    get 'entreprise/:slug', action: :show, as: :landing
+    get 'aide/:slug', action: :show, as: :featured_landing
+  end
+
+  resource :solicitation, only: %i[create]
+
+  controller :about do
+    get :qui_sommes_nous
+    get :cgu
+    get :top_5
+  end
 
   resource :stats, only: [:show] do
     collection do
@@ -11,15 +23,6 @@ Rails.application.routes.draw do
       get :tables
     end
   end
-
-  get 'qui_sommes_nous', to: 'about#qui_sommes_nous'
-  get 'cgu', to: 'about#cgu'
-  get 'top_5', to: 'about#top_5'
-
-  get 'entreprise/:slug', to: 'landings#show', as: 'landing'
-  get 'aide/:slug', to: 'landings#show', as: 'featured_landing'
-
-  resource :solicitation, only: %i[create]
 
   # Application
   resources :diagnoses, only: %i[index new show], path: 'analyses' do
@@ -51,7 +54,7 @@ Rails.application.routes.draw do
     end
   end
 
-  resources :besoins, as: 'needs', controller: 'needs', only: %i[index show] do
+  resources :needs, only: %i[index show], path: 'besoins' do
     collection do
       get :archives
       get :index_antenne
@@ -67,12 +70,13 @@ Rails.application.routes.draw do
   resources :feedbacks, only: %i[create destroy]
   resources :experts, only: %i[edit update]
 
-  resources :relances, as: 'reminders', controller: 'reminders', only: %i[index show] do
+  resources :reminders, only: %i[index show], path: 'relances' do
     member do
       post :reminders_notes
     end
   end
 
+  ## Redirection for compatibility
   get '/diagnoses', to: redirect('/analyses')
 
   # Devise
@@ -93,8 +97,8 @@ Rails.application.routes.draw do
   ActiveAdmin.routes(self)
 
   # Impersonate
-  mount UserImpersonate::Engine => '/impersonate', as: 'impersonate_engine'
+  mount UserImpersonate::Engine, at: '/impersonate', as: 'impersonate_engine'
 
   # LetterOpener
-  mount LetterOpenerWeb::Engine, at: "/letter_opener" if Rails.env.development?
+  mount LetterOpenerWeb::Engine, at: '/letter_opener' if Rails.env.development?
 end


### PR DESCRIPTION
* Remove now-unused /conseillers route.
* Reorder in distinct sections (for Pages and Application)
* Tidy up codestyle a bit

The generated routes are the exact same as before (except for the removed /conseillers route). The order changes, but as far as I can tell, there are no ambiguous routes that would be resolved differently.
