### PR TITLE
Ajustements des pages d’accueil

### DIFF
--- a/app/assets/stylesheets/pages.sass
+++ b/app/assets/stylesheets/pages.sass
@@ -72,7 +72,6 @@ section.section#featured-landings
           text-decoration: underline
 
 section.section#description
-  text-align: center
   h2
     font-size: 1.75rem
   p, a
@@ -85,7 +84,6 @@ section.section#description
     font-weight: bold
 
 section.section#landing-topics
-  text-align: center
   a
     margin: 2rem 0
     font-weight: bold

--- a/app/views/landing_topics/_example_topics.haml
+++ b/app/views/landing_topics/_example_topics.haml
@@ -1,13 +1,13 @@
 - if landing.featured_on_home
   - if landing_topics.present?
     %h3
-      = t('.exemple_topics')
+      = t('.example_topics')
     .row
       = render partial: 'landing_topics/landing_topic', collection: landing_topics
     %p
       = t('.not_in_topics')
       = link_to t('.not_in_topics_more'), root_path(links_tracking_params)
 
-  - else
-    %p.text-center
-      = link_to landing.button, root_path(links_tracking_params), class: 'button primary large'
+- else
+  %p.text-center
+    = link_to landing.button, root_path(links_tracking_params), class: 'button primary large'

--- a/app/views/landings/index.haml
+++ b/app/views/landings/index.haml
@@ -3,12 +3,12 @@
 = render 'hero'
 
 %section.section.section-white#description
-  .container
+  .container.text-center
     = image_tag('place-des-entreprises-logo.png', alt: "logo Place des Entreprises", id: 'logo-pde')
     %h2.lead-text
       = t('.question')
     %h2.lead-text
-      = t('.answere')
+      = t('.answer')
     = link_to t('.submit_request'), '#featured-landings', class: 'button blue'
     = render 'institutions'
 

--- a/app/views/landings/show.haml
+++ b/app/views/landings/show.haml
@@ -6,12 +6,12 @@
 = render 'hero'
 
 %section.section.section-white#landing-topics
-  .container
+  .container.text-center
     = render 'landing_details', landing: @landing
 
 %section.section.section-grey
   .container
-    = render 'landing_topics/exemple_topics', landing: @landing, landing_topics: @landing_topics, links_tracking_params: @links_tracking_params
+    = render 'landing_topics/example_topics', landing: @landing, landing_topics: @landing_topics, links_tracking_params: @links_tracking_params
 
 - if @landing.featured_on_home
   %section.section.section-white

--- a/config/locales/views.fr.yml
+++ b/config/locales/views.fr.yml
@@ -174,15 +174,15 @@ fr:
     feedback:
       delete: Supprimer ce commentaire ?
   landing_topics:
-    exemple_topics:
-      exemple_topics: 'Exemples d’aides :'
+    example_topics:
+      example_topics: 'Exemples d’aides :'
       not_in_topics: Votre question n’est pas dans cette liste ?
       not_in_topics_more: Voir tous les domaines d’aides aux entreprises
   landings:
     hero:
       title: 'Place des Entreprises : le guichet public et gratuit d’accompagnement des TPE & PME'
     index:
-      answere: 'Service public simple et rapide : vous êtes rappelé par LE conseiller qui peut vous aider.'
+      answer: 'Service public simple et rapide : vous êtes rappelé par LE conseiller qui peut vous aider.'
       meta:
         description: Financement de projets, difficultés financières, cession reprise, formation, recrutement… Service public rapide et gratuit pour accéder au bon conseiller.
         title: Place des Entreprises, le guichet public des TPE et PME

--- a/spec/features/landing_page_feature_spec.rb
+++ b/spec/features/landing_page_feature_spec.rb
@@ -5,7 +5,7 @@ require 'rails_helper'
 describe 'Landing Page Feature', type: :feature do
   before do
     Rails.cache.clear
-    create :landing, slug: 'landing', button: 'Go to Home', featured_on_home: true
+    create :landing, slug: 'landing', button: 'Go to Home'
   end
 
   describe 'get solicitation with pk params' do


### PR DESCRIPTION
followup #781

* Typos:
 "answere" -> "answer"
 "exemple_topics" -> "example_topics"
* Use the text-center class rather than creating a new css rule
* Fix the else condition ("landing.featured_on_home") in example_topics.haml.
 Technically, all landings are currently “featured on home”, so we might as well remove this feature.