### PR TITLE
Hide the “diagnosis without siret” form behind an env flag

### DIFF
--- a/app/views/diagnoses/index.haml
+++ b/app/views/diagnoses/index.haml
@@ -1,10 +1,15 @@
 - meta title: t('.title')
 
-%h1.ui.header
-  = t('.title')
-  = link_to t('.create_new_diagnosis'), new_diagnosis_path, class: 'ui button green right floated large new-diagnosis'
-  .sub.header
-    = t('.subtitle', name: current_user.full_name)
+- if ENV['FEATURE_DIAGNOSIS_WITHOUT_SIRET'].to_b
+  %h1.ui.header
+    = t('.title')
+    = link_to t('.create_new_diagnosis'), new_diagnosis_path, class: 'ui button green right floated large new-diagnosis'
+    .sub.header
+      = t('.subtitle', name: current_user.full_name)
+- else
+  %h1.ui.header= t('.create_new_diagnosis')
+  = render partial: 'companies/search_form', locals: { query: @query }
+
 
 = render 'diagnoses', diagnoses: @diagnoses.in_progress, title: t('.diagnoses_in_progress')
 


### PR DESCRIPTION
We’re still working on the wording.
The new UI can be enabled by adding FEATURE_DIAGNOSIS_WITHOUT_SIRET=true to .env.
In any case, `/analyses/new` is still available.

followup #773