### PR TITLE
Fixes and improvements in import_dump.rake

### DIFF
--- a/lib/tasks/import_dump.rake
+++ b/lib/tasks/import_dump.rake
@@ -47,6 +47,10 @@ namespace :import_dump do
     Subject
   ]
 
+  WHITELISTED_MODEL_ATTRIBUTES = {
+    'ExpertSubject' => ['role']
+  }
+
   ANONYMIZED_ATTRIBUTES = {
     'content' => -> { Faker::Lorem.paragraph },
     'description' => -> { Faker::Lorem.paragraph },
@@ -55,16 +59,14 @@ namespace :import_dump do
     'full_name' => -> { Faker::Name.name },
     'phone_number' => -> { Faker::PhoneNumber.phone_number },
     'expert_institution_name' => -> { Faker::Company.name },
-    'institution' => -> { Faker::Company.name },
     'name' => -> { Faker::Company.name + ' ' + Faker::Company.industry }, # institution and antenne names must be unique
     'role' => -> { Faker::Job.title },
     'label' => -> { Faker::Lorem.word },
     'current_sign_in_ip' => -> { Faker::Internet.ip_v4_address },
     'last_sign_in_ip' => -> { Faker::Internet.ip_v4_address },
     'email' => -> { Faker::Internet.email },
-    'unconfirmed_email' => -> { Faker::Internet.email },
     'query' => -> { Faker::Lorem.word },
-    'readable_locality' => -> { Faker::Address.city },
+    'readable_locality' => -> { Faker::Address.postcode + ' ' + Faker::Address.city },
     'siren' => -> { Faker::Company.french_siren_number },
     'siret' => -> { Faker::Company.french_siret_number }
   }
@@ -73,7 +75,8 @@ namespace :import_dump do
     ApplicationRecord.descendants.each do |klass|
       next if WHITELISTED_MODELS.include?(klass.to_s)
 
-      attributes = klass.attribute_names & ANONYMIZED_ATTRIBUTES.keys
+      whitelisted_model_attributes = WHITELISTED_MODEL_ATTRIBUTES[klass.to_s] || []
+      attributes = klass.attribute_names & ANONYMIZED_ATTRIBUTES.keys - whitelisted_model_attributes
       puts "#{klass} #{klass.all.count} #{attributes}"
       if attributes.present?
         klass.transaction do


### PR DESCRIPTION
* whitelist ExpertSubject.role, to avoid trying to put a fake string in an enum (an integer in DB)
  * (this makes `rake import_dump` crash right now)
* remove deleted attributes,
* fake readable_locality with a postal code, to reflect the behaviour in production