### PR TITLE
Move the steps routes to a distinct controller and fix flashes

### DIFF
--- a/app/assets/stylesheets/application/diagnoses.sass
+++ b/app/assets/stylesheets/application/diagnoses.sass
@@ -1,4 +1,4 @@
-#step2-app
+#besoins-app
   .subject.checkbox
     display: block
   .subject
@@ -11,7 +11,7 @@
     input[type=checkbox]:checked ~ textarea
       display: block
 
-#step4-app
+#selection-app
   td.checkbox-width
     width: 10px
   td.expert-width

--- a/app/controllers/diagnoses/steps_controller.rb
+++ b/app/controllers/diagnoses/steps_controller.rb
@@ -1,0 +1,78 @@
+class Diagnoses::StepsController < ApplicationController
+  before_action :retrieve_diagnosis
+
+  def besoins
+    if request.post?
+      authorize @diagnosis, :update?
+
+      diagnosis_params = params.require(:diagnosis).permit(:content,
+                                                           needs_attributes: [:_destroy, :content, :subject_id, :id])
+      diagnosis_params[:step] = 3
+      if @diagnosis.update(diagnosis_params)
+        redirect_to action: :visite, id: @diagnosis and return
+      end
+      flash.alert = @diagnosis.errors.full_messages.to_sentence
+    end
+
+    respond_to do |format|
+      format.js { render 'flashes' }
+      format.html do
+        @themes = Theme.ordered_for_interview
+      end
+    end
+  end
+
+  def visite
+    if request.post?
+      authorize @diagnosis, :update?
+
+      diagnosis_params = params_for_visite
+      diagnosis_params[:visitee_attributes][:company_id] = @diagnosis.facility.company.id
+      diagnosis_params[:step] = 4
+      if @diagnosis.update(diagnosis_params)
+        redirect_to action: :selection, id: @diagnosis and return
+      end
+      flash.alert = @diagnosis.errors.full_messages.to_sentence
+    end
+
+    respond_to do |format|
+      format.js { render 'flashes' }
+      format.html
+    end
+  end
+
+  def selection
+    if request.post?
+      authorize @diagnosis, :update?
+      if @diagnosis.match_and_notify!(params_for_matches)
+        flash.notice = I18n.t('diagnoses.steps.selection.notifications_sent')
+        redirect_to need_path(@diagnosis) and return
+      end
+      flash.alert = @diagnosis.errors.full_messages.to_sentence
+    end
+
+    respond_to do |format|
+      format.js { render 'flashes' }
+      format.html
+    end
+  end
+
+  private
+
+  def retrieve_diagnosis
+    safe_params = params.permit(:id)
+    @diagnosis = Diagnosis.find(safe_params[:id])
+  end
+
+  def params_for_visite
+    permitted = params.require(:diagnosis).permit(:happened_on, visitee_attributes: [:full_name, :role, :email, :phone_number, :id])
+    permitted
+  end
+
+  def params_for_matches
+    matches = params.permit(matches: {}).require(:matches)
+    matches.transform_values do |expert_subjects_selection|
+      expert_subjects_selection.select{ |_,v| v == '1' }.keys
+    end
+  end
+end

--- a/app/controllers/diagnoses_controller.rb
+++ b/app/controllers/diagnoses_controller.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 class DiagnosesController < ApplicationController
-  before_action :retrieve_diagnosis, only: %i[show archive unarchive step2 besoins step3 visite step4 selection]
+  before_action :retrieve_diagnosis, only: %i[show archive unarchive]
 
   include FlashToReviewSubjects
 
@@ -54,74 +54,20 @@ class DiagnosesController < ApplicationController
     if @diagnosis.completed?
       redirect_to need_path(@diagnosis)
     else
-      redirect_to action: "step#{@diagnosis.step}", id: @diagnosis
+      redirect_to controller: 'diagnoses/steps', action: Diagnosis::STEPS[@diagnosis.step], id: @diagnosis
     end
   end
 
   def archive
+    authorize @diagnosis, :update?
     @diagnosis.archive!
     redirect_to diagnoses_path
   end
 
   def unarchive
+    authorize @diagnosis, :update?
     @diagnosis.unarchive!
     redirect_to diagnoses_path
-  end
-
-  def step2
-    @themes = Theme.ordered_for_interview
-  end
-
-  def besoins
-    diagnosis_params = params.require(:diagnosis).permit(:content,
-                                                         needs_attributes: [:_destroy, :content, :subject_id, :id])
-    diagnosis_params[:step] = 3
-    authorize @diagnosis, :update?
-    if @diagnosis.update(diagnosis_params)
-      redirect_to action: :step3, id: @diagnosis
-    else
-      flash.alert = @diagnosis.errors.full_messages.to_sentence
-      respond_to do |format|
-        format.js { render 'application/flashes' }
-        format.html do
-          @themes = Theme.all.includes(:subjects)
-          render action: :step2
-        end
-      end
-    end
-  end
-
-  def step3; end
-
-  def visite
-    diagnosis_params = params_for_visite
-    diagnosis_params[:visitee_attributes][:company_id] = @diagnosis.facility.company.id
-    diagnosis_params[:step] = 4
-    authorize @diagnosis, :update?
-    if @diagnosis.update(diagnosis_params)
-      redirect_to action: :step4, id: @diagnosis
-    else
-      flash.alert = @diagnosis.errors.full_messages.to_sentence
-      respond_to do |format|
-        format.js { render 'application/flashes' }
-        format.html { render action: :step3 }
-      end
-    end
-  end
-
-  def step4; end
-
-  def selection
-    if @diagnosis.match_and_notify!(params_for_matches)
-      flash.notice = I18n.t('diagnoses.step5.notifications_sent')
-      redirect_to need_path(@diagnosis)
-    else
-      flash.alert = @diagnosis.errors.full_messages.to_sentence
-      respond_to do |format|
-        format.js { render 'application/flashes' }
-        format.html { render action: :step4, status: :bad_request }
-      end
-    end
   end
 
   def find_cities
@@ -138,18 +84,6 @@ class DiagnosesController < ApplicationController
       .includes(:matches,
                 :visitee, facility: :company,
         needs: :matches)
-  end
-
-  def params_for_visite
-    permitted = params.require(:diagnosis).permit(:happened_on, visitee_attributes: [:full_name, :role, :email, :phone_number, :id])
-    permitted
-  end
-
-  def params_for_matches
-    matches = params.permit(matches: {}).require(:matches)
-    matches.transform_values do |expert_subjects_selection|
-      expert_subjects_selection.select{ |_,v| v == '1' }.keys
-    end
   end
 
   def retrieve_diagnosis

--- a/app/models/diagnosis.rb
+++ b/app/models/diagnosis.rb
@@ -37,6 +37,7 @@ class Diagnosis < ApplicationRecord
   #
   LAST_STEP = 5
   AUTHORIZED_STEPS = (1..LAST_STEP).to_a.freeze
+  STEPS = { 2 => :besoins, 3 => :visite, 4 => :selection }
 
   ## Associations
   #

--- a/app/views/application/_flashes.html.haml
+++ b/app/views/application/_flashes.html.haml
@@ -1,13 +1,16 @@
-- if alert || notice
-  %p#flashes
-    - if alert
-      .ui.icon.error.message
-        .icon.inbox
+#flashes
+  - if alert
+    .ui.icon.error.message
+      %i.icon.exclamation.triangle
+      .content
+        .header
         %p= alert
+    .ui.hidden.divider
 
-    - if notice
-      .ui.icon.success.message
-        %i.success.icon
-        .content
-          .header
-          %p= notice
+  - if notice
+    .ui.icon.success.message
+      %i.success.icon
+      .content
+        .header
+        %p= notice
+    .ui.hidden.divider

--- a/app/views/diagnoses/steps/_expert_subject_checkboxes.html.haml
+++ b/app/views/diagnoses/steps/_expert_subject_checkboxes.html.haml
@@ -14,11 +14,11 @@
       %td
         = expert_subject_form.label checkbox_id, class: 'clickable' do
           .tiny.text.bold
-            = t('diagnoses.step4.expert_scope_of_work')
+            = t('diagnoses.steps.selection.expert_scope_of_work')
           .small.text
             = expert_subject.institution_subject.description
           - if expert_subject.description.present?
             .tiny.text.bold
-              = t('diagnoses.step4.more_informations')
+              = t('diagnoses.steps.selection.more_informations')
             .small.text
               = expert_subject.description

--- a/app/views/diagnoses/steps/_header.haml
+++ b/app/views/diagnoses/steps/_header.haml
@@ -1,6 +1,6 @@
 .ui.grid.stackable
   .row.center.aligned
     .column
-      = render 'company_details', diagnosis: diagnosis
+      = render 'diagnoses/company_details', diagnosis: diagnosis
   .row
     = render 'steps', current_page_step: current_page_step, diagnosis_step: diagnosis.step

--- a/app/views/diagnoses/steps/_steps.haml
+++ b/app/views/diagnoses/steps/_steps.haml
@@ -4,4 +4,4 @@
     .step{ class: class_for_step }
       .content
         .title
-          = t("diagnoses.step#{displayed_step}.title")
+          = t("diagnoses.steps.#{Diagnosis::STEPS[displayed_step]}.title")

--- a/app/views/diagnoses/steps/besoins.html.haml
+++ b/app/views/diagnoses/steps/besoins.html.haml
@@ -2,7 +2,7 @@
 
 = render 'header', diagnosis: @diagnosis, current_page_step: 2
 
-#step2-app
+#besoins-app
   = form_with model: @diagnosis,
     url: besoins_diagnosis_path(@diagnosis),
     method: :post,

--- a/app/views/diagnoses/steps/selection.haml
+++ b/app/views/diagnoses/steps/selection.haml
@@ -2,14 +2,14 @@
 
 = render 'header', diagnosis: @diagnosis, current_page_step: 4
 
-#step4-app
+#selection-app
   - if @diagnosis.needs.empty?
     %p= t('.no_needs')
   - else
     %p= t('.explanation')
 
     = form_with scope: :matches, url: selection_diagnosis_path(@diagnosis),
-               id: 'step4-form' do |f|
+               id: 'selection-form' do |f|
       - @diagnosis.needs.ordered_for_interview.each do |need|
         %table.ui.compact.small.table.celled
           %thead
@@ -54,7 +54,7 @@
 
 :javascript
   (function() {
-    var checkboxes = $("#step4-form input:checkbox");
+    var checkboxes = $("#selection-form input:checkbox");
     function setBoxesValidity() {
       if (checkboxes.is(":checked")) {
         checkboxes.each(function() {

--- a/app/views/diagnoses/steps/visite.html.haml
+++ b/app/views/diagnoses/steps/visite.html.haml
@@ -2,7 +2,7 @@
 
 = render 'header', diagnosis: @diagnosis, current_page_step: 3
 
-#step3-app
+#visite-app
   = form_with model: @diagnosis,
     url: visite_diagnosis_path(@diagnosis),
     method: :post,

--- a/app/views/shared/flashes.js.haml
+++ b/app/views/shared/flashes.js.haml
@@ -1,4 +1,4 @@
-var flashes = "#{j render('layouts/flashes')}";
+var flashes = "#{j render('flashes')}";
 document.getElementById('flashes').innerHTML = flashes;
 
 :ruby

--- a/config/i18n-tasks.yml
+++ b/config/i18n-tasks.yml
@@ -92,7 +92,7 @@ ignore_unused:
   - 'active_admin.scopes.*'
   - 'active_admin.move'
   - 'attributes.*'
-  - 'diagnoses.steps.*'
+  - 'diagnoses.steps.*.title'
   - 'mailers.admin_mailer.weekly_statistics.needs_abandoned.scopes.*'
   - 'mailers.user_mailer.update_match_notify.expert_and_status.*'
   - 'stats.stats_table.*'

--- a/config/locales/views.fr.yml
+++ b/config/locales/views.fr.yml
@@ -117,47 +117,43 @@ fr:
       search_manually: Entrer les informations manuellement
       sub_title: Si l’entreprise n’existe pas encore, ou qu’elle est introuvable, vous pouvez simplement saisir son nom et son implantation.
       title: Saisie manuelle
-    step2:
-      diagnosis_content_placeholder: 'Entrez des informations complémentaires concernant cette entreprise :'
-      diagnosis_content_subtitle: Informations générales sur cette entreprise
-      identify_needs: |
-        Quels besoins avez-vous détectés durant votre rencontre avec %{company_name} ?
-        N’hésitez pas à ajouter les détails à destination des référents sur ces domaines.
-      need_content_placeholder: Plus d’infos sur ce besoin
-      select_at_least_one_need: Cochez au minimum un besoin identifié.
-      title: Détection des besoins
-    step3:
-      date: Date de votre visite
-      date_placeholder: jj/mm/aaaa
-      email_address: E-mail
-      form_info: Tous les champs sont obligatoires.
-      full_name: Nom
-      full_name_placeholder: 'ex: Marie Dupont'
-      phone_number: Numéro de télephone
-      role: Fonction au sein de l’entreprise
-      role_placeholder: Directeur, Gérant…
-      title: Détails de la visite
-      your_contact_in_the_company: 'Votre contact chez %{company_name} :'
-    step4:
-      before_sending_emails_text_html: |
-        <p>En cliquant sur le bouton ci-dessous, les référents sélectionnés ci-dessus seront contactés par e-mail (vous serez en copie).</p>
-        <p>Ils auront accès aux coordonnées de l’entreprise et à l’analyse que vous avez réalisée, y compris vos commentaires.</p>
-        <p>Ils pourront recontacter directement l’entreprise pour répondre à ses besoins ou revenir vers vous pour un complément d’information.</p>
-      expert_scope_of_work: 'Compétence du référent :'
-      explanation: Ces aides répondent aux besoins identifiés. Vous pouvez sélectionner les référents que vous souhaitez contacter par e-mail.
-      more_informations: Informations complémentaires
-      no_expert_subject: Aucune aide ne répond à ce besoin sur ce territoire pour l’instant.
-      no_needs: Pas de besoins sélectionnés.
-      notify_matches: Notifier les référents sélectionnés
-      select_at_least_one_expert: Cochez au minimum un référent à contacter.
-      title: Mise en contact
-      you_can_contact_support: Vous pouvez néanmoins contacter les équipes support et relais locaux.
-    step5:
-      notifications_sent: Les notifications ont bien été envoyées.
     steps:
-      step2_title_html: Détection des besoins
-      step3_title_html: Informations complémentaires
-      step4_title_html: Mise en contact
+      besoins:
+        diagnosis_content_placeholder: 'Entrez des informations complémentaires concernant cette entreprise :'
+        diagnosis_content_subtitle: Informations générales sur cette entreprise
+        identify_needs: |
+          Quels besoins avez-vous détectés durant votre rencontre avec %{company_name} ?
+          N’hésitez pas à ajouter les détails à destination des référents sur ces domaines.
+        need_content_placeholder: Plus d’infos sur ce besoin
+        select_at_least_one_need: Cochez au minimum un besoin identifié.
+        title: Détection des besoins
+      selection:
+        before_sending_emails_text_html: |
+          <p>En cliquant sur le bouton ci-dessous, les référents sélectionnés ci-dessus seront contactés par e-mail (vous serez en copie).</p>
+          <p>Ils auront accès aux coordonnées de l’entreprise et à l’analyse que vous avez réalisée, y compris vos commentaires.</p>
+          <p>Ils pourront recontacter directement l’entreprise pour répondre à ses besoins ou revenir vers vous pour un complément d’information.</p>
+        expert_scope_of_work: 'Compétence du référent :'
+        explanation: Ces aides répondent aux besoins identifiés. Vous pouvez sélectionner les référents que vous souhaitez contacter par e-mail.
+        more_informations: Informations complémentaires
+        no_expert_subject: Aucune aide ne répond à ce besoin sur ce territoire pour l’instant.
+        no_needs: Pas de besoins sélectionnés.
+        notifications_sent: Les notifications ont bien été envoyées.
+        notify_matches: Notifier les référents sélectionnés
+        select_at_least_one_expert: Cochez au minimum un référent à contacter.
+        title: Mise en contact
+        you_can_contact_support: Vous pouvez néanmoins contacter les équipes support et relais locaux.
+      visite:
+        date: Date de votre visite
+        date_placeholder: jj/mm/aaaa
+        email_address: E-mail
+        form_info: Tous les champs sont obligatoires.
+        full_name: Nom
+        full_name_placeholder: 'ex: Marie Dupont'
+        phone_number: Numéro de télephone
+        role: Fonction au sein de l’entreprise
+        role_placeholder: Directeur, Gérant…
+        title: Détails de la visite
+        your_contact_in_the_company: 'Votre contact chez %{company_name} :'
   experts:
     edit:
       description: Cochez les domaines d’intervention correspondant à votre activité. Vous pouvez apporter les précisions que vous jugez utiles pour les autres conseillers.

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -59,12 +59,14 @@ Rails.application.routes.draw do
       post :archive
       post :unarchive
 
-      get :besoins, action: :step2
-      post :besoins
-      get :visite, action: :step3
-      post :visite
-      get :selection, action: :step4
-      post :selection
+      controller 'diagnoses/steps' do
+        get :besoins
+        post :besoins
+        get :visite
+        post :visite
+        get :selection
+        post :selection
+      end
     end
   end
 

--- a/spec/controllers/companies_controller_spec.rb
+++ b/spec/controllers/companies_controller_spec.rb
@@ -30,7 +30,7 @@ RSpec.describe CompaniesController, type: :controller do
 
   describe 'POST #create_diagnosis_from_siret' do
     context 'save worked' do
-      it 'redirects to the created diagnosis step2 page' do
+      it 'redirects to the created diagnosis besoins page' do
         siret = '12345678901234'
         facility = create :facility, siret: siret
         allow(UseCases::SearchFacility).to receive(:with_siret_and_save).with(siret) { facility }

--- a/spec/controllers/diagnoses/steps_controller_spec.rb
+++ b/spec/controllers/diagnoses/steps_controller_spec.rb
@@ -1,0 +1,54 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+RSpec.describe Diagnoses::StepsController, type: :controller do
+  login_user
+
+  let(:diagnosis) { create :diagnosis, advisor: advisor }
+  let(:advisor) { current_user }
+
+  describe 'GET #besoins' do
+    subject(:request) { get :besoins, params: { id: diagnosis.id } }
+
+    context 'diagnosis' do
+      it('returns http success') { expect(response).to be_successful }
+    end
+  end
+
+  describe 'GET #visite' do
+    subject(:request) { get :visite, params: { id: diagnosis.id } }
+
+    context 'diagnosis step < last' do
+      it('returns http success') { expect(response).to be_successful }
+    end
+  end
+
+  describe 'GET #selection' do
+    subject(:request) { get :selection, params: { id: diagnosis.id } }
+
+    context 'diagnosis' do
+      it('returns http success') { expect(response).to be_successful }
+    end
+  end
+
+  describe 'POST #selection' do
+    let(:expert_subject) { create(:expert_subject) }
+    let!(:need) { create(:need, diagnosis: diagnosis) }
+
+    before do
+      post :selection, params: { id: diagnosis.id, matches: { need.id => { expert_subject.id => '1' } } }
+    end
+
+    context 'match_and_notify! succeeds' do
+      let(:result) { true }
+
+      it('redirects to the besoins page') { expect(response).to redirect_to need_path(diagnosis) }
+    end
+
+    context 'match_and_notify! fails' do
+      let(:result) { false }
+
+      it('fails') { expect(response).not_to be_successful }
+    end
+  end
+end

--- a/spec/controllers/diagnoses_controller_spec.rb
+++ b/spec/controllers/diagnoses_controller_spec.rb
@@ -44,51 +44,6 @@ RSpec.describe DiagnosesController, type: :controller do
     end
   end
 
-  describe 'GET #step2' do
-    subject(:request) { get :step2, params: { id: diagnosis.id } }
-
-    context 'diagnosis' do
-      it('returns http success') { expect(response).to be_successful }
-    end
-  end
-
-  describe 'GET #step3' do
-    subject(:request) { get :step3, params: { id: diagnosis.id } }
-
-    context 'diagnosis step < last' do
-      it('returns http success') { expect(response).to be_successful }
-    end
-  end
-
-  describe 'GET #step4' do
-    subject(:request) { get :step4, params: { id: diagnosis.id } }
-
-    context 'diagnosis' do
-      it('returns http success') { expect(response).to be_successful }
-    end
-  end
-
-  describe 'POST #selection' do
-    let(:expert_subject) { create(:expert_subject) }
-    let!(:need) { create(:need, diagnosis: diagnosis) }
-
-    before do
-      post :selection, params: { id: diagnosis.id, matches: { need.id => { expert_subject.id => '1' } } }
-    end
-
-    context 'match_and_notify! succeeds' do
-      let(:result) { true }
-
-      it('redirects to the besoins page') { expect(response).to redirect_to need_path(diagnosis) }
-    end
-
-    context 'match_and_notify! fails' do
-      let(:result) { false }
-
-      it('fails') { expect(response).not_to be_successful }
-    end
-  end
-
   describe 'archival' do
     describe 'POST #archive' do
       before { post :archive, params: { id: diagnosis.id } }

--- a/spec/views/diagnoses/steps/step4.html.haml_spec.rb
+++ b/spec/views/diagnoses/steps/step4.html.haml_spec.rb
@@ -1,7 +1,7 @@
 require "spec_helper"
 require 'rails_helper'
 
-describe "diagnoses/step4.html.haml", type: :view do
+describe "diagnoses/steps/selection.html.haml", type: :view do
   let(:need) { create :need }
   let(:diagnosis) { create :diagnosis, needs: [need] }
   let(:institution_subject) { create :institution_subject, subject: need.subject }


### PR DESCRIPTION
* move to diagnoses/steps
* rename the GET “stepX” routes to the same routes as the POST routes
* move the partial and rename the i18n keys

This should make things easier for #791 and subsequent redesign of the diagnosis steps.

Additional related changes:

* Define named constants for the 2, 3, 4 diagnosis steps. This is not yet a proper enum, but we’re getting there.
* Fix flash messages not being displayed after remote forms; we still need to use flashes.js.haml, but at least it’s working.