### PR TITLE
Add a new /mes_competences url

### DIFF
--- a/app/controllers/experts_controller.rb
+++ b/app/controllers/experts_controller.rb
@@ -2,7 +2,15 @@
 
 class ExpertsController < ApplicationController
   before_action :authenticate_user!
-  before_action :find_expert
+  before_action :find_expert, except: %i[mes_competences]
+
+  def mes_competences
+    if current_user.experts.present?
+      redirect_to edit_expert_path(current_user.experts.first)
+    else
+      redirect_to profile_path
+    end
+  end
 
   def edit
     @is_by_theme = @expert.institution.institutions_subjects

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -92,6 +92,7 @@ Rails.application.routes.draw do
   resources :matches, only: %i[update]
   resources :feedbacks, only: %i[create destroy]
   resources :experts, only: %i[edit update]
+  get 'mes_competences' => 'experts#mes_competences'
 
   resources :reminders, only: %i[index show], path: 'relances' do
     member do


### PR DESCRIPTION
It only redirects to the first expert, if any. This is temporary for an experiment while we redesign the profile page. (refs #766)