### PR TITLE
De-duplicate status notification emails

### DIFF
--- a/app/controllers/matches_controller.rb
+++ b/app/controllers/matches_controller.rb
@@ -6,7 +6,7 @@ class MatchesController < ApplicationController
     authorize @match
     previous_status = @match.status
     @match.update status: params[:status]
-    UserMailer.update_match_notify(@match, current_user, previous_status).deliver_later
+    UserMailer.deduplicated_send_match_notify(@match, current_user, previous_status)
     if @match.status_taking_care?
       if @match.advisor.support_expert_subject.nil?
         CompanyMailer.taking_care_by_expert(@match).deliver_later

--- a/config/initializers/core_extensions.rb
+++ b/config/initializers/core_extensions.rb
@@ -1,5 +1,7 @@
 require 'core_extensions/active_record/created_within'
+require 'core_extensions/delayed/job/remove_jobs'
 require 'core_extensions/relation/human_count'
 
 ActiveRecord::Base.include CoreExtensions::ActiveRecord::CreatedWithin
+Delayed::Job.include CoreExtensions::Delayed::Job::RemoveJobs
 ActiveRecord::Relation.include CoreExtensions::Relation::HumanCount

--- a/lib/core_extensions/delayed/job/remove_jobs.rb
+++ b/lib/core_extensions/delayed/job/remove_jobs.rb
@@ -1,0 +1,39 @@
+module CoreExtensions
+  module Delayed
+    module Job
+      module RemoveJobs
+        extend ActiveSupport::Concern
+        class_methods do
+          # Remove existing delayed jobs in the given queue, matching the
+          def remove_jobs(queue = nil, &block)
+            # Lock all jobs in the queue
+            lock_name = "remove-jobs-#{SecureRandom.base64(16)}"
+            self
+              .for_queues(queue)
+              .where(locked_at: nil)
+              .update_all(locked_at: Time.now, locked_by: lock_name)
+
+            # Find which jobs to strike
+            locked_jobs = self.where(locked_by: lock_name)
+            if block.present?
+              removed_jobs = locked_jobs.filter { |job| yield(job) }
+            else
+              removed_jobs = locked_jobs
+            end
+            # implementation caveat:
+            # * locked_jobs is an ActiveRecord::Relation, queried each time.
+            # * removed_jobs on the other hand is an actual Array
+
+            # Actually delete it
+            removed_jobs.each(&:destroy)
+
+            # Unlock remaining locked jobs
+            locked_jobs.update_all(locked_at: nil, locked_by: nil)
+
+            removed_jobs
+          end
+        end
+      end
+    end
+  end
+end

--- a/spec/lib/core_extensions/delayed/job/remove_jobs_spec.rb
+++ b/spec/lib/core_extensions/delayed/job/remove_jobs_spec.rb
@@ -1,0 +1,61 @@
+require 'rails_helper'
+require 'core_extensions/delayed/job/remove_jobs'
+
+describe CoreExtensions::Delayed::Job::RemoveJobs, type: :lib do
+  describe 'remove_jobs' do
+    before do
+      stub_const('SomeClass', Class.new do
+        def self.a_method; end
+
+        def self.another_method; end
+      end)
+    end
+
+    subject(:remove_jobs) { Delayed::Job.remove_jobs(queue, &block) }
+
+    let(:queue) { 'queue' }
+    let(:block) { -> (job) { job.payload_object.method_name == :a_method } }
+
+    context 'one job' do
+      before { SomeClass.delay(queue: 'queue').a_method }
+
+      context 'one job, matching' do
+        it { expect{ remove_jobs }.to change(Delayed::Job, :count).by(-1) }
+      end
+
+      context 'no queue or block specified' do
+        let(:queue) { nil }
+        let(:block) { nil }
+
+        it { expect{ remove_jobs }.to change(Delayed::Job, :count).by(-1) }
+      end
+
+      context 'one job, other queue' do
+        let(:queue) { 'another_queue' }
+
+        it { expect{ remove_jobs }.not_to change(Delayed::Job, :count) }
+      end
+
+      context 'one job, not matching block' do
+        let(:block) { -> (job) { job.payload_object.method_name == 'another_method' } }
+
+        it { expect{ remove_jobs }.not_to change(Delayed::Job, :count) }
+      end
+    end
+
+    context 'several jobs' do
+      let(:job) { SomeClass.delay(queue: 'queue').a_method }
+
+      before do
+        SomeClass.delay(queue: 'queue').a_method
+        SomeClass.delay(queue: 'queue').a_method
+
+        SomeClass.delay(queue: 'queue').another_method
+        SomeClass.delay(queue: 'another_queue').a_method
+        SomeClass.delay(queue: 'another_queue').another_method
+      end
+
+      it { expect{ remove_jobs }.to change(Delayed::Job, :count).by(-2) }
+    end
+  end
+end

--- a/spec/mailers/user_mailer_spec.rb
+++ b/spec/mailers/user_mailer_spec.rb
@@ -15,4 +15,39 @@ describe UserMailer do
 
     it { expect(mail.header[:from].value).to eq ExpertMailer::SENDER }
   end
+
+  describe '#deduplicated_send_match_notify' do
+    def notify_change(new_status)
+      previous_status = a_match.status
+      a_match.status = new_status
+      described_class.deduplicated_send_match_notify(a_match, user, previous_status)
+    end
+
+    let(:a_match) { create :match, status: :quo }
+    let(:user) { create :user }
+
+    context 'subsequent changes on the same match' do
+      before do
+        notify_change(:taking_care)
+        notify_change(:done)
+      end
+
+      it do
+        expect(Delayed::Job.count).to eq 1
+        previous_status = Delayed::Job.last.payload_object.args.last.to_sym
+        expect(previous_status).to eq :quo
+      end
+    end
+
+    context 'change back to the initial value' do
+      before do
+        notify_change(:not_for_me)
+        notify_change(:quo)
+      end
+
+      it do
+        expect(Delayed::Job.count).to eq 0
+      end
+    end
+  end
 end


### PR DESCRIPTION
Wait one minute before sending `update_match_notify`, and cancel previous email jobs if a new action is taken within the minute.

refs #799