### PR TITLE
Fix flags display in /admin/users

### DIFF
--- a/app/admin/user.rb
+++ b/app/admin/user.rb
@@ -59,7 +59,7 @@ ActiveAdmin.register User do
     end
 
     column(:flags) do |u|
-      u.flags.filter{ |_, v| !!v }.map{ |k, _| User.human_attribute_name(k) }.to_sentence
+      u.flags.filter{ |_, v| v.to_b }.map{ |k, _| User.human_attribute_name(k) }.to_sentence
     end
 
     actions dropdown: true do |u|
@@ -78,7 +78,7 @@ ActiveAdmin.register User do
         [true, false].each do |value|
           localized_flag = User.human_attribute_name(flag)
           title = I18n.t("active_admin.user.flag.change.#{value}", flag: localized_flag)
-          if !!u.send(flag) != value # Only add a menu item to change to the other value.
+          if u.send(flag).to_b != value # Only add a menu item to change to the other value.
             item title, polymorphic_path(["#{flag}_#{value}", :admin, u])
           end
         end


### PR DESCRIPTION
Prevent each User flag to be wrongly interpreted as true in /admin/users. The checkbox form sets the flags values to `0` and `1` but `!!0` is actually true. Let’s use .to_b (from wannabebool instead: 0.to_b is false, 1.to_b is true, and nil.to_b is false.