### PR TITLE
Ajout des scopes “équipes” pour /admin/users et /admin/experts

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -800,6 +800,9 @@ RSpec/LetSetup:
 RSpec/MultipleExpectations:
   Enabled: false
 
+RSpec/MessageSpies:
+  Enabled: false
+
 RSpec/NestedGroups:
   Enabled: false
 

--- a/app/admin/expert.rb
+++ b/app/admin/expert.rb
@@ -10,7 +10,12 @@ ActiveAdmin.register Expert do
 
   scope :all, default: true
   scope :support_experts
-  scope :with_custom_communes, group: :special
+  scope :with_custom_communes, group: :referencing
+  scope :without_subjects, group: :referencing
+
+  scope :teams, group: :members
+  scope :personal_skillsets, group: :members
+  scope :without_users, group: :members
 
   index do
     selectable_column

--- a/app/admin/user.rb
+++ b/app/admin/user.rb
@@ -19,7 +19,7 @@ ActiveAdmin.register User do
 
   # Index
   #
-  includes :antenne, :institution, :experts, :searches, :feedbacks,
+  includes :antenne, :institution, :searches, :feedbacks,
            :sent_diagnoses, :sent_needs, :sent_matches,
            :invitees
   config.sort_order = 'created_at_desc'
@@ -28,7 +28,10 @@ ActiveAdmin.register User do
   scope :admin
   scope :deactivated
 
-  scope :without_team, group: :without_team
+  scope :without_experts, group: :teams
+  scope :single_personal_skillset, group: :teams
+  scope :single_team, group: :teams
+  scope :multiple_experts, group: :teams
 
   scope :never_used, group: :invitations
   scope :invitation_not_accepted, group: :invitations

--- a/app/mailers/expert_mailer.rb
+++ b/app/mailers/expert_mailer.rb
@@ -12,6 +12,13 @@ class ExpertMailer < ApplicationMailer
       to: @expert.email_with_display_name,
       subject: t('mailers.expert_mailer.notify_company_needs.subject', company_name: @diagnosis.company.name)
     )
+
+    # Also send a reset link to the expert’s users that have never used their account.
+    # In practice, this only happens to Experts that used to have no corresponding User and
+    # for which we created User accounts automatically.
+    expert.users.filter(&:never_used_account?).each do |user|
+      user.send_reset_password_instructions
+    end
   end
 
   def remind_involvement(expert)

--- a/app/models/diagnosis.rb
+++ b/app/models/diagnosis.rb
@@ -123,10 +123,6 @@ class Diagnosis < ApplicationRecord
   def notify_experts!
     experts.each do |expert|
       ExpertMailer.notify_company_needs(expert, self).deliver_later
-      # also send a reset link if the expert is solo and has never used his user account
-      if expert.solo? && expert.users.first.never_used_account?
-        expert.users.first.send_reset_password_instructions
-      end
     end
     UserMailer.confirm_notifications_sent(self).deliver_later
   end

--- a/app/models/expert.rb
+++ b/app/models/expert.rb
@@ -115,10 +115,6 @@ class Expert < ApplicationRecord
 
   ## Description
   #
-  def solo?
-    self.users.size == 1 && self.users.first.experts == [self]
-  end
-
   def custom_communes?
     communes.any?
   end

--- a/app/models/expert.rb
+++ b/app/models/expert.rb
@@ -49,7 +49,6 @@ class Expert < ApplicationRecord
   ## Validations
   #
   validates :antenne, :email, :phone_number, presence: true
-  validates :users, presence: true
 
   ## “Through” Associations
   #
@@ -79,6 +78,35 @@ class Expert < ApplicationRecord
       .where({ subjects: { is_support: true } })
   end
 
+  # Team stuff
+  scope :personal_skillsets, -> do
+    # Experts with only one member only represent this user’s skills.
+    single_member = Expert.unscoped.joins(:users)
+      .merge(User.unscoped.not_deleted)
+      .group(:id)
+      .having("COUNT(users.id)=1")
+
+    joins(:users)
+      .where(id: single_member)
+      .where("users.email = experts.email")
+  end
+
+  scope :without_users, -> do
+    # Experts without members can’t connect to the app.
+    # This is not a normal state, but can happen during referencing
+    # before users are actually registered, or when a user is removed.
+    left_outer_joins(:users)
+      .merge(User.unscoped.not_deleted)
+      .where(users: { id: nil })
+  end
+
+  scope :teams, -> do
+    # Experts (with members) that are not personal_skillsets are proper teams
+    where.not(id: Expert.unscoped.without_users)
+      .where.not(id: Expert.unscoped.personal_skillsets)
+  end
+
+  # Activity stuff
   scope :with_active_matches, -> do
     joins(:received_matches)
       .merge(Match.active)
@@ -91,6 +119,7 @@ class Expert < ApplicationRecord
       .distinct
   end
 
+  # Referencing
   scope :ordered_by_institution, -> do
     joins(:antenne, :institution)
       .select('experts.*', 'antennes.name', 'institutions.name')
@@ -107,6 +136,11 @@ class Expert < ApplicationRecord
     where(is_global_zone: true)
   end
 
+  scope :without_subjects, -> do
+    left_outer_joins(:experts_subjects)
+      .where(experts_subjects: { id: nil })
+  end
+
   scope :omnisearch, -> (query) do
     joins(:antenne)
       .where('experts.full_name ILIKE ?', "%#{query}%")
@@ -115,16 +149,35 @@ class Expert < ApplicationRecord
 
   ## Description
   #
-  def custom_communes?
-    communes.any?
-  end
-
   def full_name_with_role
     "#{full_name} #{full_role}"
   end
 
   def full_role
     "#{role} - #{antenne.name}"
+  end
+
+  ## Team stuff
+  def personal_skillset?
+    users.not_deleted.size == 1 &&
+      users.not_deleted.first.email == self.email
+  end
+
+  def without_users?
+    users.not_deleted.empty?
+  end
+
+  def team?
+    !without_users? && !personal_skillset?
+  end
+
+  ## Referencing
+  def custom_communes?
+    communes.any?
+  end
+
+  def without_subjects?
+    experts_subjects.empty?
   end
 
   def should_review_subjects?

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -217,10 +217,6 @@ class User < ApplicationRecord
     deleted? ? I18n.t('deleted_user.full_name') : self[:full_name]
   end
 
-  def solo?
-    self.experts.size == 1 && self.experts.first.users == [self]
-  end
-
   def full_name_with_role
     "#{full_name} - #{full_role}"
   end

--- a/app/views/mailers/expert_mailer/_never_used_account_warning.html.haml
+++ b/app/views/mailers/expert_mailer/_never_used_account_warning.html.haml
@@ -1,0 +1,2 @@
+- if @expert.users.any?(&:never_used_account?)
+  %p.warning= t('.you_need_to_use_your_user_account')

--- a/app/views/mailers/expert_mailer/_never_used_solo_account_warning.html.haml
+++ b/app/views/mailers/expert_mailer/_never_used_solo_account_warning.html.haml
@@ -1,2 +1,0 @@
-- if @expert.solo? && @expert.users.first.never_used_account?
-  %p.warning= t('.you_need_to_use_your_user_account')

--- a/app/views/mailers/expert_mailer/notify_company_needs.html.haml
+++ b/app/views/mailers/expert_mailer/notify_company_needs.html.haml
@@ -23,6 +23,6 @@
 .button
   %a{ href: need_url(@diagnosis) }= t('.reply')
 
-= render 'mailers/expert_mailer/never_used_solo_account_warning'
+= render 'mailers/expert_mailer/never_used_account_warning'
 
 %p= t('mailers.see_you_on_place_des_entreprises_html', link_to_root: link_to(t('app_name'), root_url))

--- a/app/views/mailers/expert_mailer/remind_involvement.html.haml
+++ b/app/views/mailers/expert_mailer/remind_involvement.html.haml
@@ -15,6 +15,6 @@
   title: t('.needs_taking_care'),
   visited_at: true
 
-= render 'mailers/expert_mailer/never_used_solo_account_warning'
+= render 'mailers/expert_mailer/never_used_account_warning'
 
 %p= t('mailers.see_you_on_place_des_entreprises_html', link_to_root: link_to_root)

--- a/config/locales/devise.fr.yml
+++ b/config/locales/devise.fr.yml
@@ -36,7 +36,7 @@ fr:
         someone_invited_you_html: "%{inviter} (%{mail_to_inviter}) vous invite à rejoindre l’équipe de <b>%{antenne_name}</b>."
         subject: Invitation sur Place des Entreprises
       reset_password_instructions:
-        account_but_never_connected_html: "<p>Vous disposez d’un accès à Place des Entreprises mais vous n’êtes pas encore connecté. Cliquez sur le bouton ci-dessous pour définir votre mot de passe et activer votre compte.</p>"
+        account_but_never_connected_html: "<p>Vous disposez d’un accès à Place des Entreprises mais vous n’êtes pas encore connecté·e. Cliquez sur le bouton ci-dessous pour définir votre mot de passe et activer votre compte.</p>"
         change_my_password: Changer de mot de passe
         choose_my_password: Choisir mon mot de passe
         ignore: Si vous n’êtes pas à l’origine de cette demande, vous pouvez ignorer cet e-mail. Votre mot de passe ne sera pas modifié.

--- a/config/locales/models.fr.yml
+++ b/config/locales/models.fr.yml
@@ -27,21 +27,33 @@ fr:
       diagnosis_completed: Analyses terminées
       done: Clôturé
       invitation_not_accepted: Invitations pas encore acceptées
+      multiple_experts: Multi-référents
       never_used: Non connectable
       not_taken_after_3_weeks: 3 semaines sans réponse
+      personal_skillsets: Individuel
       rejected: Refusés
       sent: Mises en relation envoyées
+      single_personal_skillset: Solos
+      single_team: Équipiers
       support_experts: Support
+      teams: Équipes
       to_support: Support
       tooltips:
         abandoned_quo_not_taken: Non pris en charge depuis 3 semaines
         abandoned_taken_not_done: Pas de nouvelles depuis 3 semaines
         diagnosis_completed: Besoins identifiés dans des analyses terminées
+        multiple_experts: Membres de plusieurs équipes, ou avec des domaines de compétences séparés
         never_used: L’utilisateur devra choisir son mot de passe (recevoir une invitation ou une notification) pour se connecter
+        personal_skillsets: 'Domaine de compétences d’un seul utilisateur: référents avec un seul utilisateur dont l’adresse email est identique au référent.'
+        single_personal_skillset: Utilisateurs qui n’ont qu’un seul référent, qui correspond à leur domaine de compétence personnel.
+        single_team: Membres d’une équipe (et d’une seule)
+        teams: 'Équipes: plusieurs membres, ou un seul mais dont l’adresse email diffère de celle du référent'
       with_custom_communes: Zone spécifique
       with_deleted_expert: Référent supprimé
       without_communes: Sans zone d’intervention
-      without_team: Sans équipe/référent
+      without_experts: Sans référent
+      without_subjects: Sans compétence
+      without_users: Aucun membre
     solicitations:
       show_company_page: Page de la société
     subject:

--- a/config/locales/views.fr.yml
+++ b/config/locales/views.fr.yml
@@ -261,7 +261,7 @@ fr:
       taking_care_by_support:
         content_html: Votre demande sur Place des Entreprise - %{subject} - vient d’être prise en charge par %{expert_antenne}.
     expert_mailer:
-      never_used_solo_account_warning:
+      never_used_account_warning:
         you_need_to_use_your_user_account: Attention ! Place des entreprises nécessite désormais de se connecter à son compte utilisateur pour accéder au informations des entreprises. Vous allez recevoir un email expliquant comment activer votre compte et choisir votre mot de passe.
       notify_company_needs:
         advisor_met_company: "%{advisor_name_with_role} l’a rencontrée le %{visit_date}."

--- a/spec/models/diagnosis_spec.rb
+++ b/spec/models/diagnosis_spec.rb
@@ -128,45 +128,4 @@ RSpec.describe Diagnosis, type: :model do
       it { expect{ match_and_notify }.to raise_error ActiveRecord::RecordNotFound }
     end
   end
-
-  describe 'notify_experts!' do
-    subject(:notify_experts!) { diagnosis.notify_experts! }
-
-    let(:diagnosis) do
-      expert = build :expert, users: users
-      match = build :match, expert: expert
-      need = build :need, matches: [match]
-      create :diagnosis, needs: [need]
-    end
-
-    context 'solo expert, never used' do
-      let(:users) { [build(:user, invitation_sent_at: nil, encrypted_password: '')] }
-
-      it do
-        expect_any_instance_of(User).to receive(:send_reset_password_instructions).once
-
-        notify_experts!
-      end
-    end
-
-    context 'solo expert, used account' do
-      let(:users) { [build(:user, invitation_sent_at: DateTime.now, encrypted_password: 'password')] }
-
-      it do
-        expect_any_instance_of(User).not_to receive(:send_reset_password_instructions)
-
-        notify_experts!
-      end
-    end
-
-    context 'expert with several users' do
-      let(:users) { build_list :user, 2 }
-
-      it do
-        expect_any_instance_of(User).not_to receive(:send_reset_password_instructions)
-
-        notify_experts!
-      end
-    end
-  end
 end

--- a/spec/models/expert_spec.rb
+++ b/spec/models/expert_spec.rb
@@ -25,7 +25,74 @@ RSpec.describe Expert, type: :model do
     end
   end
 
-  describe 'scopes' do
+  describe 'team notions' do
+    describe 'personal_skillset scope' do
+      let(:user) { create :user, email: 'user@example' }
+      let(:user2) { create :user, email: 'otheruser@example' }
+
+      subject(:expert) { create :expert, email: 'user@example', users: expert_users }
+
+      context 'an expert with a single user with the same email is a personal_skillset' do
+        let(:expert_users) { [user] }
+
+        it do
+          is_expected.to be_personal_skillset
+          is_expected.not_to be_team
+          is_expected.not_to be_without_users
+          expect(described_class.personal_skillsets).to eq [expert]
+          expect(described_class.teams).to eq []
+          expect(described_class.without_users).to eq []
+        end
+      end
+
+      context 'an expert with a single user with a different email is a team' do
+        let(:expert_users) { [user2] }
+
+        it do
+          is_expected.not_to be_personal_skillset
+          is_expected.to be_team
+          is_expected.not_to be_without_users
+          expect(described_class.personal_skillsets).to eq []
+          expect(described_class.teams).to eq [expert]
+          expect(described_class.without_users).to eq []
+        end
+      end
+
+      context 'an expert with several users is a team' do
+        let(:expert_users) { [user, user2] }
+
+        it do
+          is_expected.not_to be_personal_skillset
+          is_expected.to be_team
+          is_expected.not_to be_without_users
+          expect(described_class.personal_skillsets).to eq []
+          expect(described_class.teams).to eq [expert]
+          expect(described_class.without_users).to eq []
+        end
+      end
+
+      context 'an expert with no user is neither a team nor a personal_skillset' do
+        let(:expert_users) { [] }
+
+        it do
+          is_expected.not_to be_personal_skillset
+          is_expected.not_to be_team
+          is_expected.to be_without_users
+          expect(described_class.personal_skillsets).to eq []
+          expect(described_class.teams).to eq []
+          expect(described_class.without_users).to eq [expert]
+        end
+      end
+    end
+  end
+
+  describe 'to_s' do
+    let(:expert) { build :expert, full_name: 'Ivan Collombet' }
+
+    it { expect(expert.to_s).to eq 'Ivan Collombet' }
+  end
+
+  describe 'referencing' do
     describe 'commune zone scopes' do
       let(:expert_with_custom_communes) { create :expert, antenne: antenne, communes: [commune1] }
       let(:expert_without_custom_communes) { create :expert, antenne: antenne }
@@ -45,35 +112,51 @@ RSpec.describe Expert, type: :model do
         it { is_expected.to match_array [expert_without_custom_communes] }
       end
     end
-  end
 
-  describe 'to_s' do
-    let(:expert) { build :expert, full_name: 'Ivan Collombet' }
+    describe 'without_subjects' do
+      subject(:expert) { create :expert, experts_subjects: expert_subjects }
 
-    it { expect(expert.to_s).to eq 'Ivan Collombet' }
-  end
+      context 'without subject' do
+        let(:expert_subjects) { [] }
 
-  describe 'should_review_subjects?' do
-    subject { expert.should_review_subjects? }
+        it {
+          is_expected.to be_without_subjects
+          expect(described_class.without_subjects).to include expert
+        }
+      end
 
-    let(:expert) { create :expert, subjects_reviewed_at: reviewed_at }
+      context 'with subject' do
+        let(:expert_subjects) { create_list :expert_subject, 2 }
 
-    context 'subjects never reviewed' do
-      let(:reviewed_at) { nil }
-
-      it{ is_expected.to be_truthy }
+        it {
+          is_expected.not_to be_without_subjects
+          expect(described_class.without_subjects).not_to include expert
+        }
+      end
     end
 
-    context 'subjects reviewed long ago' do
-      let(:reviewed_at) { 10.years.ago }
+    describe 'should_review_subjects?' do
+      subject { expert.should_review_subjects? }
 
-      it{ is_expected.to be_truthy }
-    end
+      let(:expert) { create :expert, subjects_reviewed_at: reviewed_at }
 
-    context 'subjects reviewed recently' do
-      let(:reviewed_at) { 2.days.ago }
+      context 'subjects never reviewed' do
+        let(:reviewed_at) { nil }
 
-      it{ is_expected.to be_falsey }
+        it{ is_expected.to be_truthy }
+      end
+
+      context 'subjects reviewed long ago' do
+        let(:reviewed_at) { 10.years.ago }
+
+        it{ is_expected.to be_truthy }
+      end
+
+      context 'subjects reviewed recently' do
+        let(:reviewed_at) { 2.days.ago }
+
+        it{ is_expected.to be_falsey }
+      end
     end
   end
 end

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -155,39 +155,6 @@ RSpec.describe User, type: :model do
     it { expect(user.full_name_with_role).to eq 'Ivan Collombet - Business Developer - DINUM' }
   end
 
-  describe '#solo?' do
-    subject { user.solo? }
-
-    let(:user) { create(:user) }
-    let(:user2) { create(:user) }
-    let(:expert1) { create(:expert) }
-    let(:expert2) { create(:expert) }
-
-    context ('with no expert') do
-      before { user.experts = [] }
-
-      it { is_expected.to be_falsey }
-    end
-
-    context ('with one expert') do
-      before { expert1.users = [user] }
-
-      it { is_expected.to be_truthy }
-    end
-
-    context ('with several experts') do
-      before { user.experts = [expert1, expert2] }
-
-      it { is_expected.to be_falsey }
-    end
-
-    context ('with one expert, several users') do
-      before { expert1.users = [user, user2] }
-
-      it { is_expected.to be_falsey }
-    end
-  end
-
   describe '#never_used_account?' do
     subject { user.never_used_account? }
 


### PR DESCRIPTION
This adds `without_users` and `personal_skillsets` scopes and methods to Expert. This will be central to adapt the UI for the different cases in #766.

Additionally, this
* adds a related “without_users” scope
* add team-related scopes in User as well
* adds ActiveAdmin scopes for all these
* removes the old `solo?` method in User and Expert
* refactor Diagnosis/ExpertMailer that was using `solo?`; this changes the behaviour when sending password instructions to users after notifying an expert: we used to only send the password email if the expert only had one user, but in reality we have situations where several users could need it.
