### PR TITLE
Link directly to the form in the landing pages from the homepage

### DIFF
--- a/app/assets/javascripts/pages.js
+++ b/app/assets/javascripts/pages.js
@@ -5,6 +5,5 @@
 // This is hopefully a workaround until we migrate the rest of the app to the datagouv template
 
 // = require rails-ujs
-// = require turbolinks
 
 // = require_tree ./pages

--- a/app/assets/stylesheets/pages.sass
+++ b/app/assets/stylesheets/pages.sass
@@ -80,7 +80,7 @@ span.navbar__domain
 
 //  landings index and show
 
-section.section#featured-landings
+section.section#section-thematiques
   background: linear-gradient(45deg, #0053b3, #006be6)
   background: linear-gradient(45deg,var(--theme-primary), var(--theme-primary-light))
   a:hover

--- a/app/assets/stylesheets/pages.sass
+++ b/app/assets/stylesheets/pages.sass
@@ -192,3 +192,12 @@ section.section#landing-topics
 @media screen and (-ms-high-contrast: active), (-ms-high-contrast: none)
   img[src*=".svg"]
     width: 100%
+
+// General settings
+
+html
+  scroll-behavior: smooth
+
+@media (prefers-reduced-motion: reduce)
+  html
+    scroll-behavior: auto

--- a/app/views/landings/_landing.haml
+++ b/app/views/landings/_landing.haml
@@ -1,5 +1,7 @@
 .card
-  - path = landing_path({ slug: landing.slug }.merge(links_tracking_params))
+  - link_params = { slug: landing.slug, anchor: 'section-formulaire' }
+  - link_params.merge!(links_tracking_params)
+  - path = landing_path(link_params)
   = link_to path do
     .card__content
       %h3.landing-title= simple_format(landing.home_title, {}, wrapper_tag: 'span')

--- a/app/views/landings/_landing_details.haml
+++ b/app/views/landings/_landing_details.haml
@@ -4,7 +4,7 @@
   %h2.section__title
     = simple_format(landing.subtitle, {}, wrapper_tag: 'span')
 
-  = link_to landing.button, '#solicitation-form', class: 'button blue'
+  = link_to landing.button, '#section-formulaire', class: 'button blue'
 
   - if @landing.logos.present?
     %p

--- a/app/views/landings/index.haml
+++ b/app/views/landings/index.haml
@@ -9,10 +9,10 @@
       = t('.question')
     %h2.lead-text
       = t('.answer')
-    = link_to t('.submit_request'), '#featured-landings', class: 'button blue'
+    = link_to t('.submit_request'), '#section-thematiques', class: 'button blue'
     = render 'institutions'
 
-%section.section.section-color#featured-landings
+%section.section.section-color#section-thematiques
   .container
     = render 'landings', landings: @landings, links_tracking_params: @links_tracking_params
 

--- a/app/views/landings/show.haml
+++ b/app/views/landings/show.haml
@@ -13,7 +13,7 @@
   .container
     = render 'landing_topics/example_topics', landing: @landing, landing_topics: @landing_topics, links_tracking_params: @links_tracking_params
 
-%section.section.section-white
+%section.section.section-white#section-formulaire
   .container.container-small
     = render 'solicitations/form', description_example: @landing.description_example
 


### PR DESCRIPTION
fixes #839

Also, this enables smooth scrolling to local anchors, and disable turbolinks on local pages.

See https://caniuse.com/#search=scroll-behavior
As of today, only Safari is missing it, but it’s already available in the latest Safari Technology Preview. (IE lacks it completely, but who cares about IE.)

Also disable Turbolinks for public pages, for two reasons:
* Turbolinks messes with smooth scrolling, when going from one page to another with an anchor. Since Turbolinks replaces the <body>, the browser still believes it should be scrolling to the new location from the current location on the old page, which makes no sense. (See https://github.com/turbolinks/turbolinks/issues/181#issuecomment-545084567)
* When clicking a link to the same page with an anchor, turbolinks issues an XHR request, even if we’re actually not staying on the same. This is unneeded, and actually goes contrary to the original intent of turbolinks (which is to reduce the number of http requests). (See https://github.com/turbolinks/turbolinks/issues/75)
* Finally, for our public pages, turbolinks offers very little in terms of performance, since assets are cached on the client side anyway. Let’s rely on the browser for this.