### PR TITLE
Envoyer les mails de commentaires des besoins à tous les intervenants

### DIFF
--- a/app/controllers/matches_controller.rb
+++ b/app/controllers/matches_controller.rb
@@ -8,6 +8,7 @@ class MatchesController < ApplicationController
     @match.update status: params[:status]
     UserMailer.deduplicated_send_match_notify(@match, current_user, previous_status)
     if @match.status_taking_care?
+      UserMailer.notify_other_experts(match, user).deliver_later
       if @match.advisor.support_expert_subject.nil?
         CompanyMailer.taking_care_by_expert(@match).deliver_later
       else

--- a/app/mailers/user_mailer.rb
+++ b/app/mailers/user_mailer.rb
@@ -40,6 +40,16 @@ class UserMailer < ApplicationMailer
     mail(to: @advisor.email, subject: t('mailers.user_mailer.update_match_notify.subject', company_name: @company.name))
   end
 
+  def notify_other_experts(match, user)
+    @match = match
+    @user = user
+    @company = match.company
+    @subject = match.subject
+    @need = @match.need
+    emails = (@need.matches.where(status: :quo).map(&:expert) - @user.experts).pluck(:email)
+    mail(to: emails, subject: t('mailers.user_mailer.update_match_notify.subject', company_name: @company.name))
+  end
+
   def self.deduplicated_send_match_notify(match, user, previous_status)
     if ENV['DEVELOPMENT_INLINE_JOBS'].to_b
       update_match_notify(match, user, previous_status).deliver_later

--- a/app/models/feedback.rb
+++ b/app/models/feedback.rb
@@ -56,11 +56,7 @@ class Feedback < ApplicationRecord
   end
 
   def persons_to_notify
-    if author == need.advisor
-      need.experts
-    else
-      [need.advisor]
-    end
+    need.experts + [need.advisor] - [author]
   end
 
   private

--- a/app/views/mailers/user_mailer/notify_other_experts.html.haml
+++ b/app/views/mailers/user_mailer/notify_other_experts.html.haml
@@ -1,0 +1,13 @@
+%p= t('mailers.hello')
+
+%p= t('.need_description_html',
+  company_name: @company.name,
+  subject: @subject,
+  path: diagnosis_url(@match.diagnosis),
+  user: @user.full_name,
+  antenne: @user.antenne.name)
+
+%p= t('.complementary_help')
+
+%p= t('mailers.user_mailer.nice_day')
+%p= t('mailers.place_des_entreprises_team_html', link_to_root: link_to(t('app_name'), root_url))

--- a/app/views/mailers/user_mailer/update_match_notify.html.haml
+++ b/app/views/mailers/user_mailer/update_match_notify.html.haml
@@ -12,5 +12,5 @@
     antenne: @person.antenne.name,
     previous_status: t("attributes.statuses_action.#{@previous_status}"))
 
-%p= t('.nice_day')
+%p= t('mailers.user_mailer.nice_day')
 %p= t('mailers.place_des_entreprises_team_html', link_to_root: link_to(t('app_name'), root_url))

--- a/config/locales/views.fr.yml
+++ b/config/locales/views.fr.yml
@@ -315,6 +315,10 @@ fr:
         new_comment_html: "%{author} (%{antenne}) a fait un commentaire concernant le besoin de l’entreprise <b>%{company}</b>, adressé le %{date}."
         reply: Répondre
         subject: "[Place des Entreprises] Des nouvelles de l’entreprise %{company_name}"
+      nice_day: Bonne journée,
+      notify_other_experts:
+        need_description_html: "Le besoin de l’entreprise <a href='%{path}'>%{company_name}</a> - %{subject} - a été pris en charge par %{user} (%{antenne})."
+        complementary_help: "Il correspond à votre champ d'intervention. Avez-vous une solution complémentaire à proposer ?"
       update_match_notify:
         expert_and_status:
           done_html: "<p>%{user} (%{antenne}) a clôturé ce besoin.</p>"
@@ -322,7 +326,6 @@ fr:
           quo_html: "<p>%{user} (%{antenne}) a annulé sa derniere action (%{previous_status}).</p>"
           taking_care_html: "<p>%{user} (%{antenne}) a pris en charge ce besoin.</p>"
         need_description_html: Le besoin de l’entreprise <a href='%{path}'>%{company_name}</a> que vous avez adressé le %{date} - %{subject} - a évolué.
-        nice_day: Bonne journée,
         subject: "[Place des Entreprises] Des nouvelles de l’entreprise %{company_name}"
     withdraw_request_html: Si vous souhaitez retirer votre demande, contactez-nous <a href='mailto:contact@place-des-entreprises.beta.gouv.fr'>contact@place-des-entreprises.beta.gouv.fr</a>
   matches:

--- a/spec/mailers/previews/user_mailer_preview.rb
+++ b/spec/mailers/previews/user_mailer_preview.rb
@@ -16,6 +16,10 @@ class UserMailerPreview < ActionMailer::Preview
     UserMailer.update_match_notify(Match.all.sample, User.all.sample, Match.all.sample.status)
   end
 
+  def notify_other_experts
+    UserMailer.notify_other_experts(Match.all.sample, User.all.sample)
+  end
+
   private
 
   def user

--- a/spec/mailers/user_mailer_spec.rb
+++ b/spec/mailers/user_mailer_spec.rb
@@ -16,6 +16,17 @@ describe UserMailer do
     it { expect(mail.header[:from].value).to eq ExpertMailer::SENDER }
   end
 
+  describe '#notify_other_experts' do
+    subject(:mail) { described_class.notify_other_experts(a_match, user).deliver_now }
+
+    let(:a_match) { create :match }
+    let(:user) { create :user }
+
+    it_behaves_like 'an email'
+
+    it { expect(mail.header[:from].value).to eq ExpertMailer::SENDER }
+  end
+
   describe '#deduplicated_send_match_notify' do
     def notify_change(new_status)
       previous_status = a_match.status


### PR DESCRIPTION
- Envoyer les mails de commentaires des besoins à tous les intervenants
- Plus envoi d'un nouveau mail de notification aux experts quand un autre expert prend en charge

closes #799