### PR TITLE
Envoyer un nouveau mail de notification aux experts quand un autre prend en charge

### DIFF
--- a/app/controllers/matches_controller.rb
+++ b/app/controllers/matches_controller.rb
@@ -6,7 +6,7 @@ class MatchesController < ApplicationController
     authorize @match
     previous_status = @match.status
     @match.update status: params[:status]
-    UserMailer.deduplicated_send_match_notify(@match, current_user, previous_status)
+    UserMailer.deduplicated_send_match_notify(@match, previous_status)
     if @match.status_taking_care?
       CompanyMailer.notify_taking_care(@match).deliver_later
     end

--- a/app/controllers/matches_controller.rb
+++ b/app/controllers/matches_controller.rb
@@ -7,8 +7,5 @@ class MatchesController < ApplicationController
     previous_status = @match.status
     @match.update status: params[:status]
     MatchMailerService.deduplicated_notify_status(@match, previous_status)
-    if @match.status_taking_care?
-      CompanyMailer.notify_taking_care(@match).deliver_later
-    end
   end
 end

--- a/app/controllers/matches_controller.rb
+++ b/app/controllers/matches_controller.rb
@@ -6,7 +6,7 @@ class MatchesController < ApplicationController
     authorize @match
     previous_status = @match.status
     @match.update status: params[:status]
-    UserMailer.deduplicated_send_match_notify(@match, previous_status)
+    MatchMailerService.deduplicated_notify_status(@match, previous_status)
     if @match.status_taking_care?
       CompanyMailer.notify_taking_care(@match).deliver_later
     end

--- a/app/mailers/expert_mailer.rb
+++ b/app/mailers/expert_mailer.rb
@@ -35,4 +35,11 @@ class ExpertMailer < ApplicationMailer
       subject: t('mailers.expert_mailer.remind_involvement.subject')
     )
   end
+
+  def notify_other_taking_care(expert, match)
+    @expert = expert
+    @match = match
+
+    mail(to: @expert.email_with_display_name, subject: t('mailers.user_mailer.notify_match_status.subject', company_name: @match.company.name))
+  end
 end

--- a/app/mailers/user_mailer.rb
+++ b/app/mailers/user_mailer.rb
@@ -31,31 +31,4 @@ class UserMailer < ApplicationMailer
     @subject = match.subject
     mail(to: @advisor.email, subject: t('mailers.user_mailer.notify_match_status.subject', company_name: @company.name))
   end
-
-  def self.deduplicated_send_match_notify(match, previous_status)
-    if ENV['DEVELOPMENT_INLINE_JOBS'].to_b
-      notify_match_status(match, previous_status).deliver_later
-      return
-    end
-
-    # Kill similar jobs that are not run yet (or being run).
-    # Disable DEVELOPMENT_INLINE_JOBS to debug :)
-    queue = 'match_notify'
-    previous_jobs = Delayed::Job.remove_jobs queue do |job|
-      payload = job.payload_object
-      # Remove the similar emails about to be sent
-      [payload.object, payload.method_name] == [UserMailer, :update_match_notify] &&
-        payload.args.first == match
-    end
-
-    # Fetch the oldest status from the previous jobs
-    old_status = previous_jobs.first&.payload_object&.args&.last
-    old_status ||= previous_status
-
-    # Reschedule a new email, if needed.
-    if match.status != old_status
-      # Use DelayedJob (instead of the abstract layer, ActiveJob) because it’s easier to filter the payload object
-      delay(run_at: 1.minute.from_now, queue: queue).notify_match_status(match, old_status)
-    end
-  end
 end

--- a/app/mailers/user_mailer.rb
+++ b/app/mailers/user_mailer.rb
@@ -20,22 +20,21 @@ class UserMailer < ApplicationMailer
          subject: t('mailers.user_mailer.match_feedback.subject', company_name: feedback.need.company))
   end
 
-  def update_match_notify(match, user, previous_status)
+  def notify_match_status(match, previous_status)
     @status = {}
     @match = match
     @expert = match.expert
     @previous_status = previous_status
-    @person = user || match.expert
     @advisor = match.advisor
     @company = match.company
     @need = match.need
     @subject = match.subject
-    mail(to: @advisor.email, subject: t('mailers.user_mailer.update_match_notify.subject', company_name: @company.name))
+    mail(to: @advisor.email, subject: t('mailers.user_mailer.notify_match_status.subject', company_name: @company.name))
   end
 
-  def self.deduplicated_send_match_notify(match, user, previous_status)
+  def self.deduplicated_send_match_notify(match, previous_status)
     if ENV['DEVELOPMENT_INLINE_JOBS'].to_b
-      update_match_notify(match, user, previous_status).deliver_later
+      notify_match_status(match, previous_status).deliver_later
       return
     end
 
@@ -46,17 +45,17 @@ class UserMailer < ApplicationMailer
       payload = job.payload_object
       # Remove the similar emails about to be sent
       [payload.object, payload.method_name] == [UserMailer, :update_match_notify] &&
-        payload.args.first(2) == [match, user]
+        payload.args.first == match
     end
 
     # Fetch the oldest status from the previous jobs
-    old_status = previous_jobs.first&.payload_object&.args&.third
+    old_status = previous_jobs.first&.payload_object&.args&.last
     old_status ||= previous_status
 
     # Reschedule a new email, if needed.
     if match.status != old_status
       # Use DelayedJob (instead of the abstract layer, ActiveJob) because it’s easier to filter the payload object
-      delay(run_at: 1.minute.from_now, queue: queue).update_match_notify(match, user, old_status)
+      delay(run_at: 1.minute.from_now, queue: queue).notify_match_status(match, old_status)
     end
   end
 end

--- a/app/models/need.rb
+++ b/app/models/need.rb
@@ -174,6 +174,10 @@ class Need < ApplicationRecord
     last_activity_at < 3.weeks.ago
   end
 
+  def quo_experts
+    Expert.joins(:received_matches).merge(matches.status_quo)
+  end
+
   ## Status
   #
   STATUSES = %i[

--- a/app/services/match_mailer_service.rb
+++ b/app/services/match_mailer_service.rb
@@ -1,0 +1,34 @@
+# frozen_string_literal: true
+
+class MatchMailerService
+  def self.deduplicated_notify_status(match, previous_status)
+    if ENV['DEVELOPMENT_INLINE_JOBS'].to_b
+      notify_status(match, previous_status).perform_later
+      return
+    end
+
+    # Kill similar jobs that are not run yet (or being run).
+    # Disable DEVELOPMENT_INLINE_JOBS to debug :)
+    queue = 'match_notify'
+    previous_jobs = Delayed::Job.remove_jobs queue do |job|
+      payload = job.payload_object
+      # Remove the similar emails about to be sent
+      [payload.object, payload.method_name] == [MatchMailerService, :notify_status] &&
+        payload.args.first == match
+    end
+
+    # Fetch the oldest status from the previous jobs
+    old_status = previous_jobs.first&.payload_object&.args&.last
+    old_status ||= previous_status
+
+    # Reschedule a new email, if needed.
+    if match.status != old_status
+      # Use DelayedJob (instead of the abstract layer, ActiveJob) because it’s easier to filter the payload object
+      delay(run_at: 1.minute.from_now, queue: queue).notify_status(match, old_status)
+    end
+  end
+
+  def self.notify_status(match, previous_status)
+    UserMailer.notify_match_status(match, previous_status).deliver_later
+  end
+end

--- a/app/services/match_mailer_service.rb
+++ b/app/services/match_mailer_service.rb
@@ -35,6 +35,11 @@ class MatchMailerService
     if should_notify_everyone(previous_status, match.status)
       # Notify the company
       CompanyMailer.notify_taking_care(match).deliver_later
+
+      # Notify other experts that haven’t responded yet
+      match.need.quo_experts.each do |expert|
+        ExpertMailer.notify_other_taking_care(expert, match).deliver_later
+      end
     end
   end
 

--- a/app/services/match_mailer_service.rb
+++ b/app/services/match_mailer_service.rb
@@ -30,5 +30,18 @@ class MatchMailerService
 
   def self.notify_status(match, previous_status)
     UserMailer.notify_match_status(match, previous_status).deliver_later
+
+    # Notify everyone if the match is being taken care of *now*
+    if should_notify_everyone(previous_status, match.status)
+      # Notify the company
+      CompanyMailer.notify_taking_care(match).deliver_later
+    end
+  end
+
+  def self.should_notify_everyone(old_status, new_status)
+    not_taken_care_of = %w[quo not_for_me]
+    taken_care_of = %w[taking_care done]
+
+    old_status.in?(not_taken_care_of) && new_status.in?(taken_care_of)
   end
 end

--- a/app/views/mailers/expert_mailer/notify_other_taking_care.html.haml
+++ b/app/views/mailers/expert_mailer/notify_other_taking_care.html.haml
@@ -1,0 +1,13 @@
+%p= t('mailers.hello_name', name: @expert.full_name)
+
+%p= t('.need_description_html',
+  company_name: @match.company.name,
+  subject: @match.subject,
+  path: diagnosis_url(@match.diagnosis),
+  expert: @match.expert.full_name,
+  antenne: @match.expert.antenne.name)
+
+%p= t('.complementary_help')
+
+%p= t('mailers.user_mailer.nice_day')
+%p= t('mailers.place_des_entreprises_team_html', link_to_root: link_to(t('app_name'), root_url))

--- a/app/views/mailers/user_mailer/notify_match_status.html.haml
+++ b/app/views/mailers/user_mailer/notify_match_status.html.haml
@@ -8,9 +8,9 @@
 
 %blockquote
   = t(".expert_and_status.#{@match.status}_html",
-    user: @person.full_name,
-    antenne: @person.antenne.name,
+    expert: @expert.full_name,
+    antenne: @expert.antenne.name,
     previous_status: t("attributes.statuses_action.#{@previous_status}"))
 
-%p= t('.nice_day')
+%p= t('mailers.user_mailer.nice_day')
 %p= t('mailers.place_des_entreprises_team_html', link_to_root: link_to(t('app_name'), root_url))

--- a/config/i18n-tasks.yml
+++ b/config/i18n-tasks.yml
@@ -94,7 +94,7 @@ ignore_unused:
   - 'attributes.*'
   - 'diagnoses.steps.*.title'
   - 'mailers.admin_mailer.weekly_statistics.needs_abandoned.scopes.*'
-  - 'mailers.user_mailer.update_match_notify.expert_and_status.*'
+  - 'mailers.user_mailer.notify_match_status.expert_and_status.*'
   - 'stats.stats_table.*'
   - 'stats.series.*'
   - 'categories_juridiques.*'

--- a/config/locales/views.fr.yml
+++ b/config/locales/views.fr.yml
@@ -343,6 +343,9 @@ fr:
         reply: Répondre sur Place des entreprises
         subject: "[Place des Entreprises] L’entreprise %{company_name} a besoin de vous"
         this_company: L’entreprise
+      notify_other_taking_care:
+        complementary_help: Il correspond à votre champ d'intervention. Avez-vous une solution complémentaire à proposer ?
+        need_description_html: Le besoin de l’entreprise <a href='%{path}'>%{company_name}</a> - %{subject} - a été pris en charge par %{expert} (%{antenne}).
       remind_involvement:
         needs_for_you: 'Ces entreprises ont besoin de vous :'
         needs_quo: 'Besoins restés sans réponse : quelle est votre position ?'

--- a/config/locales/views.fr.yml
+++ b/config/locales/views.fr.yml
@@ -378,14 +378,14 @@ fr:
         new_comment_html: "%{author} (%{antenne}) a fait un commentaire concernant le besoin de l’entreprise <b>%{company}</b>, adressé le %{date}."
         reply: Répondre
         subject: "[Place des Entreprises] Des nouvelles de l’entreprise %{company_name}"
-      update_match_notify:
+      nice_day: Bonne journée,
+      notify_match_status:
         expert_and_status:
-          done_html: "<p>%{user} (%{antenne}) a clôturé ce besoin.</p>"
-          not_for_me_html: "<p>%{user} (%{antenne}) a refusé ce besoin.</p><p>Si aucun expert n’intervient, l’Equipe Place des Entreprises prendra le relai.</p>"
-          quo_html: "<p>%{user} (%{antenne}) a annulé sa derniere action (%{previous_status}).</p>"
-          taking_care_html: "<p>%{user} (%{antenne}) a pris en charge ce besoin.</p>"
+          done_html: "<p>%{expert} (%{antenne}) a clôturé ce besoin.</p>"
+          not_for_me_html: "<p>%{expert} (%{antenne}) a refusé ce besoin.</p><p>Si aucun expert n’intervient, l’Equipe Place des Entreprises prendra le relai.</p>"
+          quo_html: "<p>%{expert} (%{antenne}) a annulé sa derniere action (%{previous_status}).</p>"
+          taking_care_html: "<p>%{expert} (%{antenne}) a pris en charge ce besoin.</p>"
         need_description_html: Le besoin de l’entreprise <a href='%{path}'>%{company_name}</a> que vous avez adressé le %{date} - %{subject} - a évolué.
-        nice_day: Bonne journée,
         subject: "[Place des Entreprises] Des nouvelles de l’entreprise %{company_name}"
     withdraw_request_html: Si vous souhaitez retirer votre demande, %{mailto_link}.
   matches:

--- a/spec/mailers/expert_mailer_spec.rb
+++ b/spec/mailers/expert_mailer_spec.rb
@@ -83,4 +83,15 @@ describe ExpertMailer do
 
     it { expect(mail.header[:from].value).to eq ExpertMailer::SENDER }
   end
+
+  describe '#notify_other_taking_care' do
+    subject(:mail) { described_class.notify_other_taking_care(expert, a_match).deliver_now }
+
+    let(:expert) { create :expert }
+    let(:a_match) { create :match }
+
+    it_behaves_like 'an email'
+
+    it { expect(mail.header[:from].value).to eq ExpertMailer::SENDER }
+  end
 end

--- a/spec/mailers/previews/expert_mailer_preview.rb
+++ b/spec/mailers/previews/expert_mailer_preview.rb
@@ -9,6 +9,10 @@ class ExpertMailerPreview < ActionMailer::Preview
     ExpertMailer.remind_involvement(expert)
   end
 
+  def notify_other_taking_care
+    ExpertMailer.notify_other_taking_care(Expert.sample, Match.sample)
+  end
+
   private
 
   def active_expert

--- a/spec/mailers/previews/user_mailer_preview.rb
+++ b/spec/mailers/previews/user_mailer_preview.rb
@@ -8,7 +8,7 @@ class UserMailerPreview < ActionMailer::Preview
     UserMailer.match_feedback(feedback, feedback.need.advisor)
   end
 
-  def update_match_notify
-    UserMailer.update_match_notify(Match.all.sample, User.all.sample, Match.all.sample.status)
+  def notify_match_status
+    UserMailer.notify_match_status(Match.all.sample, Match.all.sample.status)
   end
 end

--- a/spec/mailers/user_mailer_spec.rb
+++ b/spec/mailers/user_mailer_spec.rb
@@ -14,39 +14,4 @@ describe UserMailer do
 
     it { expect(mail.header[:from].value).to eq ExpertMailer::SENDER }
   end
-
-  describe '#deduplicated_send_match_notify' do
-    def notify_change(new_status)
-      previous_status = a_match.status
-      a_match.status = new_status
-      described_class.deduplicated_send_match_notify(a_match, previous_status)
-    end
-
-    let(:a_match) { create :match, status: :quo }
-    let(:user) { create :user }
-
-    context 'subsequent changes on the same match' do
-      before do
-        notify_change(:taking_care)
-        notify_change(:done)
-      end
-
-      it do
-        expect(Delayed::Job.count).to eq 1
-        previous_status = Delayed::Job.last.payload_object.args.last.to_sym
-        expect(previous_status).to eq :quo
-      end
-    end
-
-    context 'change back to the initial value' do
-      before do
-        notify_change(:not_for_me)
-        notify_change(:quo)
-      end
-
-      it do
-        expect(Delayed::Job.count).to eq 0
-      end
-    end
-  end
 end

--- a/spec/mailers/user_mailer_spec.rb
+++ b/spec/mailers/user_mailer_spec.rb
@@ -4,11 +4,10 @@ require 'rails_helper'
 require 'mailers/shared_examples_for_an_email'
 
 describe UserMailer do
-  describe '#update_match_notify' do
-    subject(:mail) { described_class.update_match_notify(a_match, user, previous_status).deliver_now }
+  describe '#notify_match_status' do
+    subject(:mail) { described_class.notify_match_status(a_match, previous_status).deliver_now }
 
     let(:a_match) { create :match }
-    let(:user) { create :user }
     let(:previous_status) { 'taking_care' }
 
     it_behaves_like 'an email'
@@ -20,7 +19,7 @@ describe UserMailer do
     def notify_change(new_status)
       previous_status = a_match.status
       a_match.status = new_status
-      described_class.deduplicated_send_match_notify(a_match, user, previous_status)
+      described_class.deduplicated_send_match_notify(a_match, previous_status)
     end
 
     let(:a_match) { create :match, status: :quo }

--- a/spec/services/match_mailer_service_spec.rb
+++ b/spec/services/match_mailer_service_spec.rb
@@ -1,0 +1,40 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+describe MatchMailerService do
+  before { ENV['APPLICATION_EMAIL'] = 'contact@mailrandom.fr' }
+
+  describe '#deduplicated_notify_status' do
+    def notify_change(new_status)
+      previous_status = a_match.status
+      a_match.status = new_status
+      described_class.deduplicated_notify_status(a_match, previous_status)
+    end
+
+    let(:a_match) { create :match, status: :quo }
+
+    context 'subsequent changes on the same match' do
+      before do
+        notify_change(:taking_care)
+        notify_change(:done)
+      end
+
+      it do
+        expect(Delayed::Job.count).to eq 1
+        previous_status = Delayed::Job.last.payload_object.args.last.to_sym
+        expect(previous_status).to eq :quo
+      end
+    end
+
+    context 'change back to the initial value' do
+      before do
+        notify_change(:not_for_me)
+        notify_change(:quo)
+      end
+
+      it do
+        expect(Delayed::Job.count).to eq 0
+      end
+    end
+  end
+end

--- a/spec/services/match_mailer_service_spec.rb
+++ b/spec/services/match_mailer_service_spec.rb
@@ -37,4 +37,46 @@ describe MatchMailerService do
       end
     end
   end
+
+  describe '#notify_status' do
+    before do
+      mailer_double = double().as_null_object
+      allow(UserMailer).to receive(:notify_match_status) { mailer_double }
+      allow(CompanyMailer).to receive(:notify_taking_care) { mailer_double }
+
+      described_class.notify_status(a_match, previous_status)
+    end
+
+    let(:a_match) { create :match, status: new_status }
+
+    context 'taken care of now' do
+      let(:previous_status) { 'quo' }
+      let(:new_status) { 'taking_care' }
+
+      it do
+        expect(UserMailer).to have_received(:notify_match_status)
+        expect(CompanyMailer).to have_received(:notify_taking_care)
+      end
+    end
+
+    context 'already taken care of' do
+      let(:previous_status) { 'done' }
+      let(:new_status) { 'taking_care' }
+
+      it do
+        expect(UserMailer).to have_received(:notify_match_status)
+        expect(CompanyMailer).not_to have_received(:notify_taking_care)
+      end
+    end
+
+    context 'not taken care of' do
+      let(:previous_status) { 'quo' }
+      let(:new_status) { 'not_for_me' }
+
+      it do
+        expect(UserMailer).to have_received(:notify_match_status)
+        expect(CompanyMailer).not_to have_received(:notify_taking_care)
+      end
+    end
+  end
 end

--- a/spec/services/match_mailer_service_spec.rb
+++ b/spec/services/match_mailer_service_spec.rb
@@ -43,6 +43,10 @@ describe MatchMailerService do
       mailer_double = double().as_null_object
       allow(UserMailer).to receive(:notify_match_status) { mailer_double }
       allow(CompanyMailer).to receive(:notify_taking_care) { mailer_double }
+      allow(ExpertMailer).to receive(:notify_other_taking_care) { mailer_double }
+
+      other_matches = create_list :match, 2, status: :quo
+      create :need, matches: [a_match] + other_matches
 
       described_class.notify_status(a_match, previous_status)
     end
@@ -56,6 +60,7 @@ describe MatchMailerService do
       it do
         expect(UserMailer).to have_received(:notify_match_status)
         expect(CompanyMailer).to have_received(:notify_taking_care)
+        expect(ExpertMailer).to have_received(:notify_other_taking_care).twice
       end
     end
 
@@ -66,6 +71,7 @@ describe MatchMailerService do
       it do
         expect(UserMailer).to have_received(:notify_match_status)
         expect(CompanyMailer).not_to have_received(:notify_taking_care)
+        expect(ExpertMailer).not_to have_received(:notify_other_taking_care)
       end
     end
 
@@ -76,6 +82,7 @@ describe MatchMailerService do
       it do
         expect(UserMailer).to have_received(:notify_match_status)
         expect(CompanyMailer).not_to have_received(:notify_taking_care)
+        expect(ExpertMailer).not_to have_received(:notify_other_taking_care)
       end
     end
   end


### PR DESCRIPTION
Nettoyage:
* Suppression de UserMailer.daily_change_update (qui n’était plus utilisé depuis longtemps)
* Unification de CompanyMailer.taking_care_by_expert et CompanyMailer.taking_care_by_support

Correction:
* Dans le mail de notification à l’advisor, ne plus utiliser le nom de l’utilisateur qui change le statut, mais celui de l’expert.

Refactor:
* Déplacement de la méthode de déduplication des emails de notification dans un nouveau service (MatchMailerService)

Amélioration:
* Déduplication du mail de notification de prise en charge aux entreprises (CompanyMailer.notify_taking_care)

Nouveauté (enfin) :
* Envoi d’un mail de notification de prise en charge aux autres experts sur un besoin qui n’ont pas encore répondu. (ExpertMailer.notify_others_taking_care)

closes #799