### PR TITLE
Display foreign key violations errors in /admin when trying to destroy

### DIFF
--- a/app/admin/patches/data_access.rb
+++ b/app/admin/patches/data_access.rb
@@ -1,11 +1,24 @@
 module Admin
   module Patches
+    ## !! Monkey-patch overrides !!
     module DataAccess
-      ## !! Monkey-patch override !!
-      # When filtering for “has_many through” associations, AA  may yield duplicate rows in ActiveAdmin
+      # When filtering for “has_many through” associations,
+      # AA  may yield duplicate rows in ActiveAdmin
       # See #691
       def scoped_collection
         super.distinct
+      end
+
+      # Display errors in AA when failing to destroy an object
+      # because of a PG::ForeignKeyViolation exception.
+      # Inspired by https://github.com/activeadmin/activeadmin/issues/5369
+      def destroy_resource(object)
+        begin
+          super
+        rescue ActiveRecord::ActiveRecordError => e
+          object.errors.add(:base, e.message)
+          flash[:alert] = object.errors.full_messages.join(". ").html_safe
+        end
       end
     end
 


### PR DESCRIPTION
When trying to destroy an object that is still referenced, for example an Institution that still has Antennes, PG will throw an exception and AA will fail and return an `error 500` blank page.

This catches and displays the underlying error; there seems to be no mechanism in AA to handle destroy failures at all. 🤷🏻‍♂️