### PR TITLE
Add rubocop i18n

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -2,6 +2,7 @@ require:
   - rubocop-rspec
   - rubocop-performance
   - rubocop-rails
+  - rubocop-i18n
 
 AllCops:
   TargetRubyVersion: 2.6
@@ -1302,4 +1303,13 @@ Style/YodaCondition:
   Enabled: false
 
 Style/ZeroLengthPredicate:
+  Enabled: false
+
+RailsI18n:
+  Enabled: true
+  Exclude:
+    - 'lib/tasks/*.rake'
+    - 'spec/**/*'
+
+GetText:
   Enabled: false

--- a/Gemfile
+++ b/Gemfile
@@ -104,6 +104,7 @@ group :development do
   gem 'rubocop-performance', require: false
   gem 'rubocop-rails', require: false
   gem 'rubocop-faker', require: false
+  gem 'rubocop-i18n', require: false
   gem 'brakeman', require: false
 end
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -416,6 +416,8 @@ GEM
       unicode-display_width (>= 1.4.0, < 1.7)
     rubocop-faker (0.2.0)
       rubocop (>= 0.74)
+    rubocop-i18n (2.0.1)
+      rubocop (~> 0.51)
     rubocop-performance (1.5.2)
       rubocop (>= 0.71.0)
     rubocop-rails (2.4.2)
@@ -555,6 +557,7 @@ DEPENDENCIES
   rspec_junit_formatter
   rubocop
   rubocop-faker
+  rubocop-i18n
   rubocop-performance
   rubocop-rails
   rubocop-rspec

--- a/app/controllers/pages_controller.rb
+++ b/app/controllers/pages_controller.rb
@@ -5,6 +5,6 @@ class PagesController < SharedController
   ## Configuration for honeypot-captcha
   #
   def honeypot_fields
-    { :commentaire => 'Laissez ce champ vide !' }
+    { :commentaire => t('honeypot_captcha.comment') }
   end
 end

--- a/app/services/api_entreprise/entreprise_response.rb
+++ b/app/services/api_entreprise/entreprise_response.rb
@@ -4,7 +4,7 @@ module ApiEntreprise
   class EntrepriseResponse
     attr_reader :http_response
 
-    DEFAULT_ERROR_MESSAGE = 'There was an error retrieving entreprise details.'
+    DEFAULT_ERROR_MESSAGE = I18n.t('api_entreprise.default_error_message.entreprise')
 
     def initialize(http_response)
       @http_response = http_response

--- a/app/services/api_entreprise/etablissement_response.rb
+++ b/app/services/api_entreprise/etablissement_response.rb
@@ -4,7 +4,7 @@ module ApiEntreprise
   class EtablissementResponse
     attr_reader :http_response
 
-    DEFAULT_ERROR_MESSAGE = 'There was an error retrieving etablissement details.'
+    DEFAULT_ERROR_MESSAGE = I18n.t('api_entreprise.default_error_message.etablissement')
 
     def initialize(http_response)
       @http_response = http_response

--- a/app/views/shared/errors/404.html.haml
+++ b/app/views/shared/errors/404.html.haml
@@ -1,4 +1,4 @@
-- meta title: 'Erreur !'
+- meta title: t('.title')
 
-%h1= 'Erreur !'
-%p= "Cette page n’existe pas, ou vous n’y avez pas accès."
+%h1= t('.title')
+%p= t('.message')

--- a/app/views/shared/errors/500.html.haml
+++ b/app/views/shared/errors/500.html.haml
@@ -1,6 +1,4 @@
-- meta title: 'Erreur !'
+- meta title: t('.title')
 
-%h1 Erreur !
-%p
-  Cette erreur était inattendue…
-  Nous avons été prévenus de son apparition et nous allons la réparer dès que possible !
+%h1= t('.title')
+%p= t('.message_html')

--- a/config/locales/fr.yml
+++ b/config/locales/fr.yml
@@ -1,6 +1,10 @@
 ---
 fr:
   all_choices: Tous
+  api_entreprise:
+    default_error_message:
+      entreprise: Erreur lors de la récupération des détails de l’entreprise.
+      etablissement: Erreur lors de la récupération des détails de l’établissement.
   app_name: Place des Entreprises
   cgu: Conditions d’utilisation
   company_contact: Chefs d’entreprises, cliquez ici
@@ -160,6 +164,8 @@ fr:
       create: Créer un(e) %{model}
       submit: Enregistrer ce(tte) %{model}
       update: Modifier ce(tte) %{model}
+  honeypot_captcha:
+    comment: Laissez ce champ vide !
   needs:
     additional_experts:
       add_match_with: Voulez-vous contacter %{name} au sujet de ce besoin (%{subject}) ?
@@ -221,6 +227,14 @@ fr:
   privacy:
     explanation_html: '<h2>Cookies déposés et configuration du suivi</h2> <p>Ce site dépose un petit fichier texte (un « cookie ») sur votre ordinateur lorsque vous le consultez. Cela nous permet de mesurer le nombre de visites et de comprendre quelles sont les pages les plus consultées.</p> <iframe style="background:#fafbfc; border:0; width: 100%;" src="https://stats.data.gouv.fr/index.php?module=CoreAdminHome&action=optOut&language=fr&fontFamily=sans-serif"></iframe> <h3>Ce site n’affiche pas de bannière de consentement aux cookies, pourquoi ?</h3> <p>C’est vrai, vous n’avez pas eu à cliquer sur un bloc qui recouvre la moitié de la page pour dire que vous êtes d’accord avec le dépôt de cookies. <br> <br> Rien d’exceptionnel, pas de passe-droit. Nous respectons simplement la loi, qui dit que certains outils de suivi d’audience, correctement configurés pour respecter la vie privée, sont exemptés d’autorisation préalable. <br> <br> Nous utilisons pour cela <a href="https://matomo.org/" target="_blank">Matomo</a>, un outil <a href="https://matomo.org/free-software/" target="_blank">libre</a>, paramétré pour être en conformité avec la <a href="https://www.cnil.fr/fr/solutions-pour-la-mesure-daudience">recommandation « Cookies » </a>de la CNIL. Cela signifie que votre adresse IP, par exemple, est anonymisée avant d’être enregistrée. Il est donc impossible d’associer vos visites sur ce site à votre personne. </p>'
   search: Rechercher
+  shared:
+    errors:
+      '404':
+        message: Cette page n’existe pas, ou vous n’y avez pas accès.
+        title: Erreur !
+      '500':
+        message_html: Cette erreur était inattendue…</br>Nous avons été prévenus de son apparition et nous allons la réparer dès que possible !
+        title: Erreur !
   sign_in: Connexion
   support:
     array:

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -126,4 +126,7 @@ Rails.application.routes.draw do
   get '/profile', to: redirect('/mon_compte')
   get '/mes_competences', to: redirect('/mon_compte/referents')
   get '/diagnoses', to: redirect('/analyses')
+
+  ## Handle 404 properly
+  get '*unmatched_route', :to => 'shared#not_found'
 end


### PR DESCRIPTION
This is imperfect, but a first step.
- It’s using rubocop, not haml-lint, which means haml files are not verified.
- It uses a regexp to decide if a string looks like human-displayed sentence. The rules are:
  > Sentences are determined by the STRING_REGEXP. (Upper case character, at least one space, and sentence punctuation at the end)