### PR TITLE
add partner_token to FORM_INFO_KEYS

### DIFF
--- a/app/models/solicitation.rb
+++ b/app/models/solicitation.rb
@@ -33,7 +33,7 @@ class Solicitation < ApplicationRecord
   ## JSON Accessors
   #
   TRACKING_KEYS = %i[pk_campaign pk_kwd gclid slug]
-  FORM_INFO_KEYS = [:alternative] + TRACKING_KEYS
+  FORM_INFO_KEYS = %i[alternative partner_token] + TRACKING_KEYS
   store_accessor :form_info, FORM_INFO_KEYS.map(&:to_s)
 
   ## ActiveAdmin/Ransacker helpers


### PR DESCRIPTION
Prevent error `undefined local variable or method partner_token' for Solicitation`