### PR TITLE
Store form info and campaign params in the session

### DIFF
--- a/app/admin/solicitation.rb
+++ b/app/admin/solicitation.rb
@@ -38,7 +38,7 @@ ActiveAdmin.register Solicitation do
     column :phone_number
     column :description
     column :created_at
-    Solicitation::TRACKING_KEYS.each{ |k| column k }
+    Solicitation::FORM_INFO_KEYS.each{ |k| column k }
   end
 
   ## Show

--- a/app/controllers/solicitations_controller.rb
+++ b/app/controllers/solicitations_controller.rb
@@ -1,6 +1,6 @@
 class SolicitationsController < PagesController
   def create
-    @solicitation = Solicitation.create(solicitation_params)
+    @solicitation = Solicitation.create(solicitation_params.merge(retrieve_form_info))
 
     if !@solicitation.valid?
       @result = 'failure'
@@ -22,12 +22,13 @@ class SolicitationsController < PagesController
 
   private
 
-  def index_tracking_params
-    params.permit(Solicitation::TRACKING_KEYS)
-  end
-
   def solicitation_params
     params.require(:solicitation)
-      .permit(:description, :siret, :phone_number, :email, form_info: {}, needs: {})
+      .permit(:description, :siret, :phone_number, :email, needs: {})
+  end
+
+  def retrieve_form_info
+    form_info = session.delete(:solicitation_form_info)
+    { form_info: form_info }
   end
 end

--- a/app/models/solicitation.rb
+++ b/app/models/solicitation.rb
@@ -32,8 +32,7 @@ class Solicitation < ApplicationRecord
 
   ## JSON Accessors
   #
-  TRACKING_KEYS = %i[pk_campaign pk_kwd gclid slug]
-  FORM_INFO_KEYS = %i[alternative partner_token] + TRACKING_KEYS
+  FORM_INFO_KEYS = %i[slug alternative partner_token pk_campaign pk_kwd gclid]
   store_accessor :form_info, FORM_INFO_KEYS.map(&:to_s)
 
   ## ActiveAdmin/Ransacker helpers

--- a/app/views/landing_topics/_example_topics.haml
+++ b/app/views/landing_topics/_example_topics.haml
@@ -5,4 +5,4 @@
     = render partial: 'landing_topics/landing_topic', collection: landing_topics
   %p
     = t('.not_in_topics')
-    = link_to t('.not_in_topics_more'), root_path(links_tracking_params)
+    = link_to t('.not_in_topics_more'), root_path

--- a/app/views/landings/_landing.haml
+++ b/app/views/landings/_landing.haml
@@ -1,6 +1,5 @@
 .card
   - link_params = { slug: landing.slug, anchor: 'section-formulaire' }
-  - link_params.merge!(links_tracking_params)
   - path = landing_path(link_params)
   = link_to path do
     .card__content

--- a/app/views/landings/_landings.haml
+++ b/app/views/landings/_landings.haml
@@ -1,8 +1,8 @@
 %h2.section__title= t('.title')
 - landings.each_slice(3) do |landings|
   .row
-    = render landings, links_tracking_params: links_tracking_params
+    = render landings
 
 %p.text-center.white-on-dark
   = t('.other_questions')
-  = link_to t('.contact_us'), landing_path({ slug: 'contactez-nous' }.merge(links_tracking_params))
+  = link_to t('.contact_us'), landing_path(slug: 'contactez-nous')

--- a/app/views/landings/index.haml
+++ b/app/views/landings/index.haml
@@ -14,7 +14,7 @@
 
 %section.section.section-color#section-thematiques
   .container
-    = render 'landings', landings: @landings, links_tracking_params: @links_tracking_params
+    = render 'landings', landings: @landings
 
 %section.section.section-grey#testimonials
   .container

--- a/app/views/landings/show.haml
+++ b/app/views/landings/show.haml
@@ -11,7 +11,7 @@
 
 %section.section.section-grey
   .container
-    = render 'landing_topics/example_topics', landing: @landing, landing_topics: @landing_topics, links_tracking_params: @links_tracking_params
+    = render 'landing_topics/example_topics', landing: @landing, landing_topics: @landing_topics
 
 %section.section.section-white#section-formulaire
   .container.container-small

--- a/app/views/solicitations/_form.haml
+++ b/app/views/solicitations/_form.haml
@@ -1,8 +1,6 @@
 #solicitation-form
   %h2.section__title= t('.title')
   = form_with(model: @solicitation, url: solicitation_path, scope: 'solicitation', method: :post, html: { honeypot: true }) do |f|
-    - @solicitation.form_info.each do |k,v|
-      = f.hidden_field "form_info[#{k}]", value: v
     .form__group
       = f.label 'description', t('.description.label')
       - example = local_assigns[:description_example] || t('.description.default_example')


### PR DESCRIPTION
Instead of polluting the url with. (Also, it’s a lot simpler and safer.)

---

C’est du nettoyage, mais il y a plus à venir dans le même domaine: il faut probablement qu’on réarchitecture un peu LandingController et SolicitationsController pour le formulaire en iframe (#628 #830) et le suivi des sollicitations (#601)