### PR TITLE
Enable collection partial caching in /sollicitations

### DIFF
--- a/app/views/solicitations/canceled.html.haml
+++ b/app/views/solicitations/canceled.html.haml
@@ -3,4 +3,5 @@
 %h1.ui.header
   #{@solicitations.count} #{t('.title')}
 
-= render @solicitations
+= render partial: 'solicitations/solicitation', collection: @solicitations, cached: true
+

--- a/app/views/solicitations/index.html.haml
+++ b/app/views/solicitations/index.html.haml
@@ -5,4 +5,4 @@
   = link_to t('.canceled'), canceled_solicitations_path, class: 'compact ui button right floated'
   = link_to t('.processed'), processed_solicitations_path, class: 'compact ui button right floated'
 
-= render @solicitations
+= render partial: 'solicitations/solicitation', collection: @solicitations, cached: true

--- a/app/views/solicitations/processed.html.haml
+++ b/app/views/solicitations/processed.html.haml
@@ -3,4 +3,4 @@
 %h1.ui.header
   #{@solicitations.count} #{t('.title')}
 
-= render @solicitations
+= render partial: 'solicitations/solicitation', collection: @solicitations, cached: true


### PR DESCRIPTION
Wow that was easy. On my machine, it cuts rendering for `/sollicitations` from 1600-1800ms to 200-300ms, with this nice line in the logs:
```
  Rendered collection of solicitations/_solicitation.haml [765 / 765 cache hits] (Duration: 87.9ms | Allocations: 32139)
```
(Small disadvantage: the shorthand syntax for render doesn’t support options.)