### PR TITLE
Prevent crashing when starting a new diagnosis without a solicitation

### DIFF
--- a/app/views/companies/_search_form.haml
+++ b/app/views/companies/_search_form.haml
@@ -7,7 +7,7 @@
     .field
       - if local_assigns[:solicitation].present?
         = hidden_field_tag :solicitation, solicitation.id
-      - siret = defined?(solicitation) ? solicitation&.siret : ''
+      - siret = local_assigns[:solicitation]&.siret
       .ui.action.input
         = text_field_tag :query, query || siret, autofocus: true, placeholder: t('companies.search.explanation')
         %button.ui.button.green{ type: 'submit' }= t('search')

--- a/app/views/diagnoses/new.haml
+++ b/app/views/diagnoses/new.haml
@@ -23,7 +23,8 @@
       = hidden_field_tag :solicitation, @solicitation.id
     .field
       = label_tag t('.name')
-      = text_field_tag :name, @params['name'] || defined?(@solicitation) ? @solicitation.full_name : '', required: true
+      - name = local_assigns[:solicitation]&.full_name
+      = text_field_tag :name, name, required: true
     .field
       = label_tag t('.postal_code')
       = text_field_tag :postal_code, @params['postal_code'], required: true, pattern: '[0-9]{5}'


### PR DESCRIPTION
followup #911
fixes PLACE-DES-ENTREPRISES-60

The fix could have been just to add a `&`, but we might as well use `local_assigns` instead of `defined`.