### PR TITLE
Fix Uglifier complaining about ES6 syntax

### DIFF
--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -26,7 +26,7 @@ Rails.application.configure do
   }
 
   # Compress JavaScripts and CSS.
-  config.assets.js_compressor = :uglifier
+  config.assets.js_compressor = Uglifier.new(harmony: true)
   # Compress CSS using a preprocessor.
   # config.assets.css_compressor = :sass
 


### PR DESCRIPTION
In #913, we use some ✨fancy ES6 javascript✨ syntax, and Uglifier needs to be made aware of this.

The exact command that fails is RAILS_ENV=production bundle exec rake assets:precompile.

The error message is
> Uglifier::Error: Unexpected token: name (boxes_parent). To use ES6 syntax, harmony mode must be enabled with Uglifier.new(:harmony => true).

In development, Uglifier isn’t used 🤷🏻‍♂️.

See https://github.com/lautis/uglifier/issues/127 for context.