### PR TITLE
Workaround a weird crash in /admin/solicitations

### DIFF
--- a/app/views/solicitations/_tracking.haml
+++ b/app/views/solicitations/_tracking.haml
@@ -1,5 +1,5 @@
 %ul
-  - if solicitation.pk_campaign
+  - if solicitation.pk_campaign.present?
     %li #{t('activerecord.attributes.solicitation.pk_campaign')} : #{link_to_tracked_campaign(solicitation)}
-  - if solicitation.pk_kwd
+  - if solicitation.pk_kwd.present?
     %li #{t('activerecord.attributes.solicitation.pk_kwd')} : « #{link_to_tracked_ad(solicitation)} »


### PR DESCRIPTION
rendering the solicitation 1969 made this crash; i’m not sure exactly why `if solicitation.pk_campaign` was true, while the value in DB was nil. I suspect something with a weird encoding and jsonb storage.

PLACE-DES-ENTREPRISES-5R