### PR TITLE
Remove the red outline around checkboxes in Firefox

### DIFF
--- a/app/assets/stylesheets/pages.sass
+++ b/app/assets/stylesheets/pages.sass
@@ -186,6 +186,9 @@ section.section#section-formulaire
   #solicitation-options .panel
     padding: 1em
     padding: var(--space-s)
+    input[type=checkbox]:-moz-ui-invalid
+      // Firefox adds a red outline before the user clicks a checkbox, remove it.
+      box-shadow: none
 
 .section#stats
   padding: 2em


### PR DESCRIPTION
fixup #913