### PR TITLE
Override default button appearances on ios safari

### DIFF
--- a/app/assets/stylesheets/pages.sass
+++ b/app/assets/stylesheets/pages.sass
@@ -18,6 +18,9 @@
   img
     height: 40px
 
+input[type=submit].button
+  -webkit-appearance: none
+
 footer
   .title
     display: flex


### PR DESCRIPTION
Not exactly sure why this is iOS only. 🤷🏻‍♂️