### PR TITLE
Add a formal Landing <-> Solicitation association

### DIFF
--- a/app/admin/helpers/admin_link_to.rb
+++ b/app/admin/helpers/admin_link_to.rb
@@ -5,6 +5,7 @@ module Admin
     module AdminLinkTo
       def admin_link_to(object, association = nil, options = {})
         if association.nil?
+          return nil if object.nil?
           return link_to(object, polymorphic_path([:admin, object]))
         end
 

--- a/app/admin/solicitation.rb
+++ b/app/admin/solicitation.rb
@@ -5,7 +5,7 @@ ActiveAdmin.register Solicitation do
   #
   scope :all, default: true
 
-  includes :diagnoses, diagnoses: :company
+  includes :diagnoses, :landing, diagnoses: :company
 
   index do
     selectable_column
@@ -17,7 +17,7 @@ ActiveAdmin.register Solicitation do
       end
     end
     column :description do |s|
-      div link_to s.slug, landing_path(s.slug) if s.slug
+      div(admin_link_to(s.landing) || s.slug)
       options = s.selected_options
       if options.present?
         div t('activerecord.attributes.solicitation.selected_options') + ' : ' do
@@ -58,6 +58,7 @@ ActiveAdmin.register Solicitation do
   #
   preserve_default_filters!
   remove_filter :diagnoses
+  filter :slug
   filter :status, as: :select, collection: -> { Solicitation.statuses.map { |status, value| [Solicitation.human_attribute_name("statuses.#{status}"), value] } }
   remove_filter :with_selected_option
   filter :with_selected_option_in, as: :select, label: I18n.t('solicitations.solicitation.selected_options'), collection: -> { LandingOption.all.pluck(:slug) }
@@ -95,9 +96,7 @@ ActiveAdmin.register Solicitation do
   #
   show title: :to_s do
     panel I18n.t('attributes.description') do
-      if solicitation.slug
-        div link_to solicitation.slug, landing_path(solicitation.slug)
-      end
+      div(admin_link_to(solicitation.landing) || solicitation.slug)
       blockquote simple_format(solicitation.description)
     end
 

--- a/app/controllers/landings_controller.rb
+++ b/app/controllers/landings_controller.rb
@@ -3,7 +3,7 @@ class LandingsController < PagesController
     @landings = Rails.cache.fetch('landings', expires_in: 3.minutes) do
       Landing.ordered_for_home.to_a
     end
-    @tracking_params = info_params.except(:slug)
+    @tracking_params = info_params
   end
 
   def show
@@ -16,8 +16,8 @@ class LandingsController < PagesController
     @landing_topics = @landing.landing_topics.ordered_for_landing
     @landing_options = @landing.landing_options.ordered_for_landing
 
-    @tracking_params = info_params.except(:slug)
-    @solicitation = Solicitation.new
+    @tracking_params = info_params
+    @solicitation = Solicitation.new(landing: @landing)
     @solicitation.form_info = info_params
   end
 
@@ -40,7 +40,7 @@ class LandingsController < PagesController
     end
 
     respond_to do |format|
-      format.html { redirect_to landing_path(@solicitation.slug, anchor: 'section-formulaire'), notice: t('.thanks') }
+      format.html { redirect_to landing_path(@solicitation.landing, anchor: 'section-formulaire'), notice: t('.thanks') }
       format.js
     end
   end
@@ -54,12 +54,16 @@ class LandingsController < PagesController
     end
   end
 
+  def show_params
+    params.permit(:slug, *Solicitation::FORM_INFO_KEYS)
+  end
+
   def info_params
-    params.permit(*Solicitation::FORM_INFO_KEYS)
+    show_params.slice(*Solicitation::FORM_INFO_KEYS)
   end
 
   def solicitation_params
     params.require(:solicitation)
-      .permit(:description, :siret, :full_name, :phone_number, :email, form_info: {}, options: {})
+      .permit(:description, :siret, :full_name, :phone_number, :email, :slug, form_info: {}, options: {})
   end
 end

--- a/app/models/landing.rb
+++ b/app/models/landing.rb
@@ -11,10 +11,16 @@
 #  created_at       :datetime         not null
 #  updated_at       :datetime         not null
 #
+# Indexes
+#
+#  index_landings_on_slug  (slug) UNIQUE
+#
 
 class Landing < ApplicationRecord
   has_many :landing_topics, inverse_of: :landing, :dependent => :destroy
   has_many :landing_options, inverse_of: :landing, :dependent => :destroy
+
+  has_many :solicitations, primary_key: :slug, foreign_key: :slug, inverse_of: :landing
 
   ## JSON Accessors
   #

--- a/app/models/solicitation.rb
+++ b/app/models/solicitation.rb
@@ -10,9 +10,14 @@
 #  options      :jsonb
 #  phone_number :string
 #  siret        :string
+#  slug         :string
 #  status       :integer          default("in_progress")
 #  created_at   :datetime         not null
 #  updated_at   :datetime         not null
+#
+# Indexes
+#
+#  index_solicitations_on_slug  (slug)
 #
 
 class Solicitation < ApplicationRecord
@@ -21,6 +26,7 @@ class Solicitation < ApplicationRecord
   ## Associations
   #
   has_many :diagnoses, inverse_of: :solicitation
+  belongs_to :landing, primary_key: :slug, foreign_key: :slug, inverse_of: :solicitations, optional: true
 
   ## Validations
   #

--- a/app/models/solicitation.rb
+++ b/app/models/solicitation.rb
@@ -38,12 +38,11 @@ class Solicitation < ApplicationRecord
   ## Scopes
   #
   scope :of_campaign, -> (campaign) { where("form_info->>'pk_campaign' = ?", campaign) }
-  scope :of_slug, -> (slug) { where("form_info->>'slug' = ?", slug) }
   scope :with_selected_option, -> (option) { where("options->>? = '1'", option) }
 
   ## JSON Accessors
   #
-  FORM_INFO_KEYS = %i[slug partner_token pk_campaign pk_kwd gclid]
+  FORM_INFO_KEYS = %i[partner_token pk_campaign pk_kwd gclid]
   store_accessor :form_info, FORM_INFO_KEYS.map(&:to_s)
 
   ## ActiveAdmin/Ransacker helpers

--- a/app/views/landings/_form.haml
+++ b/app/views/landings/_form.haml
@@ -3,6 +3,7 @@
   - if landing.form_top_message.present?
     %p= landing.form_top_message.html_safe
   = form_with(model: @solicitation, url: create_solicitation_path, scope: 'solicitation', method: :post, html: { honeypot: true }) do |f|
+    = f.hidden_field :slug
     - @solicitation.form_info.each do |k,v|
       = f.hidden_field "form_info[#{k}]", value: v
     - if landing_options.present?

--- a/db/migrate/20200323133834_add_slug_to_solicitation.rb
+++ b/db/migrate/20200323133834_add_slug_to_solicitation.rb
@@ -1,0 +1,18 @@
+class AddSlugToSolicitation < ActiveRecord::Migration[6.0]
+  def change
+    add_column :solicitations, :slug, :string
+
+    add_index :solicitations, :slug
+    add_index :landings, :slug, unique: true
+
+    # We can‘t add a foreign key: some landing slugs have been modified, can be removed, etc.
+    # after solicitations have been made.
+    # In fact, we don’t event want it.
+    # I’m keeping this line for future reference.
+    # add_foreign_key :solicitations, :landings, column: :slug, primary_key: :slug
+
+    up_only do
+      Solicitation.update_all("slug = form_info->>'slug'")
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_03_16_145816) do
+ActiveRecord::Schema.define(version: 2020_03_23_133834) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -236,6 +236,7 @@ ActiveRecord::Schema.define(version: 2020_03_16_145816) do
     t.string "home_title", default: "f"
     t.text "home_description", default: "f"
     t.integer "home_sort_order"
+    t.index ["slug"], name: "index_landings_on_slug", unique: true
   end
 
   create_table "matches", force: :cascade do |t|
@@ -289,6 +290,8 @@ ActiveRecord::Schema.define(version: 2020_03_16_145816) do
     t.string "siret"
     t.integer "status", default: 0
     t.string "full_name"
+    t.string "slug"
+    t.index ["slug"], name: "index_solicitations_on_slug"
   end
 
   create_table "subjects", id: :serial, force: :cascade do |t|


### PR DESCRIPTION
This is done in passing while adding validations to Solicitation. See next PRs :)

This uses the `slug` as the key for the association. The mais problem was to take the slug out of the `form_info` and make it a proper column; the rest is just using the proper options for `has_many` and `belongs_to`.

This also adds indexes for `slug`, which is always a good idea.

---

To be clear: the point is that we can write `solicitation.landing`, or `landing.solicitations` or `Solicitation.all.joins(:landing)`, etc.