### PR TITLE
Fix error "Can't find variable: checkboxes_require_one"

### DIFF
--- a/app/assets/javascripts/shared/checkboxes_require_one.js
+++ b/app/assets/javascripts/shared/checkboxes_require_one.js
@@ -1,16 +1,25 @@
-function checkboxes_require_one(selector, message) {
-  let boxes_parent = document.querySelector(selector);
+(function(){
+  addEventListener("turbolinks:load", setupCheckboxesGroups);
+  addEventListener("DOMContentLoaded", setupCheckboxesGroups);
 
-  function updateBoxesValidity() {
-    let at_least_one_checked = !!boxes_parent.querySelector("input[type=checkbox]:checked");
-    let validity = at_least_one_checked ? "" : message;
-    let boxes = boxes_parent.querySelectorAll("input[type=checkbox]");
-    for (let i = 0; i < boxes.length; ++i) {
-      boxes[i].setCustomValidity(validity);
-    }
+  const checkboxes_attribute = "data-checkboxes-require-one-with";
+  function setupCheckboxesGroups(event) {
+    var groups = document.querySelectorAll(`[${checkboxes_attribute}]:not([${checkboxes_attribute}=""])`);
+    for (var i = 0; i < groups.length; ++i) { checkboxesRequireOne(groups[i]); }
   }
 
-  boxes_parent.addEventListener("click", function(event) { if (event.target.matches("input[type=checkbox]")) { updateBoxesValidity(); } });
+  function checkboxesRequireOne(group) {
+    group.addEventListener("click", function (event) {
+      if (event.target.matches("input[type=checkbox]")) { updateCheckboxesValidity(group); }
+    });
 
-  updateBoxesValidity();
-}
+    updateCheckboxesValidity(group);
+  }
+
+  function updateCheckboxesValidity(group) {
+    var at_least_one_checked = !!group.querySelector("input[type=checkbox]:checked");
+    var validity = at_least_one_checked ? "" : group.attributes[checkboxes_attribute].value;
+    var boxes = group.querySelectorAll("input[type=checkbox]");
+    for (var i = 0; i < boxes.length; ++i) { boxes[i].setCustomValidity(validity); }
+  }
+})();

--- a/app/views/diagnoses/steps/selection.haml
+++ b/app/views/diagnoses/steps/selection.haml
@@ -7,7 +7,8 @@
     = t('.explanation')
 
   = form_with scope: :matches, url: selection_diagnosis_path(@diagnosis),
-             id: 'selection-form', class: 'ui form' do |f|
+             id: 'selection-form', class: 'ui form',
+             data: { checkboxes_require_one_with: t(".select_at_least_one_expert") } do |f|
     - @diagnosis.needs.ordered_for_interview.each do |need|
       .ui.segment.shadow-less
         %h3.ui.header= need.subject
@@ -48,5 +49,3 @@
           = t('.notify_matches')
 
     .clear
-    :javascript
-        checkboxes_require_one("#selection-form", "#{ t(".select_at_least_one_expert") }");

--- a/app/views/landings/_form.haml
+++ b/app/views/landings/_form.haml
@@ -7,7 +7,7 @@
     - @solicitation.form_info.each do |k,v|
       = f.hidden_field "form_info[#{k}]", value: v
     - if landing_options.present?
-      .form__group#solicitation-options
+      .form__group#solicitation-options{ data: { checkboxes_require_one_with: t(".select_at_least_one_option") } }
         = f.label :options, t('.select_options')
         .panel
           = f.fields_for :options do |fields|
@@ -16,8 +16,6 @@
                 = fields.check_box option.slug
                 = fields.label option.slug, class: 'label-inline' do
                   = option.description.html_safe
-        :javascript
-          checkboxes_require_one("#solicitation-options", "#{ t(".select_at_least_one_option") }");
     .form__group
       = f.label 'description', t('.description.label')
       - example = landing.description_example.presence || t('.description.default_example')


### PR DESCRIPTION
Who knew you couldn’t run code that was not loaded yet?

🙂 fixes PLACE-DES-ENTREPRISES-6G PLACE-DES-ENTREPRISES-68. (old Chrome and Firefoxes.
🙂This also fixes PLACE-DES-ENTREPRISES-6G, which is the same error but on old Safaris,
🙃 but it still on old Safaris doesn’t work because `setCustomValidity()` doesn’t seem to be supported on Safari 9 (neither is `required = true`). For this, I’m adding server-side validation and proper error reporting in a next PR.

Also, I’m relatively happy with the new selector-based activation: the script is automatically run for elements with the attribute `data-checkboxes-require-one-with`, and the message is also set in that attribute.