### PR TITLE
Garde les sessions utilisateur ouvertes plus longtemps

### DIFF
--- a/app/views/devise/sessions/new.html.haml
+++ b/app/views/devise/sessions/new.html.haml
@@ -11,7 +11,6 @@
     - if devise_mapping.rememberable?
       .field
         .ui.checkbox
-          = f.check_box :remember_me, tabindex: 0, class: 'hidden'
           = f.label :remember_me
     .actions
       = f.submit t('sign_in'), class: 'ui button green'

--- a/app/views/devise/sessions/new.html.haml
+++ b/app/views/devise/sessions/new.html.haml
@@ -11,6 +11,7 @@
     - if devise_mapping.rememberable?
       .field
         .ui.checkbox
+          = f.check_box :remember_me, checked: true, class: 'hidden'
           = f.label :remember_me
     .actions
       = f.submit t('sign_in'), class: 'ui button green'

--- a/config/initializers/devise.rb
+++ b/config/initializers/devise.rb
@@ -166,7 +166,7 @@ Devise.setup do |config|
 
   # ==> Configuration for :rememberable
   # The time the user will be remembered without asking for credentials again.
-  # config.remember_for = 2.weeks
+  config.remember_for = 2.years
 
   # Invalidates all the remember me tokens when the user signs out.
   config.expire_all_remember_me_on_sign_out = true


### PR DESCRIPTION
On n’a pas de vraiment bonne raison de limiter les sessions à deux semaines; pour une bonne partie des référents qui ne vient pas souvent, ça annule complètement l’effet de “se souvenir de moi”. Au passage, autant précocher cette option à la connexion.