### PR TITLE
Make /feedbacks#create work without js

### DIFF
--- a/app/controllers/feedbacks_controller.rb
+++ b/app/controllers/feedbacks_controller.rb
@@ -7,6 +7,11 @@ class FeedbacksController < ApplicationController
       flash.alert = @feedback.errors.full_messages.to_sentence
       redirect_back(fallback_location: root_path)
     end
+
+    respond_to do |format|
+      format.js
+      format.html { redirect_to need_path(@feedback.need.diagnosis, anchor: "feedback-#{@feedback.id}") }
+    end
   end
 
   def destroy


### PR DESCRIPTION
This is the same as #933, but for feedbacks creations 

We have users with IE11 on Windows 7 without javascript 🎉

PLACE-DES-ENTREPRISES-57

This does _not_ make the destroy link work, as this is a method: :delete link backed by rails-ujs.