### PR TITLE
Fix error display in diagnosis steps in solicitation is invalid

### DIFF
--- a/app/models/solicitation.rb
+++ b/app/models/solicitation.rb
@@ -116,7 +116,7 @@ class Solicitation < ApplicationRecord
   ## Validations
   #
   def validate_selected_options
-    if landing&.landing_options.present? && selected_options.empty?
+    if options.present? && selected_options.empty?
       errors.add(:options, :blank)
     end
   end

--- a/config/locales/models.fr.yml
+++ b/config/locales/models.fr.yml
@@ -176,7 +176,7 @@ fr:
         options: Aides demandées
         pk_campaign: Campagne
         pk_kwd: Mots-clés
-        selected_options: Aides demandées
+        selected_options: Aides sélectionnées
         slug: Page thématique
         tracking: Suivi
       solicitation/statuses:

--- a/spec/models/solicitation_spec.rb
+++ b/spec/models/solicitation_spec.rb
@@ -17,32 +17,27 @@ RSpec.describe Solicitation, type: :model do
 
   describe 'custom validations' do
     describe 'validate_selected_options' do
-      subject(:solicitation) { build :solicitation, landing: landing, options: options }
+      subject(:solicitation) { build :solicitation, options: options }
 
       before { solicitation.validate }
 
-      context 'no option in landing' do
-        let(:landing) { build :landing }
+      context 'no option' do
         let(:options) { {} }
 
         it { is_expected.to be_valid }
       end
 
-      context 'with options in landing' do
-        let(:landing) { build :landing, :with_options }
+      context 'with a chosen option' do
+        let(:options) { { first_option: 1, second_option: 0 } }
 
-        context 'with a chosen option' do
-          let(:options) { { landing.landing_options.first => '0', landing.landing_options.last => '1' } }
+        it { is_expected.to be_valid }
+      end
 
-          it { is_expected.to be_valid }
-        end
+      context 'with no chosen option' do
+        let(:options) { { first_option: 0, second_option: 0 } }
 
-        context 'with no chosen option' do
-          let(:options) { { landing.landing_options.first => '0', landing.landing_options.last => '0' } }
-
-          it { is_expected.not_to be_valid }
-          it { expect(solicitation.errors.details).to eq({ options: [{ error: :blank }] }) }
-        end
+        it { is_expected.not_to be_valid }
+        it { expect(solicitation.errors.details).to eq({ options: [{ error: :blank }] }) }
       end
     end
   end


### PR DESCRIPTION
refs #958. PLACE-DES-ENTREPRISES-71

* The issue was not with the flash, but with the error being an uncatched exception.
(I’m still not quite happy with this section of the app, but it’s one less bug.)
* Also, be slightly less strict when validating selected options in solicitations. If the landing options change after the solicitation is made, we don’t want the solicitation to suddenly become invalid.
