### PR TITLE
Améliorations des relations Solicitations-LandingOptions

### DIFF
--- a/app/admin/solicitation.rb
+++ b/app/admin/solicitation.rb
@@ -62,8 +62,6 @@ ActiveAdmin.register Solicitation do
   remove_filter :diagnoses
   filter :landing_slug
   filter :status, as: :select, collection: -> { Solicitation.statuses.map { |status, value| [Solicitation.human_attribute_name("statuses.#{status}"), value] } }
-  remove_filter :with_selected_option
-  filter :with_selected_option_in, as: :select, label: I18n.t('solicitations.solicitation.selected_options'), collection: -> { LandingOption.all.pluck(:slug) }
 
   ## Batch actions
   # Statuses

--- a/app/admin/solicitation.rb
+++ b/app/admin/solicitation.rb
@@ -89,6 +89,10 @@ ActiveAdmin.register Solicitation do
     column :options do |s|
       s.landing_options_slugs.join("\n")
     end
+    Solicitation.all_past_landing_options_slugs.each do |landing|
+      column landing do |s|
+        s.landing_options_slugs.include?(landing) ? I18n.t('yes') : ''
+      end
     end
     Solicitation::FORM_INFO_KEYS.each{ |k| column k }
   end

--- a/app/admin/solicitation.rb
+++ b/app/admin/solicitation.rb
@@ -90,11 +90,11 @@ ActiveAdmin.register Solicitation do
       s.landing_options_slugs.join("\n")
     end
     Solicitation.all_past_landing_options_slugs.each do |landing|
-      column landing do |s|
+      column landing, humanize_name: false do |s|
         s.landing_options_slugs.include?(landing) ? I18n.t('yes') : ''
       end
     end
-    Solicitation::FORM_INFO_KEYS.each{ |k| column k }
+    Solicitation::FORM_INFO_KEYS.each{ |k| column k, humanize_name: false }
   end
 
   ## Show

--- a/app/admin/solicitation.rb
+++ b/app/admin/solicitation.rb
@@ -17,11 +17,11 @@ ActiveAdmin.register Solicitation do
       end
     end
     column :description do |s|
-      div(admin_link_to(s.landing) || s.slug)
-      options = s.selected_options
-      if options.present?
-        div t('activerecord.attributes.solicitation.selected_options') + ' : ' do
-          options.each { |option| status_tag option }.join('')
+      div(admin_link_to(s.landing) || s.landing_slug)
+      options_slugs = s.landing_options_slugs
+      if options_slugs.present?
+        div t('activerecord.attributes.solicitation.landing_options') + ' : ' do
+          options_slugs.each { |option| div status_tag option }.join
         end
       end
       blockquote simple_format(s.description&.truncate(20000, separator: ' '))
@@ -60,7 +60,7 @@ ActiveAdmin.register Solicitation do
   #
   preserve_default_filters!
   remove_filter :diagnoses
-  filter :slug
+  filter :landing_slug
   filter :status, as: :select, collection: -> { Solicitation.statuses.map { |status, value| [Solicitation.human_attribute_name("statuses.#{status}"), value] } }
   remove_filter :with_selected_option
   filter :with_selected_option_in, as: :select, label: I18n.t('solicitations.solicitation.selected_options'), collection: -> { LandingOption.all.pluck(:slug) }
@@ -88,8 +88,9 @@ ActiveAdmin.register Solicitation do
     column :full_name
     column :phone_number
     column :email
-    column :selected_options do |s|
-      s.selected_options.join("\n")
+    column :options do |s|
+      s.landing_options_slugs.join("\n")
+    end
     end
     Solicitation::FORM_INFO_KEYS.each{ |k| column k }
   end
@@ -98,7 +99,7 @@ ActiveAdmin.register Solicitation do
   #
   show title: :to_s do
     panel I18n.t('attributes.description') do
-      div(admin_link_to(solicitation.landing) || solicitation.slug)
+      div(admin_link_to(solicitation.landing) || solicitation.landing_slug)
       blockquote simple_format(solicitation.description)
     end
 

--- a/app/models/landing.rb
+++ b/app/models/landing.rb
@@ -17,10 +17,17 @@
 #
 
 class Landing < ApplicationRecord
+  ## Associations
+  #
   has_many :landing_topics, inverse_of: :landing, :dependent => :destroy
   has_many :landing_options, inverse_of: :landing, :dependent => :destroy
 
   has_many :solicitations, primary_key: :slug, foreign_key: :slug, inverse_of: :landing
+  accepts_nested_attributes_for :landing_topics, :landing_options, allow_destroy: true
+
+  ## Scopes
+  #
+  scope :ordered_for_home, -> { where.not(home_sort_order: nil).order(:home_sort_order) }
 
   ## JSON Accessors
   #
@@ -33,10 +40,6 @@ class Landing < ApplicationRecord
     form_promise_message thank_you_message
   ]
   store_accessor :content, CONTENT_KEYS
-
-  accepts_nested_attributes_for :landing_topics, :landing_options, allow_destroy: true
-
-  scope :ordered_for_home, -> { where.not(home_sort_order: nil).order(:home_sort_order) }
 
   def to_s
     slug

--- a/app/models/landing.rb
+++ b/app/models/landing.rb
@@ -22,7 +22,7 @@ class Landing < ApplicationRecord
   has_many :landing_topics, inverse_of: :landing, :dependent => :destroy
   has_many :landing_options, inverse_of: :landing, :dependent => :destroy
 
-  has_many :solicitations, primary_key: :slug, foreign_key: :slug, inverse_of: :landing
+  has_many :solicitations, primary_key: :slug, foreign_key: :landing_slug, inverse_of: :landing
   accepts_nested_attributes_for :landing_topics, :landing_options, allow_destroy: true
 
   ## Scopes

--- a/app/models/landing_option.rb
+++ b/app/models/landing_option.rb
@@ -5,7 +5,8 @@
 #  id                 :bigint(8)        not null, primary key
 #  description        :text
 #  landing_sort_order :integer
-#  slug               :string
+#  slug               :string           not null
+#  title              :string
 #  landing_id         :bigint(8)
 #
 # Indexes

--- a/app/models/landing_option.rb
+++ b/app/models/landing_option.rb
@@ -19,7 +19,11 @@
 #
 
 class LandingOption < ApplicationRecord
+  ## Associations
+  #
   belongs_to :landing, inverse_of: :landing_options, touch: true
 
+  ## Scopes
+  #
   scope :ordered_for_landing, -> { order(:landing_sort_order, :id) }
 end

--- a/app/models/solicitation.rb
+++ b/app/models/solicitation.rb
@@ -88,6 +88,10 @@ class Solicitation < ApplicationRecord
     self.landing_options_slugs = options_hash.select{ |_, v| v.to_bool }.keys
   end
 
+  def self.all_past_landing_options_slugs
+    self.distinct.pluck("unnest(#{:landing_options_slugs})")
+  end
+
   ##
   #
   def institution

--- a/app/models/solicitation.rb
+++ b/app/models/solicitation.rb
@@ -116,7 +116,7 @@ class Solicitation < ApplicationRecord
   ## Validations
   #
   def validate_selected_options
-    if options.present? && selected_options.empty?
+    if landing&.landing_options.present? && selected_options.empty?
       errors.add(:options, :blank)
     end
   end

--- a/app/models/solicitation.rb
+++ b/app/models/solicitation.rb
@@ -37,6 +37,11 @@ class Solicitation < ApplicationRecord
   validates :email, format: { with: Devise.email_regexp }
 
   def validate_landing_options_on_create
+    # landing can not be nil on creation
+    # later, landing_slug can refer to a removed Landing
+    if landing.nil?
+      errors.add(:landing, :blank)
+    end
     # if the landing has options, landing_options should refer to existing options on creation
     # later, landing_options_slugs may refer to removed LandingOptions
     if landing&.landing_options.present? && landing_options.empty?

--- a/app/models/solicitation.rb
+++ b/app/models/solicitation.rb
@@ -2,22 +2,23 @@
 #
 # Table name: solicitations
 #
-#  id           :bigint(8)        not null, primary key
-#  description  :string
-#  email        :string
-#  form_info    :jsonb
-#  full_name    :string
-#  options      :jsonb
-#  phone_number :string
-#  siret        :string
-#  slug         :string
-#  status       :integer          default("in_progress")
-#  created_at   :datetime         not null
-#  updated_at   :datetime         not null
+#  id                    :bigint(8)        not null, primary key
+#  description           :string
+#  email                 :string
+#  form_info             :jsonb
+#  full_name             :string
+#  landing_options_slugs :string           is an Array
+#  landing_slug          :string           not null
+#  options_deprecated    :jsonb
+#  phone_number          :string
+#  siret                 :string
+#  status                :integer          default("in_progress")
+#  created_at            :datetime         not null
+#  updated_at            :datetime         not null
 #
 # Indexes
 #
-#  index_solicitations_on_slug  (slug)
+#  index_solicitations_on_landing_slug  (landing_slug)
 #
 
 class Solicitation < ApplicationRecord
@@ -25,21 +26,27 @@ class Solicitation < ApplicationRecord
 
   ## Associations
   #
+  belongs_to :landing, primary_key: :slug, foreign_key: :landing_slug, inverse_of: :solicitations, optional: true
   has_many :diagnoses, inverse_of: :solicitation
-  belongs_to :landing, primary_key: :slug, foreign_key: :slug, inverse_of: :solicitations, optional: true
   has_and_belongs_to_many :badges, -> { distinct }
 
   ## Validations
   #
-  validates :slug, :description, :full_name, :phone_number, :email, presence: true, allow_blank: false
-  validate :validate_selected_options
+  validates :landing_slug, :description, :full_name, :phone_number, :email, presence: true, allow_blank: false
+  validate :validate_landing_options_on_create, on: :create
   validates :email, format: { with: Devise.email_regexp }
 
+  def validate_landing_options_on_create
+    # if the landing has options, landing_options should refer to existing options on creation
+    # later, landing_options_slugs may refer to removed LandingOptions
+    if landing&.landing_options.present? && landing_options.empty?
+      errors.add(:landing_options, :blank)
+    end
+  end
 
   ## Scopes
   #
   scope :of_campaign, -> (campaign) { where("form_info->>'pk_campaign' = ?", campaign) }
-  scope :with_selected_option, -> (option) { where("options->>? = '1'", option) }
 
   ## JSON Accessors
   #
@@ -74,14 +81,24 @@ class Solicitation < ApplicationRecord
     record
   end
 
+  ## Options
+  # I would love to use a has_many relation, but Rails doesn’t (yet?) support backing relations with postgresql arrays.
+  def landing_options=(landing_options)
+    self.landing_options_slugs = landing_options.pluck(:slug)
+  end
+
+  def landing_options
+    LandingOption.where(slug: landing_options_slugs)
+  end
+
+  def options=(options_hash) # Support for old-style solicitation form. TODO: Remove this
+    self.landing_options_slugs = options_hash.select{ |_, v| v.to_bool }.keys
+  end
+
   ##
   #
   def institution
     Institution.find_by(partner_token: partner_token) if partner_token.present?
-  end
-
-  def selected_options
-    options.select{ |_, v| v.to_bool }.keys
   end
 
   def normalized_phone_number
@@ -109,13 +126,5 @@ class Solicitation < ApplicationRecord
   #
   def allowed_new_statuses
     self.class.statuses.keys - [self.status]
-  end
-
-  ## Validations
-  #
-  def validate_selected_options
-    if landing&.landing_options.present? && selected_options.empty?
-      errors.add(:options, :blank)
-    end
   end
 end

--- a/app/models/solicitation.rb
+++ b/app/models/solicitation.rb
@@ -88,8 +88,12 @@ class Solicitation < ApplicationRecord
     self.landing_options_slugs = options_hash.select{ |_, v| v.to_bool }.keys
   end
 
+  # * Retrieve all the landing options slugs used in the past;
+  #   LandingOptions may have been removed, but the slug remains here.
+  # * :landing_options_slugs is a postgresql array; we could use unnest() to flatten it
+  #   but let’s keep it easier to understand. It’s not performance-critical.
   def self.all_past_landing_options_slugs
-    self.distinct.pluck("unnest(#{:landing_options_slugs})")
+    self.pluck(:landing_options_slugs).flatten.uniq
   end
 
   ##

--- a/app/models/solicitation.rb
+++ b/app/models/solicitation.rb
@@ -53,18 +53,6 @@ class Solicitation < ApplicationRecord
   FORM_INFO_KEYS = %i[partner_token pk_campaign pk_kwd gclid]
   store_accessor :form_info, FORM_INFO_KEYS.map(&:to_s)
 
-  ## ActiveAdmin/Ransacker helpers
-  #
-  FORM_INFO_KEYS.each do |key|
-    ransacker key do |parent|
-      Arel::Nodes::InfixOperation.new('->>', parent.table[:form_info], Arel::Nodes.build_quoted(key.to_s))
-    end
-  end
-  ransacker(:with_selected_option, formatter: -> (value) {
-    with_selected_option(value).pluck(:id)
-      .presence
-  }) { |parent| parent.table[:id] }
-
   ##
   # Development helper
   def self.new(attributes = nil, &block)

--- a/app/models/solicitation.rb
+++ b/app/models/solicitation.rb
@@ -35,8 +35,6 @@ class Solicitation < ApplicationRecord
   validate :validate_selected_options
   validates :email, format: { with: Devise.email_regexp }
 
-  ## “Through” Associations
-  #
 
   ## Scopes
   #

--- a/app/views/landings/_show_solicitation_form.html.haml
+++ b/app/views/landings/_show_solicitation_form.html.haml
@@ -14,7 +14,7 @@
           - landing_options.each do |option|
             .p
               = fields.check_box option.slug
-              = fields.label option.slug, class: 'label-inline' do
+              = fields.label option.slug, option.title, class: 'label-inline' do
                 = option.description.html_safe
       .notification.error= solicitation.errors.full_messages_for(:options).to_sentence
   .form__group

--- a/app/views/solicitations/_solicitation.haml
+++ b/app/views/solicitations/_solicitation.haml
@@ -27,14 +27,14 @@
           .item
             %strong= Solicitation.human_attribute_name(attribut) + ' : '
             = solicitation.send(attribut)
-      - if solicitation.slug.present?
+      - if solicitation.landing_slug.present?
         .item
           %strong= t('.slug')
-          = link_to(solicitation.slug, landing_path(solicitation.slug))
-      - if solicitation.selected_options.present?
+          = link_to(solicitation.landing_slug, solicitation.landing)
+      - if solicitation.landing_options_slugs.present?
         .item
-          %strong= t('.selected_options')
-          - solicitation.selected_options.each do |option|
+          %strong= t('.landing_options')
+          - solicitation.landing_options_slugs.each do |option|
             .ui.small.label= option
       .item
         %strong= t('.description')

--- a/config/locales/models.fr.yml
+++ b/config/locales/models.fr.yml
@@ -176,7 +176,7 @@ fr:
         options: Aides demandées
         pk_campaign: Campagne
         pk_kwd: Mots-clés
-        selected_options: Aides sélectionnées
+        selected_options: Aides demandées
         slug: Page thématique
         tracking: Suivi
       solicitation/statuses:

--- a/config/locales/models.fr.yml
+++ b/config/locales/models.fr.yml
@@ -171,12 +171,11 @@ fr:
         query: Requête
         user: Utilisateur
       solicitation:
+        landing_options: Aides demandées
         needs: Besoins sélectionnés
         normalized_phone_number: Téléphone
-        options: Aides demandées
         pk_campaign: Campagne
         pk_kwd: Mots-clés
-        selected_options: Aides demandées
         slug: Page thématique
         tracking: Suivi
       solicitation/statuses:

--- a/config/locales/views.fr.yml
+++ b/config/locales/views.fr.yml
@@ -526,7 +526,7 @@ fr:
       create_diagnosis: Démarrer une analyse
       description: 'Description :'
       email: 'Email :'
-      selected_options: 'Cases cochées :'
+      landing_options: 'Aides demandées :'
       siret: 'Siret :'
       slug: 'Page thématique :'
     solicitations_tabs:

--- a/db/migrate/20200331125244_change_landing_option_slug_to_title.rb
+++ b/db/migrate/20200331125244_change_landing_option_slug_to_title.rb
@@ -1,0 +1,14 @@
+class ChangeLandingOptionSlugToTitle < ActiveRecord::Migration[6.0]
+  def change
+    rename_column :landing_options, :slug, :title
+    add_column :landing_options, :slug, :string
+
+    up_only do
+      LandingOption.all.each do |option|
+        option.update(slug: option.title.parameterize.underscore)
+      end
+    end
+
+    change_column_null :landing_options, :slug, false
+  end
+end

--- a/db/migrate/20200331132751_change_solicitation_selected_options.rb
+++ b/db/migrate/20200331132751_change_solicitation_selected_options.rb
@@ -1,0 +1,15 @@
+class ChangeSolicitationSelectedOptions < ActiveRecord::Migration[6.0]
+  def change
+    rename_column :solicitations, :slug, :landing_slug
+    change_column_null :solicitations, :landing_slug, false
+
+    add_column :solicitations, :landing_options_slugs, :string, array: true
+    rename_column :solicitations, :options, :options_deprecated
+
+    up_only do
+      Solicitation.find_each do |s|
+        s.update(landing_options_slugs: s.options_deprecated.select{ |_, v| v.to_bool }.keys.map{ |o| o.parameterize.underscore })
+      end
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_03_24_095649) do
+ActiveRecord::Schema.define(version: 2020_03_31_125244) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -223,10 +223,11 @@ ActiveRecord::Schema.define(version: 2020_03_24_095649) do
   end
 
   create_table "landing_options", force: :cascade do |t|
-    t.string "slug"
+    t.string "title"
     t.text "description"
     t.integer "landing_sort_order"
     t.bigint "landing_id"
+    t.string "slug", null: false
     t.index ["landing_id"], name: "index_landing_options_on_landing_id"
   end
 

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_03_31_125244) do
+ActiveRecord::Schema.define(version: 2020_03_31_132751) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -296,15 +296,16 @@ ActiveRecord::Schema.define(version: 2020_03_31_125244) do
     t.string "description"
     t.string "email"
     t.string "phone_number"
-    t.jsonb "options", default: {}
+    t.jsonb "options_deprecated", default: {}
     t.jsonb "form_info", default: {}
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.string "siret"
     t.integer "status", default: 0
     t.string "full_name"
-    t.string "slug"
-    t.index ["slug"], name: "index_solicitations_on_slug"
+    t.string "landing_slug", null: false
+    t.string "landing_options_slugs", array: true
+    t.index ["landing_slug"], name: "index_solicitations_on_landing_slug"
   end
 
   create_table "subjects", id: :serial, force: :cascade do |t|

--- a/spec/features/new_solicitation_feature_spec.rb
+++ b/spec/features/new_solicitation_feature_spec.rb
@@ -25,7 +25,7 @@ describe 'New Solicitation Feature', type: :feature, js: true do
 
     it do
       expect(page).to have_content('Merci')
-      expect(solicitation.slug).to eq 'test-landing'
+      expect(solicitation.landing_slug).to eq 'test-landing'
       expect(solicitation.siret).to eq '123 456 789 00010'
       expect(solicitation.pk_campaign).to eq 'FOO'
       expect(solicitation.pk_kwd).to eq 'BAR'

--- a/spec/models/solicitation_spec.rb
+++ b/spec/models/solicitation_spec.rb
@@ -17,27 +17,32 @@ RSpec.describe Solicitation, type: :model do
 
   describe 'custom validations' do
     describe 'validate_selected_options' do
-      subject(:solicitation) { build :solicitation, options: options }
+      subject(:solicitation) { build :solicitation, landing: landing, options: options }
 
       before { solicitation.validate }
 
-      context 'no option' do
+      context 'no option in landing' do
+        let(:landing) { build :landing }
         let(:options) { {} }
 
         it { is_expected.to be_valid }
       end
 
-      context 'with a chosen option' do
-        let(:options) { { first_option: 1, second_option: 0 } }
+      context 'with options in landing' do
+        let(:landing) { build :landing, :with_options }
 
-        it { is_expected.to be_valid }
-      end
+        context 'with a chosen option' do
+          let(:options) { { landing.landing_options.first => '0', landing.landing_options.last => '1' } }
 
-      context 'with no chosen option' do
-        let(:options) { { first_option: 0, second_option: 0 } }
+          it { is_expected.to be_valid }
+        end
 
-        it { is_expected.not_to be_valid }
-        it { expect(solicitation.errors.details).to eq({ options: [{ error: :blank }] }) }
+        context 'with no chosen option' do
+          let(:options) { { landing.landing_options.first => '0', landing.landing_options.last => '0' } }
+
+          it { is_expected.not_to be_valid }
+          it { expect(solicitation.errors.details).to eq({ options: [{ error: :blank }] }) }
+        end
       end
     end
   end

--- a/spec/models/solicitation_spec.rb
+++ b/spec/models/solicitation_spec.rb
@@ -8,7 +8,7 @@ RSpec.describe Solicitation, type: :model do
   end
 
   describe 'validations' do
-    it { is_expected.to validate_presence_of :slug }
+    it { is_expected.to validate_presence_of :landing_slug }
     it { is_expected.to validate_presence_of :description }
     it { is_expected.to validate_presence_of :full_name }
     it { is_expected.to validate_presence_of :phone_number }
@@ -16,32 +16,32 @@ RSpec.describe Solicitation, type: :model do
   end
 
   describe 'custom validations' do
-    describe 'validate_selected_options' do
-      subject(:solicitation) { build :solicitation, landing: landing, options: options }
+    describe 'validate_landing_options_on_create' do
+      subject(:solicitation) { build :solicitation, landing: landing, landing_options: options }
 
       before { solicitation.validate }
 
       context 'no option in landing' do
-        let(:landing) { build :landing }
-        let(:options) { {} }
+        let(:landing) { create :landing }
+        let(:options) { [] }
 
         it { is_expected.to be_valid }
       end
 
       context 'with options in landing' do
-        let(:landing) { build :landing, :with_options }
+        let(:landing) { create :landing, :with_options }
 
         context 'with a chosen option' do
-          let(:options) { { landing.landing_options.first => '0', landing.landing_options.last => '1' } }
+          let(:options) { [landing.landing_options.first] }
 
           it { is_expected.to be_valid }
         end
 
         context 'with no chosen option' do
-          let(:options) { { landing.landing_options.first => '0', landing.landing_options.last => '0' } }
+          let(:options) { [] }
 
           it { is_expected.not_to be_valid }
-          it { expect(solicitation.errors.details).to eq({ options: [{ error: :blank }] }) }
+          it { expect(solicitation.errors.details).to eq({ landing_options: [{ error: :blank }] }) }
         end
       end
     end


### PR DESCRIPTION
Preparation for #940, but il will also help for #949. First item of #952, as well.

* Make proper slugs and titles for LandingOptions 
  * move the current slug to title, and a parameterized version of it to slug
  * make the slug nonnull
* Use an array of selected options slugs instead of a hash
  * Deprecate solicitations.options (to options_deprecated)
  * Move the chosen keys to the new array
  * Also rename solicitations.slug to landing_slug and make it nonnull
* Revert 536d6fdba9c6e59d6a749bf537fb02e74babec68 Tweak selected options validation in solicitation. 
* Validate Solicitation.landing actually exists on create
* Add a column per landing slug in the solicitations csv (#952)

--- 
Can I say I enjoy using a postgresql array of slugs to define a has_many relation?