### PR TITLE
Use the session cookie for form_info

### DIFF
--- a/app/views/landings/_index_landing_card.html.haml
+++ b/app/views/landings/_index_landing_card.html.haml
@@ -1,5 +1,5 @@
 .card{ class: (landing.emphasis.to_bool ? 'emphasis' : '') }
-  - path = landing_path({ slug: landing.slug }.merge(tracking_params))
+  - path = landing_path({ slug: landing.slug })
   = link_to path do
     .card__content
       %h3.landing-title= simple_format(landing.home_title, {}, wrapper_tag: 'span')

--- a/app/views/landings/_index_landing_cards.html.haml
+++ b/app/views/landings/_index_landing_cards.html.haml
@@ -1,8 +1,8 @@
 %h2.section__title= t('.title')
 - landings.each_slice(3) do |landings_slice|
   .row
-    = render partial: 'index_landing_card', collection: landings_slice, as: :landing, locals: { tracking_params: tracking_params }
+    = render partial: 'index_landing_card', collection: landings_slice, as: :landing
 
 %p.text-center.white-on-dark
   = t('.other_questions')
-  = link_to t('.contact_us'), landing_path({ slug: 'contactez-nous' }.merge(tracking_params))
+  = link_to t('.contact_us'), landing_path({ slug: 'contactez-nous' })

--- a/app/views/landings/_show_solicitation_form.html.haml
+++ b/app/views/landings/_show_solicitation_form.html.haml
@@ -2,8 +2,6 @@
 - if landing.form_top_message.present?
   %p= landing.form_top_message.html_safe
 = form_with(model: solicitation, url: create_solicitation_landing_path(anchor: 'section-formulaire'), local: true, html: { honeypot: true }) do |f|
-  - solicitation.form_info.each do |k,v|
-    = f.hidden_field "form_info[#{k}]", value: v
   - if solicitation.errors.present?
     :javascript
       _paq.push(['trackEvent', 'contact-entreprise', 'failure']);

--- a/app/views/landings/index.haml
+++ b/app/views/landings/index.haml
@@ -15,7 +15,7 @@
 
 %section.section.section-color#section-thematiques
   .container
-    = render 'index_landing_cards', landings: @landings, tracking_params: @tracking_params
+    = render 'index_landing_cards', landings: @landings
 
 %section.section.section-grey#section-testimonials
   .container

--- a/spec/features/new_solicitation_feature_spec.rb
+++ b/spec/features/new_solicitation_feature_spec.rb
@@ -5,12 +5,15 @@ require 'rails_helper'
 describe 'New Solicitation Feature', type: :feature, js: true do
   before do
     Rails.cache.clear
-    create :landing, slug: 'landing'
+    create :landing, slug: 'test-landing', home_sort_order: 0, home_title: 'Test Landing'
   end
 
   describe 'post solicitation' do
+    let(:solicitation) { Solicitation.last }
+
     before do
-      visit '/entreprise/landing'
+      visit '/?pk_campaign=FOO&pk_kwd=BAR'
+      click_link 'Test Landing'
 
       fill_in 'Description', with: 'Ceci est un test'
       fill_in 'SIRET', with: '123 456 789 00010'
@@ -20,6 +23,12 @@ describe 'New Solicitation Feature', type: :feature, js: true do
       click_button 'Envoyer ma demande'
     end
 
-    it { expect(page).to have_content('Merci') }
+    it do
+      expect(page).to have_content('Merci')
+      expect(solicitation.slug).to eq 'test-landing'
+      expect(solicitation.siret).to eq '123 456 789 00010'
+      expect(solicitation.pk_campaign).to eq 'FOO'
+      expect(solicitation.pk_kwd).to eq 'BAR'
+    end
   end
 end


### PR DESCRIPTION
* Store form info and campaign params in the session cookie, instead of polluting the url with it. It also turns out to be simpler to manage.
* Improve New Solicitation Feature spec to actually check that the solicitation params (including the tracking params) are saved.

(This helps for #939)