### PR TITLE
bump rspec-rails gem

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -80,7 +80,7 @@ group :development, :test do
   gem 'byebug', platform: :mri # Call 'byebug' anywhere in the code to stop execution and get a debugger console
   gem 'factory_bot_rails'
   gem 'faker'
-  gem 'rspec-rails', git: 'https://github.com/rspec/rspec-rails', branch: '4-0-maintenance'
+  gem 'rspec-rails'
   gem 'rspec_junit_formatter', require: false
 end
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,17 +1,3 @@
-GIT
-  remote: https://github.com/rspec/rspec-rails
-  revision: ece734db4f387122a091425ece0d6d094e6439e2
-  branch: 4-0-maintenance
-  specs:
-    rspec-rails (4.0.0.beta4)
-      actionpack (>= 4.2)
-      activesupport (>= 4.2)
-      railties (>= 4.2)
-      rspec-core (~> 3.9)
-      rspec-expectations (~> 3.9)
-      rspec-mocks (~> 3.9)
-      rspec-support (~> 3.9)
-
 GEM
   remote: https://rubygems.org/
   specs:
@@ -398,12 +384,20 @@ GEM
       netrc (~> 0.8)
     rspec-core (3.9.1)
       rspec-support (~> 3.9.1)
-    rspec-expectations (3.9.0)
+    rspec-expectations (3.9.1)
       diff-lcs (>= 1.2.0, < 2.0)
       rspec-support (~> 3.9.0)
     rspec-mocks (3.9.1)
       diff-lcs (>= 1.2.0, < 2.0)
       rspec-support (~> 3.9.0)
+    rspec-rails (4.0.0)
+      actionpack (>= 4.2)
+      activesupport (>= 4.2)
+      railties (>= 4.2)
+      rspec-core (~> 3.9)
+      rspec-expectations (~> 3.9)
+      rspec-mocks (~> 3.9)
+      rspec-support (~> 3.9)
     rspec-support (3.9.2)
     rspec_junit_formatter (0.4.1)
       rspec-core (>= 2, < 4, != 2.12.0)
@@ -554,7 +548,7 @@ DEPENDENCIES
   rails-controller-testing
   rails-i18n
   rails_real_favicon
-  rspec-rails!
+  rspec-rails
   rspec_junit_formatter
   rubocop
   rubocop-faker


### PR DESCRIPTION
Don’t really bump it: rspec-rails 4 has been released, we don’t need to reference the branch explicitely anymore. (We need rspec-rails 4 for rails 6)