### PR TITLE
Bump the parser gem after ruby upgrade to 2.6.6

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -304,7 +304,7 @@ GEM
       mini_portile2 (~> 2.4.0)
     orm_adapter (0.5.0)
     parallel (1.19.1)
-    parser (2.7.0.2)
+    parser (2.7.1.0)
       ast (~> 2.4.0)
     pg (1.2.2)
     polyamorous (2.3.2)


### PR DESCRIPTION
followup #985

This fixes this warning in the console:

warning: parser/current is loading parser/ruby26, which recognizes
warning: 2.6.5-compliant syntax, but you are running 2.6.6.
warning: please see https://github.com/whitequark/parser#compatibility-with-ruby-mri.

(This has no consequences, apart from being annoying)