### PR TITLE
Avoid crashing when encountering baddata in Experts

### DIFF
--- a/app/admin/expert.rb
+++ b/app/admin/expert.rb
@@ -23,8 +23,8 @@ ActiveAdmin.register Expert do
     column(:full_name) do |e|
       div admin_link_to(e)
       div '➜ ' + e.role
-      div '✉ ' + e.email
-      div '✆ ' + e.phone_number
+      div '✉ ' + (e.email || '')
+      div '✆ ' + (e.phone_number || '')
     end
     column(:institution) do |e|
       div admin_link_to(e, :institution)


### PR DESCRIPTION
refs #991; apparently we don’t have bad data in production, but it happens in local. (yet?)