### PR TITLE
Avoid crashing in solicitation csv export when no options are selected

### DIFF
--- a/app/admin/solicitation.rb
+++ b/app/admin/solicitation.rb
@@ -87,7 +87,7 @@ ActiveAdmin.register Solicitation do
     column :phone_number
     column :email
     column :options do |s|
-      s.landing_options_slugs.join("\n")
+      s.landing_options_slugs&.join("\n")
     end
     Solicitation.all_past_landing_options_slugs.each do |landing|
       column landing, humanize_name: false do |s|


### PR DESCRIPTION
It’s possible for landing_options_slugs to be nil (not just empty), and it happens if the landing has no options.