### PR TITLE
Correction des menus déroulants dans la barre de navigation

### DIFF
--- a/app/assets/javascripts/application/semantic-ui.js
+++ b/app/assets/javascripts/application/semantic-ui.js
@@ -2,7 +2,7 @@ addEventListener('turbolinks:load', function(event) {
   $('.ui.modal').modal( { closable: false }).modal('show'); // Show modal before activating other elements that may be inside the modal
   $('.popup-hover').popup({ hoverable: true });
   $('select.ui.selection.search.dropdown').dropdown({ fullTextSearch: 'exact', ignoreDiacritics: true });
-  $('.ui.dropdown').dropdown();
+  $('.ui.dropdown').not('.simple').dropdown();
   $('.tabular.menu .item').tab();
   $('.ui.accordion').accordion();
 });

--- a/app/assets/stylesheets/application/semantic-ui_extensions.sass
+++ b/app/assets/stylesheets/application/semantic-ui_extensions.sass
@@ -10,6 +10,8 @@
   border-left: none
   border-right: none
   box-shadow: none
+  .dropdown.item a
+    color: inherit
 
 .ui.segment.shadow-less
   box-shadow: none

--- a/app/assets/stylesheets/application/solicitation.sass
+++ b/app/assets/stylesheets/application/solicitation.sass
@@ -19,8 +19,3 @@
       margin-right: 0.3rem
     .search
       display: block
-
-#dropdown-solicitation
-  .menu
-    border-top-left-radius: 0
-    border-top-right-radius: 0

--- a/app/views/application/_navbar.html.haml
+++ b/app/views/application/_navbar.html.haml
@@ -14,8 +14,8 @@
           %i.tasks.icon
           = t('.diagnoses')
       - if current_user.is_admin?
-        .ui.simple.dropdown#dropdown-solicitation
-          = active_link_to solicitations_path, class: 'item' do
+        .ui.simple.dropdown.item
+          = active_link_to solicitations_path do
             %i.comment.dots.outline.icon
             = t('solicitations.index.title')
           .menu

--- a/app/views/application/_navbar.html.haml
+++ b/app/views/application/_navbar.html.haml
@@ -38,7 +38,7 @@
         = t('company_contact')
 
     - if user_signed_in?
-      .ui.simple.dropdown.right.item#nav-menu
+      .ui.simple.dropdown.right.item
         %i.user.outline.icon
         = t('.account')
         .menu


### PR DESCRIPTION
Deux corrections:
1. amélioration du css pour le menu Sollicitations, qui est à la fois un entête de menu et un lien cliquable. Il faut que le `dropdown` soit `item`, pas le `a`; cependant, ce n’est pas complètement géré par fomantic-ui et le lien reste bleu par défaut.
2. Changement du sélecteur pour activer le dropdown js de fomantic-ui, pour ne pas le faire sur les dropdown `.simple` (justement comme celles de la navbar)