### PR TITLE
Refactor StepsController before preselection

### DIFF
--- a/app/assets/stylesheets/application/diagnoses.sass
+++ b/app/assets/stylesheets/application/diagnoses.sass
@@ -1,4 +1,4 @@
-#besoins-app
+#needs-app
   .subject.checkbox
     display: block
   .subject

--- a/app/controllers/companies_controller.rb
+++ b/app/controllers/companies_controller.rb
@@ -45,7 +45,7 @@ class CompaniesController < ApplicationController
   def create_diagnosis_from_siret
     facility = UseCases::SearchFacility.with_siret_and_save(params[:siret])
     if facility
-      diagnosis = Diagnosis.new(advisor: current_user, facility: facility, step: :besoins)
+      diagnosis = Diagnosis.new(advisor: current_user, facility: facility, step: :needs)
       if params[:solicitation].present?
         solicitation = Solicitation.find_by(id: params[:solicitation])
         diagnosis.solicitation = solicitation
@@ -53,7 +53,7 @@ class CompaniesController < ApplicationController
     end
 
     if diagnosis&.save
-      redirect_to besoins_diagnosis_path(diagnosis)
+      redirect_to needs_diagnosis_path(diagnosis)
     else
       render body: nil, status: :bad_request
     end

--- a/app/controllers/diagnoses/steps_controller.rb
+++ b/app/controllers/diagnoses/steps_controller.rb
@@ -18,15 +18,6 @@ class Diagnoses::StepsController < ApplicationController
     end
   end
 
-  private
-
-  def params_for_needs
-    params.require(:diagnosis)
-      .permit(:content, needs_attributes: [:_destroy, :content, :subject_id, :id])
-  end
-
-  public
-
   def visit
     if @diagnosis.solicitation.present?
       @diagnosis.visitee = Contact.new(full_name:  @diagnosis.solicitation.full_name,email: @diagnosis.solicitation.email,
@@ -66,15 +57,6 @@ class Diagnoses::StepsController < ApplicationController
     end
   end
 
-  private
-
-  def params_for_visit
-    params.require(:diagnosis)
-      .permit(:happened_on, visitee_attributes: [:full_name, :role, :email, :phone_number, :id])
-  end
-
-  public
-
   def matches
   end
 
@@ -94,6 +76,16 @@ class Diagnoses::StepsController < ApplicationController
   def retrieve_diagnosis
     safe_params = params.permit(:id)
     @diagnosis = Diagnosis.find(safe_params[:id])
+  end
+
+  def params_for_needs
+    params.require(:diagnosis)
+      .permit(:content, needs_attributes: [:_destroy, :content, :subject_id, :id])
+  end
+
+  def params_for_visit
+    params.require(:diagnosis)
+      .permit(:happened_on, visitee_attributes: [:full_name, :role, :email, :phone_number, :id])
   end
 
   def params_for_matches

--- a/app/controllers/diagnoses/steps_controller.rb
+++ b/app/controllers/diagnoses/steps_controller.rb
@@ -1,83 +1,91 @@
 class Diagnoses::StepsController < ApplicationController
   before_action :retrieve_diagnosis
 
-  def besoins
-    if request.post?
-      authorize @diagnosis, :update?
+  def needs
+    @themes = Theme.ordered_for_interview
+  end
 
-      diagnosis_params = params.require(:diagnosis).permit(:content,
-                                                           needs_attributes: [:_destroy, :content, :subject_id, :id])
-      diagnosis_params[:step] = 3
-      if @diagnosis.update(diagnosis_params)
-        redirect_to action: :visite, id: @diagnosis and return
-      end
+  def update_needs
+    authorize @diagnosis, :update?
+
+    diagnosis_params = params_for_needs
+    diagnosis_params[:step] = 3
+    if @diagnosis.update(diagnosis_params)
+      redirect_to action: :visit
+    else
       flash.alert = @diagnosis.errors.full_messages.to_sentence
-    end
-
-    respond_to do |format|
-      format.js { render 'flashes' }
-      format.html do
-        @themes = Theme.ordered_for_interview
-      end
+      redirect_to action: :needs
     end
   end
 
-  def visite
-    if request.post?
-      authorize @diagnosis, :update?
+  private
 
-      diagnosis_params = params_for_visite
-      diagnosis_params[:visitee_attributes][:company_id] = @diagnosis.facility.company.id
-      diagnosis_params[:step] = 4
+  def params_for_needs
+    params.require(:diagnosis)
+      .permit(:content, needs_attributes: [:_destroy, :content, :subject_id, :id])
+  end
 
-      if params[:postal_code].present?
-        insee_code = ApiAdresse::Query.insee_code_for_city(params[:city]&.strip, params[:postal_code]&.strip)
-        if insee_code.nil?
-          @postal_code = params[:postal_code]
-          flash.now.alert = t('.no_result')
-          render 'flashes' and return
-        end
-        facility = @diagnosis.facility
-        commune = Commune.find_or_create_by insee_code: insee_code
-        facility.commune = commune
-        facility.update(readable_locality: "#{params[:postal_code]} #{params[:city]}")
-      end
+  public
 
-      begin
-        @diagnosis.transaction do
-          @diagnosis.update!(diagnosis_params)
-          @diagnosis.solicitation&.status_processed!
-          redirect_to action: :selection, id: @diagnosis and return
-        end
-      rescue ActiveRecord::ActiveRecordError => e
-        flash.alert = e.message
-      end
-    end
-
+  def visit
     if @diagnosis.solicitation.present?
       @diagnosis.visitee = Contact.new(full_name:  @diagnosis.solicitation.full_name,email: @diagnosis.solicitation.email,
                             phone_number: @diagnosis.solicitation.phone_number)
     end
+  end
 
-    respond_to do |format|
-      format.js { render 'flashes' }
-      format.html
+  def update_visit
+    authorize @diagnosis, :update?
+
+    diagnosis_params = params_for_visit
+    diagnosis_params[:visitee_attributes][:company_id] = @diagnosis.facility.company.id
+    diagnosis_params[:step] = 4
+
+    if params[:postal_code].present?
+      insee_code = ApiAdresse::Query.insee_code_for_city(params[:city]&.strip, params[:postal_code]&.strip)
+      if insee_code.nil?
+        @postal_code = params[:postal_code]
+        flash.now.alert = t('diagnoses.steps.visit.no_result')
+        render 'flashes' and return
+      end
+      facility = @diagnosis.facility
+      commune = Commune.find_or_create_by insee_code: insee_code
+      facility.commune = commune
+      facility.update(readable_locality: "#{params[:postal_code]} #{params[:city]}")
+    end
+
+    begin
+      @diagnosis.transaction do
+        @diagnosis.update!(diagnosis_params)
+        @diagnosis.solicitation&.status_processed!
+        redirect_to action: :matches
+      end
+    rescue ActiveRecord::ActiveRecordError => e
+      flash.alert = e.message
+      redirect_to action: :visit
     end
   end
 
-  def selection
-    if request.post?
-      authorize @diagnosis, :update?
-      if @diagnosis.match_and_notify!(params_for_matches)
-        flash.notice = I18n.t('diagnoses.steps.selection.notifications_sent')
-        redirect_to need_path(@diagnosis) and return
-      end
-      flash.alert = @diagnosis.errors.full_messages.to_sentence
-    end
+  private
 
-    respond_to do |format|
-      format.js { render 'flashes' }
-      format.html
+  def params_for_visit
+    params.require(:diagnosis)
+      .permit(:happened_on, visitee_attributes: [:full_name, :role, :email, :phone_number, :id])
+  end
+
+  public
+
+  def matches
+  end
+
+  def update_matches
+    authorize @diagnosis, :update?
+    if @diagnosis.match_and_notify!(params_for_matches)
+      flash.notice = I18n.t('diagnoses.steps.matches.notifications_sent')
+      redirect_to need_path(@diagnosis)
+    else
+      flash.alert = @diagnosis.errors.full_messages.to_sentence
+      redirect_to action: :matches
     end
   end
 
@@ -88,13 +96,8 @@ class Diagnoses::StepsController < ApplicationController
     @diagnosis = Diagnosis.find(safe_params[:id])
   end
 
-  def params_for_visite
-    permitted = params.require(:diagnosis).permit(:happened_on, visitee_attributes: [:full_name, :role, :email, :phone_number, :id])
-    permitted
-  end
-
   def params_for_matches
-    matches = params.permit(matches: {}).require(:matches)
+    matches = params.permit(matches: {}).require('matches')
     matches.transform_values do |expert_subjects_selection|
       expert_subjects_selection.select{ |_,v| v == '1' }.keys
     end

--- a/app/controllers/diagnoses/steps_controller.rb
+++ b/app/controllers/diagnoses/steps_controller.rb
@@ -9,7 +9,7 @@ class Diagnoses::StepsController < ApplicationController
     authorize @diagnosis, :update?
 
     diagnosis_params = params_for_needs
-    diagnosis_params[:step] = 3
+    diagnosis_params[:step] = :visit
     if @diagnosis.update(diagnosis_params)
       redirect_to action: :visit
     else
@@ -39,7 +39,7 @@ class Diagnoses::StepsController < ApplicationController
 
     diagnosis_params = params_for_visit
     diagnosis_params[:visitee_attributes][:company_id] = @diagnosis.facility.company.id
-    diagnosis_params[:step] = 4
+    diagnosis_params[:step] = :matches
 
     if params[:postal_code].present?
       insee_code = ApiAdresse::Query.insee_code_for_city(params[:city]&.strip, params[:postal_code]&.strip)

--- a/app/controllers/diagnoses_controller.rb
+++ b/app/controllers/diagnoses_controller.rb
@@ -35,14 +35,14 @@ class DiagnosesController < ApplicationController
     end
 
     facility = Diagnosis.create_without_siret(insee_code, params)
-    diagnosis = Diagnosis.new(advisor: current_user, facility: facility, step: :besoins)
+    diagnosis = Diagnosis.new(advisor: current_user, facility: facility, step: :needs)
     if params[:solicitation].present?
       solicitation = Solicitation.find_by(id: params[:solicitation])
       diagnosis.solicitation = solicitation
     end
 
     if diagnosis.save
-      redirect_to besoins_diagnosis_path(diagnosis)
+      redirect_to needs_diagnosis_path(diagnosis)
     else
       render body: nil, status: :bad_request
     end

--- a/app/controllers/stats_controller.rb
+++ b/app/controllers/stats_controller.rb
@@ -93,7 +93,7 @@ class StatsController < PagesController
       "activity.visits": visits_in_range,
       "activity.companies_diagnosed": companies_diagnosed_in_range,
       "activity.needs": needs_in_range,
-      "activity.needs_notified": needs_in_range.where(diagnoses: { step: 5 }),
+      "activity.needs_notified": needs_in_range.where(diagnoses: { step: :completed }),
       "activity.matches": matches_created_in_range,
       "activity.match_taken_care_of": matches_taken_care_in_range.where(status: [:taking_care, :done]),
       "activity.match_done": matches_taken_care_in_range.where(status: :done),

--- a/app/models/diagnosis.rb
+++ b/app/models/diagnosis.rb
@@ -52,6 +52,7 @@ class Diagnosis < ApplicationRecord
   ## Validations and Callbacks
   #
   validates :advisor, :facility, presence: true
+  validate :step_visit_has_needs
   validate :step_matches_has_visit_attributes
   validate :step_completed_has_matches
 
@@ -148,6 +149,14 @@ class Diagnosis < ApplicationRecord
   end
 
   private
+
+  def step_visit_has_needs
+    if step_visit?
+      if needs.blank?
+        errors.add(:needs, :blank)
+      end
+    end
+  end
 
   def step_matches_has_visit_attributes
     if step_matches?

--- a/app/views/diagnoses/steps/matches.html.haml
+++ b/app/views/diagnoses/steps/matches.html.haml
@@ -6,8 +6,9 @@
   .ui.info.message
     = t('.explanation')
 
-  = form_with scope: :matches, url: update_matches_diagnosis_path(@diagnosis),
-    method: :post,
+  = form_with model: @diagnosis,
+    url: update_matches_diagnosis_path(@diagnosis),
+    scope: :matches,
     class: 'ui form',
     data: { checkboxes_require_one_with: t(".select_at_least_one_expert") } do |f|
     - @diagnosis.needs.ordered_for_interview.each do |need|

--- a/app/views/diagnoses/steps/matches.html.haml
+++ b/app/views/diagnoses/steps/matches.html.haml
@@ -2,13 +2,14 @@
 
 = render 'header', diagnosis: @diagnosis, current_page_step: 4
 
-#selection-app
+#matches-app
   .ui.info.message
     = t('.explanation')
 
-  = form_with scope: :matches, url: selection_diagnosis_path(@diagnosis),
-             id: 'selection-form', class: 'ui form',
-             data: { checkboxes_require_one_with: t(".select_at_least_one_expert") } do |f|
+  = form_with scope: :matches, url: update_matches_diagnosis_path(@diagnosis),
+    method: :post,
+    class: 'ui form',
+    data: { checkboxes_require_one_with: t(".select_at_least_one_expert") } do |f|
     - @diagnosis.needs.ordered_for_interview.each do |need|
       .ui.segment.shadow-less
         %h3.ui.header= need.subject
@@ -37,7 +38,7 @@
 
     .ui.two.column.stackable.grid.container
       .ui.left.aligned.column.no-left-padding.no-margin
-        = link_to visite_diagnosis_path(@diagnosis), class: 'ui left labeled icon button no-margin' do
+        = link_to visit_diagnosis_path(@diagnosis), class: 'ui left labeled icon button no-margin' do
           = t('previous_step')
           %i.arrow.left.icon
 

--- a/app/views/diagnoses/steps/needs.html.haml
+++ b/app/views/diagnoses/steps/needs.html.haml
@@ -5,7 +5,6 @@
 #needs-app
   = form_with model: @diagnosis,
     url: update_needs_diagnosis_path,
-    method: :post,
     class: 'ui form',
     data: { checkboxes_require_one_with: t(".select_at_least_one_need") } do |diagnosis_form|
 

--- a/app/views/diagnoses/steps/needs.html.haml
+++ b/app/views/diagnoses/steps/needs.html.haml
@@ -6,7 +6,8 @@
   = form_with model: @diagnosis,
     url: update_needs_diagnosis_path,
     method: :post,
-    class: 'ui form diagnosis_form' do |diagnosis_form|
+    class: 'ui form',
+    data: { checkboxes_require_one_with: t(".select_at_least_one_need") } do |diagnosis_form|
 
     %h1.ui.header
       = t('.title')
@@ -40,25 +41,3 @@
         %i.arrow.right.icon
 
   .clear
-
-:javascript
-  (function() {
-    var checkboxes = $(".diagnosis_form .checkbox input:checkbox");
-    function setBoxesValidity() {
-      if (checkboxes.is(":checked")) {
-        checkboxes.each(function() {
-          this.setCustomValidity("");
-        });
-      } else {
-        checkboxes.each(function() {
-          this.setCustomValidity("#{ t('.select_at_least_one_need') }");
-        });
-      }
-    }
-    checkboxes.on("click", function() {
-      setBoxesValidity();
-    });
-    $(document).ready(function(){
-      setBoxesValidity();
-    });
-  }) ()

--- a/app/views/diagnoses/steps/needs.html.haml
+++ b/app/views/diagnoses/steps/needs.html.haml
@@ -2,9 +2,9 @@
 
 = render 'header', diagnosis: @diagnosis, current_page_step: 2
 
-#besoins-app
+#needs-app
   = form_with model: @diagnosis,
-    url: besoins_diagnosis_path(@diagnosis),
+    url: update_needs_diagnosis_path,
     method: :post,
     class: 'ui form diagnosis_form' do |diagnosis_form|
 

--- a/app/views/diagnoses/steps/visit.html.haml
+++ b/app/views/diagnoses/steps/visit.html.haml
@@ -5,7 +5,6 @@
 #visit-app
   = form_with model: @diagnosis,
     url: update_visit_diagnosis_path,
-    method: :post,
     class: 'ui form' do |diagnosis_form|
 
     %h2.ui.header

--- a/app/views/diagnoses/steps/visit.html.haml
+++ b/app/views/diagnoses/steps/visit.html.haml
@@ -2,9 +2,9 @@
 
 = render 'header', diagnosis: @diagnosis, current_page_step: 3
 
-#visite-app
+#visit-app
   = form_with model: @diagnosis,
-    url: visite_diagnosis_path(@diagnosis),
+    url: update_visit_diagnosis_path,
     method: :post,
     class: 'ui form' do |diagnosis_form|
 
@@ -42,7 +42,7 @@
     - if ENV['FEATURE_NEW_LOCALITY_FOR_DIAGNOSIS'].to_b
       = render 'new_locality', postal_code: @postal_code, diagnosis: @diagnosis
 
-    %a.ui.left.floated.button.labeled.icon{ href: besoins_diagnosis_path(@diagnosis) }
+    %a.ui.left.floated.button.labeled.icon{ href: needs_diagnosis_path }
       = t('previous_step')
       %i.arrow.left.icon
     = diagnosis_form.button :submit, class: 'ui right floated button green right labeled icon' do

--- a/config/i18n-tasks.yml
+++ b/config/i18n-tasks.yml
@@ -98,7 +98,6 @@ ignore_unused:
   - 'stats.stats_table.*'
   - 'stats.series.*'
   - 'categories_juridiques.*'
-  - 'contacts.besoins.*'
   - 'solicitations.needs.long.*'
   - '{date,datetime,errors,helpers,number,support,time}.*'
 # - '{devise,kaminari,will_paginate}.*'

--- a/config/locales/views.fr.yml
+++ b/config/locales/views.fr.yml
@@ -133,7 +133,17 @@ fr:
       sub_title: Si l’entreprise n’existe pas encore, ou qu’elle est introuvable, vous pouvez simplement saisir son nom et son implantation. SIRET non diffusible, reprise d’entreprise, déménagement…
       title: Saisie manuelle
     steps:
-      besoins:
+      matches:
+        before_sending_emails_1: En cliquant sur le bouton ci-dessous, les référents sélectionnés seront contactés par e-mail.
+        before_sending_emails_2: Ils auront accès aux coordonnées de l’entreprise et à l’analyse que vous avez réalisée, y compris vos commentaires. Ils pourront recontacter directement l’entreprise pour répondre à ses besoins ou revenir vers vous pour un complément d’information.
+        explanation: Ces aides répondent aux besoins identifiés. Vous pouvez sélectionner les référents que vous souhaitez contacter par e-mail.
+        no_expert_subject: Aucune aide ne répond à ce besoin sur ce territoire pour l’instant.
+        notifications_sent: Les notifications ont bien été envoyées.
+        notify_matches: Notifier les référents sélectionnés
+        select_at_least_one_expert: Cochez au minimum un référent à contacter.
+        title: Mise en contact
+        you_can_contact_support: Vous pouvez néanmoins contacter les équipes support et relais locaux.
+      needs:
         diagnosis_content_placeholder: 'Entrez des informations complémentaires concernant cette entreprise :'
         diagnosis_content_subtitle: Informations générales sur cette entreprise
         identify_needs: |
@@ -147,17 +157,7 @@ fr:
         new_city: Rechercher pour une autre localité que %{locality}
         postal_code: Code postal
         title: Nouvelle localité
-      selection:
-        before_sending_emails_1: En cliquant sur le bouton ci-dessous, les référents sélectionnés seront contactés par e-mail.
-        before_sending_emails_2: Ils auront accès aux coordonnées de l’entreprise et à l’analyse que vous avez réalisée, y compris vos commentaires. Ils pourront recontacter directement l’entreprise pour répondre à ses besoins ou revenir vers vous pour un complément d’information.
-        explanation: Ces aides répondent aux besoins identifiés. Vous pouvez sélectionner les référents que vous souhaitez contacter par e-mail.
-        no_expert_subject: Aucune aide ne répond à ce besoin sur ce territoire pour l’instant.
-        notifications_sent: Les notifications ont bien été envoyées.
-        notify_matches: Notifier les référents sélectionnés
-        select_at_least_one_expert: Cochez au minimum un référent à contacter.
-        title: Mise en contact
-        you_can_contact_support: Vous pouvez néanmoins contacter les équipes support et relais locaux.
-      visite:
+      visit:
         date: Date de votre visite
         date_placeholder: jj/mm/aaaa
         email_address: E-mail

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -91,12 +91,12 @@ Rails.application.routes.draw do
       post :unarchive
 
       controller 'diagnoses/steps' do
-        get :besoins
-        post :besoins
-        get :visite
-        post :visite
-        get :selection
-        post :selection
+        get :needs, path: 'besoins'
+        post :update_needs
+        get :visit, path: 'visite'
+        post :update_visit
+        get :matches, path: 'selection'
+        post :update_matches
       end
     end
   end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -92,11 +92,11 @@ Rails.application.routes.draw do
 
       controller 'diagnoses/steps' do
         get :needs, path: 'besoins'
-        post :update_needs
+        patch :update_needs
         get :visit, path: 'visite'
-        post :update_visit
+        patch :update_visit
         get :matches, path: 'selection'
-        post :update_matches
+        patch :update_matches
       end
     end
   end

--- a/spec/controllers/companies_controller_spec.rb
+++ b/spec/controllers/companies_controller_spec.rb
@@ -30,7 +30,7 @@ RSpec.describe CompaniesController, type: :controller do
 
   describe 'POST #create_diagnosis_from_siret' do
     context 'save worked' do
-      it 'redirects to the created diagnosis besoins page' do
+      it 'redirects to the created diagnosis needs page' do
         siret = '12345678901234'
         facility = create :facility, siret: siret
         allow(UseCases::SearchFacility).to receive(:with_siret_and_save).with(siret) { facility }
@@ -38,7 +38,7 @@ RSpec.describe CompaniesController, type: :controller do
         post :create_diagnosis_from_siret, format: :json, params: { siret: siret }
 
         expect(response).to have_http_status(:redirect)
-        expect(response).to redirect_to besoins_diagnosis_path(Diagnosis.last)
+        expect(response).to redirect_to needs_diagnosis_path(Diagnosis.last)
       end
     end
 

--- a/spec/controllers/diagnoses/steps_controller_spec.rb
+++ b/spec/controllers/diagnoses/steps_controller_spec.rb
@@ -7,23 +7,23 @@ RSpec.describe Diagnoses::StepsController, type: :controller do
   let(:diagnosis) { create :diagnosis, advisor: advisor }
   let(:advisor) { current_user }
 
-  describe 'GET #besoins' do
-    subject(:request) { get :besoins, params: { id: diagnosis.id } }
+  describe 'GET #needs' do
+    subject(:request) { get :needs, params: { id: diagnosis.id } }
 
     context 'diagnosis' do
       it('returns http success') { expect(response).to be_successful }
     end
   end
 
-  describe 'GET #visite' do
-    subject(:request) { get :visite, params: { id: diagnosis.id } }
+  describe 'GET #visit' do
+    subject(:request) { get :visit, params: { id: diagnosis.id } }
 
     context 'diagnosis step < last' do
       it('returns http success') { expect(response).to be_successful }
     end
   end
 
-  describe 'POST #visite' do
+  describe 'POST #update_visit' do
     let(:diagnosis) { create :diagnosis, advisor: advisor, visitee: nil }
     let(:locality) { diagnosis.facility.readable_locality }
     let(:advisor) { current_user }
@@ -32,7 +32,7 @@ RSpec.describe Diagnoses::StepsController, type: :controller do
       let(:params) { { diagnosis: { visitee_attributes: { full_name: "Edith Piaf", role: "directrice", email: "edith@piaf.fr", phone_number: "0606060606" }, happened_on: "27/01/2020" }, id: diagnosis.id } }
 
       it 'create a visitee for diagnosis' do
-        post :visite, params: params
+        post :update_visit, params: params
         diagnosis.reload
         expect(diagnosis.visitee.full_name).to eq("Edith Piaf")
         expect(diagnosis.facility.readable_locality).to eq(locality)
@@ -52,7 +52,7 @@ RSpec.describe Diagnoses::StepsController, type: :controller do
       end
 
       it 'create a visitee for diagnosis and change locality' do
-        post :visite, params: params
+        post :update_visit, params: params
         diagnosis.reload
         expect(diagnosis.visitee.full_name).to eq("Edith Piaf")
         expect(diagnosis.facility.readable_locality).to eq('78500 Sartrouville')
@@ -60,20 +60,20 @@ RSpec.describe Diagnoses::StepsController, type: :controller do
     end
   end
 
-  describe 'GET #selection' do
-    subject(:request) { get :selection, params: { id: diagnosis.id } }
+  describe 'GET #matches' do
+    subject(:request) { get :matches, params: { id: diagnosis.id } }
 
     context 'diagnosis' do
       it('returns http success') { expect(response).to be_successful }
     end
   end
 
-  describe 'POST #selection' do
+  describe 'POST #update_matches' do
     let(:expert_subject) { create(:expert_subject) }
     let!(:need) { create(:need, diagnosis: diagnosis) }
 
     before do
-      post :selection, params: { id: diagnosis.id, matches: { need.id => { expert_subject.id => '1' } } }
+      post :update_matches, params: { id: diagnosis.id, matches: { need.id => { expert_subject.id => '1' } } }
     end
 
     context 'match_and_notify! succeeds' do

--- a/spec/controllers/diagnoses_controller_spec.rb
+++ b/spec/controllers/diagnoses_controller_spec.rb
@@ -75,7 +75,7 @@ RSpec.describe DiagnosesController, type: :controller do
     it "creates a new diagnosis without siret" do
       post :create_diagnosis_without_siret, params: params
       expect(response).to have_http_status(:redirect)
-      expect(response).to redirect_to besoins_diagnosis_path(Diagnosis.last)
+      expect(response).to redirect_to needs_diagnosis_path(Diagnosis.last)
     end
   end
 end

--- a/spec/models/diagnosis_spec.rb
+++ b/spec/models/diagnosis_spec.rb
@@ -29,7 +29,7 @@ RSpec.describe Diagnosis, type: :model do
     end
 
     describe 'step_4_has_visit_attributes' do
-      subject(:diagnosis) { build :diagnosis, step: 4, visitee: visitee, happened_on: happened_on }
+      subject(:diagnosis) { build :diagnosis, step: :matches, visitee: visitee, happened_on: happened_on }
 
       context 'missing attributes' do
         let(:visitee) { nil }
@@ -56,8 +56,8 @@ RSpec.describe Diagnosis, type: :model do
 
       it do
         create :diagnosis_completed
-        create :diagnosis, step: 2
-        create :diagnosis, step: 4
+        create :diagnosis, step: :needs
+        create :diagnosis, step: :matches
 
         is_expected.to eq 2
       end
@@ -69,7 +69,7 @@ RSpec.describe Diagnosis, type: :model do
       it do
         create :diagnosis_completed
         create :diagnosis_completed
-        create :diagnosis, step: 4
+        create :diagnosis, step: :matches
 
         is_expected.to eq 2
       end
@@ -101,7 +101,7 @@ RSpec.describe Diagnosis, type: :model do
   describe 'match_and_notify!' do
     subject(:match_and_notify) { diagnosis.match_and_notify!(matches) }
 
-    let(:diagnosis) { create :diagnosis, step: 4 }
+    let(:diagnosis) { create :diagnosis, step: :matches }
     let(:need) { create :need, diagnosis: diagnosis }
     let(:expert) { create :expert }
     let(:experts_subjects) { create :expert_subject, expert: expert, subject: need.subject }

--- a/spec/models/need_spec.rb
+++ b/spec/models/need_spec.rb
@@ -51,7 +51,7 @@ RSpec.describe Need, type: :model do
     let(:not_for_me_match) { build :match, status: :not_for_me }
 
     context 'diagnosis not complete' do
-      let(:diagnosis) { create :diagnosis, step: 1 }
+      let(:diagnosis) { create :diagnosis, step: :not_started }
 
       it { is_expected.to eq :diagnosis_not_complete }
     end

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -94,7 +94,7 @@ RSpec.describe User, type: :model do
 
     describe 'active_diagnosers' do
       it do
-        diagnosis = create :diagnosis, created_at: 1.day.ago, step: 3
+        diagnosis = create :diagnosis, created_at: 1.day.ago, step: :visit, needs: create_list(:need, 1)
         diagnoser = create :user, sent_diagnoses: [diagnosis]
 
         last_30_days = (30.days.ago)..Time.zone.now

--- a/spec/views/diagnoses/steps/matches.html.haml_spec.rb
+++ b/spec/views/diagnoses/steps/matches.html.haml_spec.rb
@@ -1,7 +1,7 @@
 require "spec_helper"
 require 'rails_helper'
 
-describe "diagnoses/steps/selection.html.haml", type: :view do
+describe "diagnoses/steps/matches.html.haml", type: :view do
   let(:need) { create :need }
   let(:diagnosis) { create :diagnosis, needs: [need] }
   let(:institution_subject) { create :institution_subject, subject: need.subject }


### PR DESCRIPTION
* remove the “same path” routes for post and get, that was dumb
* stop using flashes.js, just redirect (and let turbolinks do its thing)
* remove a forgotten version of `checkboxes_require_one` in the needs step
* use diagnoses step enum names instead of magic numbers
* add a new diagnoses validation to ensure needs are selected in the needs step (it‘s already done in the frontend anyway)

This is in preparation for #940