### PR TITLE
Afficher l’institution et le sujet préselectionné dans /sollicitations

### DIFF
--- a/app/helpers/solicitation_helper.rb
+++ b/app/helpers/solicitation_helper.rb
@@ -42,4 +42,29 @@ module SolicitationHelper
     classes += STATUS_ACTION_COLORS[new_status.to_sym]
     link_to name, path, method: :post, remote: true, class: classes.join(' ')
   end
+
+  def selected_options_tags(solicitation, classes = %[])
+    tags = solicitation.landing_options_slugs.map do |slug|
+      option = LandingOption.find_by(slug: slug)
+      if option.present?
+        title_components = {}
+        if option.preselected_institution_slug.present?
+          institution = option.preselected_institution&.name || option.preselected_institution_slug
+          title_components[t('attributes.institution')] = institution
+        end
+        if option.preselected_subject_slug.present?
+          subject = option.preselected_subject&.label || option.preselected_subject_slug
+          title_components[t('attributes.subject')] = subject
+        end
+
+        title = title_components.map{ |k,v| "#{k} : #{v}" }.join("\n")
+
+        content_tag(:div, option.title, class: classes, title: title)
+      else
+        content_tag(:div, slug, class: classes)
+      end
+    end
+
+    tags.join.html_safe
+  end
 end

--- a/app/views/solicitations/_solicitation.haml
+++ b/app/views/solicitations/_solicitation.haml
@@ -27,8 +27,7 @@
       - if solicitation.landing_options_slugs.present?
         .item
           %strong= t('.landing_options')
-          - solicitation.landing_options_slugs.each do |option|
-            .ui.small.label= option
+          = selected_options_tags(solicitation, "ui small label")
       .item
         %strong= t('.description')
         %p= simple_format solicitation.description


### PR DESCRIPTION
refs #940

Ça ne sera pas essentiel, une fois la fonctionnalité complète, mais ça aide à comprendre ce qui se passe. baby steps, tout ça.

<img width="701" alt="Capture d’écran 2020-04-09 à 15 31 41" src="https://user-images.githubusercontent.com/139391/78906988-5c3b1580-7a80-11ea-9e73-481b1b7736e9.png">
