### PR TITLE
Fix Diagnosis#visite overwriting the visitee info with the solicitation

### DIFF
--- a/app/controllers/diagnoses/steps_controller.rb
+++ b/app/controllers/diagnoses/steps_controller.rb
@@ -19,8 +19,8 @@ class Diagnoses::StepsController < ApplicationController
   end
 
   def visit
-    if @diagnosis.solicitation.present?
-      @diagnosis.visitee = Contact.new(full_name:  @diagnosis.solicitation.full_name,email: @diagnosis.solicitation.email,
+    if @diagnosis.visitee.nil? && @diagnosis.solicitation.present?
+      @diagnosis.visitee = Contact.new(full_name:  @diagnosis.solicitation.full_name, email: @diagnosis.solicitation.email,
                             phone_number: @diagnosis.solicitation.phone_number)
     end
   end


### PR DESCRIPTION
Only prefill the form with the solicitation info if the visitee hasn’t been filled yet.

