### PR TITLE
Fix match_feedback following #1022

### DIFF
--- a/app/mailers/user_mailer.rb
+++ b/app/mailers/user_mailer.rb
@@ -15,7 +15,7 @@ class UserMailer < ApplicationMailer
     @feedback = feedback
     @person = person
     @author = feedback.author
-    return if @person.deleted?
+    return if @person.is_a?(User) && @person.deleted? # TODO remove the is_a? after #991
     mail(to: @person.email_with_display_name,
          reply_to: @author.email_with_display_name,
          subject: t('mailers.user_mailer.match_feedback.subject', company_name: feedback.need.company))


### PR DESCRIPTION
See also #991: when we’re able to soft-delete experts, this can be removed.