### PR TITLE
Refactor diagnosis create methods

### DIFF
--- a/app/controllers/companies_controller.rb
+++ b/app/controllers/companies_controller.rb
@@ -16,6 +16,8 @@ class CompaniesController < ApplicationController
   end
 
   def show
+    @diagnosis = DiagnosisCreation.new_diagnosis(Solicitation.find_by(id: params[:solicitation]))
+
     siret = params[:siret]
     clean_siret = Facility::clean_siret(siret)
     if clean_siret != siret
@@ -40,23 +42,6 @@ class CompaniesController < ApplicationController
       @diagnoses = Diagnosis.none
     end
     save_search(siret, @company.name)
-  end
-
-  def create_diagnosis_from_siret
-    facility = UseCases::SearchFacility.with_siret_and_save(params[:siret])
-    if facility
-      diagnosis = Diagnosis.new(advisor: current_user, facility: facility, step: :needs)
-      if params[:solicitation].present?
-        solicitation = Solicitation.find_by(id: params[:solicitation])
-        diagnosis.solicitation = solicitation
-      end
-    end
-
-    if diagnosis&.save
-      redirect_to needs_diagnosis_path(diagnosis)
-    else
-      render body: nil, status: :bad_request
-    end
   end
 
   private

--- a/app/controllers/diagnoses/steps_controller.rb
+++ b/app/controllers/diagnoses/steps_controller.rb
@@ -40,14 +40,6 @@ class Diagnoses::StepsController < ApplicationController
 
     begin
       @diagnosis.transaction do
-        if params[:insee_code].present?
-          insee_code = params[:insee_code]
-          facility = @diagnosis.facility
-          city_params = ApiAdresse::Query.city_with_code(insee_code)
-          facility.readable_locality = "#{city_params['codesPostaux']&.first} #{city_params['nom']}"
-          facility.commune = Commune.find_or_initialize_by(insee_code: insee_code)
-          facility.save!
-        end
         @diagnosis.update!(diagnosis_params)
         @diagnosis.solicitation&.status_processed!
         redirect_to action: :matches
@@ -85,7 +77,9 @@ class Diagnoses::StepsController < ApplicationController
 
   def params_for_visit
     params.require(:diagnosis)
-      .permit(:happened_on, visitee_attributes: [:full_name, :role, :email, :phone_number, :id])
+      .permit(:happened_on,
+              visitee_attributes: [:full_name, :role, :email, :phone_number, :id],
+              facility_attributes: [:insee_code, :id])
   end
 
   def params_for_matches

--- a/app/models/concerns/diagnosis_creation.rb
+++ b/app/models/concerns/diagnosis_creation.rb
@@ -1,0 +1,26 @@
+module DiagnosisCreation
+  # Helpers for diagnosis creation forms:
+  # The creation params hash for a diagnosis has nested attributes for #facility and #facility#company.
+  # Build a new diagnosis with an new facility and company:
+  # These will be used `fields_for` form helpers.
+  def self.new_diagnosis(solicitation)
+    Diagnosis.new(solicitation: solicitation,
+                  facility: Facility.new(company: Company.new(name: solicitation&.full_name)))
+  end
+
+  def self.create_diagnosis(params)
+    Diagnosis.transaction do
+      if params[:facility_attributes].include? :siret
+        # Facility attributes are nested in the hash; if there is no siret, we use the insee_code.
+        # In particular, the facility.insee_code= setter will fetch the readable locality name from the geo api.
+        # TODO: Get rid of UseCases::SearchFacility and handle implicitely in `facility#siret=`,
+        # This would let us use the params hash as provided.
+        facility_params = params.delete(:facility_attributes)
+        params[:facility] = UseCases::SearchFacility.with_siret_and_save(facility_params[:siret])
+      end
+
+      params[:step] = :needs
+      Diagnosis.create(params)
+    end
+  end
+end

--- a/app/models/diagnosis.rb
+++ b/app/models/diagnosis.rb
@@ -55,6 +55,7 @@ class Diagnosis < ApplicationRecord
   validate :step_matches_has_visit_attributes
   validate :step_completed_has_matches
 
+  accepts_nested_attributes_for :facility
   accepts_nested_attributes_for :needs, allow_destroy: true
   accepts_nested_attributes_for :visitee
 

--- a/app/models/facility.rb
+++ b/app/models/facility.rb
@@ -48,6 +48,8 @@ class Facility < ApplicationRecord
   # :commune
   has_many :territories, through: :commune, inverse_of: :facilities
 
+  accepts_nested_attributes_for :company
+
   ##
   #
   class << self

--- a/app/models/facility.rb
+++ b/app/models/facility.rb
@@ -86,13 +86,23 @@ class Facility < ApplicationRecord
     end
   end
 
+  ## insee_code / commune helpers
+  # TODO: insee_code should be just a column in facility, and we should drop the Commune model entirely.
+  #   In the meantime, fake it by delegating to commune.
+  delegate :insee_code, to: :commune, allow_nil: true # commune can be nil in new facility models.
+  def insee_code=(insee_code)
+    self.commune = Commune.find_or_initialize_by(insee_code: insee_code)
+    city_params = ApiAdresse::Query.city_with_code(insee_code)
+    self.readable_locality = "#{city_params['codesPostaux']&.first} #{city_params['nom']}"
+  end
+
+  def commune_name
+    readable_locality || insee_code
+  end
+
   ##
   #
   def to_s
     "#{company.name} (#{commune_name})"
-  end
-
-  def commune_name
-    readable_locality || commune.insee_code
   end
 end

--- a/app/views/application/_insee_code_field.html.haml
+++ b/app/views/application/_insee_code_field.html.haml
@@ -7,4 +7,4 @@
     = label_tag do
       = t('.city')
       .ui.loader.inline.mini.insee-code-loader
-    = select_tag :insee_code, [], required: required, class: 'ui fluid dropdown selection'
+    = form.select :insee_code, [], {}, { required: required, class: 'ui fluid dropdown selection', id: :insee_code }

--- a/app/views/companies/show.html.haml
+++ b/app/views/companies/show.html.haml
@@ -3,8 +3,13 @@
 #company-show
   %h1
     = @company.name
-    = link_to t('.create_diagnosis'), create_diagnosis_from_siret_companies_path(params.permit(:siret, :solicitation).slice(:siret, :solicitation)),
-    method: :post, class: 'ui right floated positive basic button'
+
+    = form_with model: @diagnosis, local: true do |form|
+      = form.hidden_field :solicitation_id
+      = form.fields_for :facility do |facility_form|
+        = facility_form.hidden_field :siret, value: @facility.etablissement.siret
+      = form.button :submit, class: 'ui right floated positive basic button' do
+        = t('.create_diagnosis')
 
   - if @diagnoses.present?
     %h2= t('.diagnoses_completed', company_name: @company.name)

--- a/app/views/diagnoses/new.haml
+++ b/app/views/diagnoses/new.haml
@@ -8,7 +8,7 @@
   %a.item{ "data-tab" => "second" }
     = t('.search_manually')
 .ui.bottom.attached.tab.new-diagnosis.segment.active{ "data-tab" => "first" }
-  = render partial: 'companies/search_form', locals: { query: @query, solicitation: @solicitation }
+  = render partial: 'companies/search_form', locals: { query: @query, solicitation: @diagnosis.solicitation }
 
 .ui.bottom.attached.tab.new-diagnosis.segment{ "data-tab" => "second" }
   %h2.ui.header
@@ -17,18 +17,21 @@
   %p
     = t('.sub_title')
 
-  = form_with url: create_diagnosis_without_siret_diagnoses_url, method: :post, class: 'ui form' do
+  = form_with model: @diagnosis, class: 'ui form', local: true do |form|
+    - if @diagnosis.errors.present?
+      .field.error
+        .ui.error.message= @diagnosis.errors.full_messages.to_sentence
+    - if @diagnosis.solicitation.present?
+      = form.hidden_field :solicitation_id
+    = form.fields_for :facility do |facility_form|
+      .field.required
+        = facility_form.fields_for :company do |company_form|
+          = label_tag t('.name')
+          = company_form.text_field :name, required: true
 
-    - if @solicitation.present?
-      = hidden_field_tag :solicitation, @solicitation.id
-    .field
-      = label_tag t('.name')
-      - name = local_assigns[:solicitation]&.full_name
-      = text_field_tag :name, name, required: true
+      = render 'insee_code_field', form: facility_form, required: true
 
-    = render 'insee_code_field', required: true
-
-    = button_tag :submit, class: 'ui right floated button green right labeled icon' do
+    = form.button :submit, class: 'ui right floated button green right labeled icon' do
       = t('next_step')
       %i.arrow.right.icon
 

--- a/app/views/diagnoses/steps/visit.html.haml
+++ b/app/views/diagnoses/steps/visit.html.haml
@@ -45,7 +45,8 @@
 
         #insee-code-row
           %h3.ui.header= t('.new_city_title')
-          = render 'insee_code_field', required: false
+          = diagnosis_form.fields_for :facility do |facility_form|
+            = render 'insee_code_field', form: facility_form, required: false
 
     %a.ui.left.floated.button.labeled.icon{ href: needs_diagnosis_path }
       = t('previous_step')

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -77,13 +77,12 @@ Rails.application.routes.draw do
   end
 
   # Application
-  resources :diagnoses, only: %i[index new show], path: 'analyses' do
+  resources :diagnoses, only: %i[index new show create], path: 'analyses' do
     collection do
       get :processed, path: 'traitees'
       get :archives
       get :index_antenne
       get :archives_antenne
-      post :create_diagnosis_without_siret
     end
 
     member do
@@ -104,7 +103,6 @@ Rails.application.routes.draw do
   resources :companies, only: %i[show], param: :siret do
     collection do
       get :search
-      post :create_diagnosis_from_siret
     end
   end
 

--- a/spec/controllers/companies_controller_spec.rb
+++ b/spec/controllers/companies_controller_spec.rb
@@ -27,29 +27,4 @@ RSpec.describe CompaniesController, type: :controller do
       expect(response).to be_successful
     end
   end
-
-  describe 'POST #create_diagnosis_from_siret' do
-    context 'save worked' do
-      it 'redirects to the created diagnosis needs page' do
-        siret = '12345678901234'
-        facility = create :facility, siret: siret
-        allow(UseCases::SearchFacility).to receive(:with_siret_and_save).with(siret) { facility }
-
-        post :create_diagnosis_from_siret, format: :json, params: { siret: siret }
-
-        expect(response).to have_http_status(:redirect)
-        expect(response).to redirect_to needs_diagnosis_path(Diagnosis.last)
-      end
-    end
-
-    context 'saved failed' do
-      it 'does not redirect' do
-        allow(UseCases::SearchFacility).to receive(:with_siret_and_save)
-
-        post :create_diagnosis_from_siret, format: :json, params: {}
-
-        expect(response).to have_http_status(:bad_request)
-      end
-    end
-  end
 end

--- a/spec/controllers/diagnoses/steps_controller_spec.rb
+++ b/spec/controllers/diagnoses/steps_controller_spec.rb
@@ -53,12 +53,15 @@ RSpec.describe Diagnoses::StepsController, type: :controller do
       let(:params) do
         {
           id: diagnosis.id,
-          insee_code: '78586',
           diagnosis: {
             happened_on: "27/01/2020",
             visitee_attributes: {
               full_name: "Edith Piaf", role: "directrice", email: "edith@piaf.fr", phone_number: "0606060606",
             },
+            facility_attributes: {
+              id: diagnosis.facility_id,
+              insee_code: '78586'
+            }
           }
         }
       end

--- a/spec/controllers/diagnoses/steps_controller_spec.rb
+++ b/spec/controllers/diagnoses/steps_controller_spec.rb
@@ -29,7 +29,17 @@ RSpec.describe Diagnoses::StepsController, type: :controller do
     let(:advisor) { current_user }
 
     describe 'with the original address' do
-      let(:params) { { diagnosis: { visitee_attributes: { full_name: "Edith Piaf", role: "directrice", email: "edith@piaf.fr", phone_number: "0606060606" }, happened_on: "27/01/2020" }, id: diagnosis.id } }
+      let(:params) do
+        {
+          id: diagnosis.id,
+          diagnosis: {
+            happened_on: "27/01/2020",
+            visitee_attributes: {
+              full_name: "Edith Piaf", role: "directrice", email: "edith@piaf.fr", phone_number: "0606060606"
+            }
+          }
+        }
+      end
 
       it 'create a visitee for diagnosis' do
         post :update_visit, params: params
@@ -40,7 +50,18 @@ RSpec.describe Diagnoses::StepsController, type: :controller do
     end
 
     describe 'with custom address' do
-      let(:params) { { diagnosis: { visitee_attributes: { full_name: "Edith Piaf", role: "directrice", email: "edith@piaf.fr", phone_number: "0606060606" }, happened_on: "27/01/2020" }, id: diagnosis.id, insee_code: '78586' } }
+      let(:params) do
+        {
+          id: diagnosis.id,
+          insee_code: '78586',
+          diagnosis: {
+            happened_on: "27/01/2020",
+            visitee_attributes: {
+              full_name: "Edith Piaf", role: "directrice", email: "edith@piaf.fr", phone_number: "0606060606",
+            },
+          }
+        }
+      end
       let(:url) { "https://geo.api.gouv.fr/communes/78586?fields=nom,codesPostaux" }
 
       before do

--- a/spec/controllers/diagnoses_controller_spec.rb
+++ b/spec/controllers/diagnoses_controller_spec.rb
@@ -84,20 +84,52 @@ RSpec.describe DiagnosesController, type: :controller do
     end
   end
 
-  describe 'POST #create_diagnosis_without_siret' do
-    let(:params) { { insee_code: '78586', name: 'analyse sans siret' } }
-    let(:url) { "https://geo.api.gouv.fr/communes/78586?fields=nom,codesPostaux" }
+  describe 'POST #create' do
+    let(:params) { { diagnosis: { facility_attributes: facility_params } } }
 
-    before do
-      stub_request(:get, url).to_return(
-        body: file_fixture('geo_api_communes_78586.json')
-      )
+    context 'with no facility data' do
+      let(:facility_params) { { invalid: 'value' } }
+
+      it 'returns an error' do
+        post :create, params: params
+
+        expect(response).to have_http_status(:unprocessable_entity)
+      end
     end
 
-    it "creates a new diagnosis without siret" do
-      post :create_diagnosis_without_siret, params: params
-      expect(response).to have_http_status(:redirect)
-      expect(response).to redirect_to needs_diagnosis_path(Diagnosis.last)
+    context 'with a facility siret' do
+      let(:siret) { '12345678901234' }
+      let(:facility_params) { { siret: siret } }
+      let(:facility) { create(:facility, siret: siret) }
+
+      before do
+        allow(UseCases::SearchFacility).to receive(:with_siret_and_save).with(siret) { facility }
+      end
+
+      it 'fetches info for ApiEntreprise and creates the diagnosis' do
+        post :create, params: params
+
+        expect(UseCases::SearchFacility).to have_received(:with_siret_and_save).with(siret)
+        expect(response).to have_http_status(:redirect)
+        expect(response).to redirect_to(needs_diagnosis_path(Diagnosis.last))
+      end
+    end
+
+    context 'with manual facility info' do
+      let(:insee_code) { '78586' }
+      let(:facility_params) { { insee_code: insee_code, company_attributes: { name: 'analyse sans siret' } } }
+
+      before do
+        city_json = JSON.parse(file_fixture('geo_api_communes_78586.json').read)
+        allow(ApiAdresse::Query).to receive(:city_with_code).with(insee_code) { city_json }
+      end
+
+      it "creates a new diagnosis without siret" do
+        post :create, params: params
+
+        expect(response).to have_http_status(:redirect)
+        expect(response).to redirect_to needs_diagnosis_path(Diagnosis.last)
+      end
     end
   end
 end

--- a/spec/models/facility_spec.rb
+++ b/spec/models/facility_spec.rb
@@ -28,7 +28,7 @@ RSpec.describe Facility, type: :model do
 
     before do
       stub_request(:get, "https://geo.api.gouv.fr/communes/78586?fields=nom,codesPostaux")
-        .to_return(body: File.read(Rails.root.join('spec', 'fixtures', 'geo_api_communes_78586.json')))
+        .to_return(body: file_fixture('geo_api_communes_78586.json'))
     end
 
     it do

--- a/spec/models/facility_spec.rb
+++ b/spec/models/facility_spec.rb
@@ -23,6 +23,21 @@ RSpec.describe Facility, type: :model do
     it { is_expected.to eq 'Mc Donalds (59600 Maubeuge)' }
   end
 
+  describe '#insee_code=' do
+    let(:facility) { build :facility }
+
+    before do
+      stub_request(:get, "https://geo.api.gouv.fr/communes/78586?fields=nom,codesPostaux")
+        .to_return(body: File.read(Rails.root.join('spec', 'fixtures', 'geo_api_communes_78586.json')))
+    end
+
+    it do
+      facility.insee_code = '78586'
+
+      expect(facility.readable_locality).to eq '78500 Sartrouville'
+    end
+  end
+
   describe 'siret validation' do
     describe 'siret_from_query' do
       subject { described_class.siret_from_query(query) }

--- a/spec/views/companies/show.html.haml_spec.rb
+++ b/spec/views/companies/show.html.haml_spec.rb
@@ -14,6 +14,7 @@ RSpec.describe 'companies/show.html.haml', type: :view do
   let(:diagnoses) { create_list :diagnosis, 2 }
 
   before do
+    assign :diagnosis, build(:diagnosis)
     assign :facility, ApiEntreprise::EtablissementWrapper.new(facility_json)
     assign :company, ApiEntreprise::EntrepriseWrapper.new(company_json)
     assign :diagnoses, diagnoses


### PR DESCRIPTION
Prepare for #940: move the diagnosis creation to a diagnosis_creation concern

1. Add insee_code getter and setter to facility
* implicitly fetch the geo api for details
2. Unify the diagnosis create methods and better params
* Use diagnosis#create instead of company#create_diagnosis_from_siret and diagnosis#create_diagnosis_without_siret
* Nest attributes for diagnosis.facility and facility.company
* Use local forms for now, so that _at least_ errors get displayed. We’ll do some js magic another time.
  * That’s a step from from returning 400 with no content
* In company#show, use a proper form, instead of an implicit link_to form. Additionally, it’s more elegant for the hidden parameters.
* The other advantage is that diagnosis creation errors, now, are always validation errors and can be displayed without special handling.