### PR TITLE
Cleanup updated_at, touches, and last_activity_at

### DIFF
--- a/app/admin/need.rb
+++ b/app/admin/need.rb
@@ -21,7 +21,7 @@ ActiveAdmin.register Need do
     end
     column :advisor
     column :created_at
-    column :last_activity_at
+    column :updated_at
     column :status do |d|
       status_status_tag(d.status)
       status_tag t('activerecord.attributes.need.is_archived') if d.is_archived
@@ -61,7 +61,7 @@ ActiveAdmin.register Need do
     column :content
     column :advisor
     column :created_at
-    column :last_activity_at
+    column :updated_at
     column :status_short_description
     column :is_archived
     column_count :matches
@@ -75,7 +75,7 @@ ActiveAdmin.register Need do
       row :subject
       row :advisor
       row :created_at
-      row :last_activity_at
+      row :updated_at
       row :archived_at
       row :content
       row(:status) { |d| status_status_tag(d.status) }

--- a/app/models/need.rb
+++ b/app/models/need.rb
@@ -109,7 +109,7 @@ class Need < ApplicationRecord
       .distinct
   end
 
-  scope :abandoned, -> { no_activity_after(2.weeks.ago) }
+  scope :abandoned, -> { no_activity_after(ABANDONED_DELAY.ago) }
 
   scope :with_some_matches_in_status, -> (status) do # can be an array
     joins(:matches).where(matches: Match.unscoped.where(status: status)).distinct
@@ -171,8 +171,10 @@ class Need < ApplicationRecord
     dates.compact.max
   end
 
+  ABANDONED_DELAY = 2.weeks
+
   def abandoned?
-    last_activity_at < 3.weeks.ago
+    last_activity_at < ABANDONED_DELAY.ago
   end
 
   def quo_experts

--- a/app/views/diagnoses/_diagnosis.haml
+++ b/app/views/diagnoses/_diagnosis.haml
@@ -17,5 +17,5 @@
             .sub.header
               = need.matches.human_count
               - if need.abandoned?
-                .ui.label.basic.orange= t('.last_activity_date', l: l(need.last_activity_at.to_date, format: :long))
+                .ui.label.basic.orange= t('.last_activity_date', l: l(need.updated_at.to_date, format: :long))
     = render 'diagnoses/archive_action', diagnosis: diagnosis

--- a/config/locales/models.fr.yml
+++ b/config/locales/models.fr.yml
@@ -392,7 +392,6 @@ fr:
     interview_sort_order: Ordre dans le questionnaire
     is_archived: Archivé
     label: Intitulé
-    last_activity_at: Dernière activité
     legal_form_code: Forme juridique
     matches:
       one: Mise en relation

--- a/lib/tasks/fixup_updated_at.rake
+++ b/lib/tasks/fixup_updated_at.rake
@@ -1,0 +1,111 @@
+namespace :fixup_updated_at do
+  def disable_timestamps
+    # Prevent (more) accidental timestamp updates
+    # (we’re using update_column, so this is actually unneeded, but it’s a good policy nonetheless.)
+    before_value = ActiveRecord::Base.record_timestamps
+    ActiveRecord::Base.record_timestamps = false
+    yield
+    ActiveRecord::Base.record_timestamps = before_value
+  end
+
+  # For #676 we accidentaly touched all the matches.
+  # migrate_skills_to_instituion.rake was run on Thu, 28 Nov 2019 17:50.
+  # In match, :updated_at is always the max of :created_at, :taken_care_of_at, :closed_at
+  task accidentally_touched_matches: :environment do
+    disable_timestamps do
+      matches_accidentaly_touched = Match.where("updated_at > closed_at")
+        .or(Match.where(closed_at: nil).where('updated_at > taken_care_of_at'))
+
+      matches_accidentaly_touched.find_each do |match|
+        match.update_column(:updated_at, [match.created_at, match.taken_care_of_at, match.closed_at].compact.max)
+      end
+    end
+  end
+
+  # For #926 and #1038 we accidentaly touched all feedbacks.
+  # AddFeedbackableToFeedbacks was run on Tue, 21 Apr 2020 14:45.
+  # expert_to_user_for_feedbacks.rake was run on Thu, 30 Apr 2020 16:41.
+  # In feedback, updated_at is always :created_at
+  task accidentally_touched_feedbacks: :environment do
+    disable_timestamps do
+      feedbacks_accidentaly_touched = Feedback.where("updated_at > created_at")
+
+      feedbacks_accidentaly_touched.find_each do |feedback|
+        feedback.update_column(:updated_at, feedback.created_at)
+      end
+    end
+  end
+
+  # We recently added touch: true to relations:
+  # Match#belongs_to :need
+  # Feedback#belongs_to :need (feedbackable)
+  task touch_needs: :environment do
+    disable_timestamps do
+      needs = Need.left_outer_joins(:matches, :feedbacks)
+        .group('needs.id')
+        .select('needs.*',
+                'max(matches.updated_at) as max_matches_updated_at',
+                'max(feedbacks.updated_at) as max_feedbacks_updated_at')
+
+      needs.find_each do |need|
+        max_updated_at = [
+          need.updated_at,
+          need.max_matches_updated_at,
+          need.max_feedbacks_updated_at
+        ].compact.max
+        need.update_column(:updated_at, max_updated_at)
+      end
+    end
+  end
+
+  # We recently added touch: true to relations:
+  # Need#belongs_to :diagnosis
+  task touch_diagnoses: :environment do
+    disable_timestamps do
+      diagnoses = Diagnosis.left_outer_joins(:needs)
+        .group('diagnoses.id')
+        .select('diagnoses.*',
+                'max(needs.updated_at) as max_needs_updated_at')
+
+      diagnoses.find_each do |diagnosis|
+        max_updated_at = [
+          diagnosis.updated_at,
+          diagnosis.max_needs_updated_at
+        ].compact.max
+        diagnosis.update_column(:updated_at, max_updated_at)
+      end
+    end
+  end
+
+  # We recently added touch: true to relations:
+  # Feedback#belongs_to :solicitation (feedbackable)
+  # Diagnosis#belongs_to :solicitation
+  task touch_solicitations: :environment do
+    disable_timestamps do
+      solicitations = Solicitation.left_outer_joins(:diagnoses, :feedbacks)
+        .group('solicitations.id')
+        .select('solicitations.*',
+                'max(diagnoses.updated_at) as max_diagnoses_updated_at',
+                'max(feedbacks.updated_at) as max_feedbacks_updated_at')
+
+      solicitations.find_each do |solicitation|
+        max_updated_at = [
+          solicitation.updated_at,
+          solicitation.max_diagnoses_updated_at,
+          solicitation.max_feedbacks_updated_at
+        ].compact.max
+        solicitation.update_column(:updated_at, max_updated_at)
+      end
+    end
+  end
+
+  desc 'Fix accidentally touched matches and feedbacks in previous data migration tasks'
+  task accidental_touches: %i[accidentally_touched_matches accidentally_touched_feedbacks]
+
+  desc 'Fix need, diagnoses and solicitations that may have been created before we added the touch: true flags.'
+  task created_before_touch_flag: %i[touch_needs touch_diagnoses touch_solicitations]
+  task all: %i[accidental_touches accidentally_touched_feedbacks]
+end
+
+desc 'Fixup accidentally touched updated_at fields in DB'
+task fixup_updated_at: %w[fixup_updated_at:all]

--- a/spec/factories/feedbacks.rb
+++ b/spec/factories/feedbacks.rb
@@ -6,5 +6,9 @@ FactoryBot.define do
     trait :for_need do
       association :feedbackable, factory: :need
     end
+
+    trait :for_solicitation do
+      association :feedbackable, factory: :solicitation
+    end
   end
 end

--- a/spec/lib/tasks/fixup_updated_at_rake_spec.rb
+++ b/spec/lib/tasks/fixup_updated_at_rake_spec.rb
@@ -1,0 +1,119 @@
+require 'rails_helper'
+require 'rake'
+
+describe 'fixup_updated_at' do
+  before do
+    PlaceDesEntreprises::Application.load_tasks
+    Rake::Task.define_task(:environment)
+  end
+
+  # In these specs, I’m creating empty models in lets,
+  # then change the timestampos in a before statement.
+  # This is because ActiveRecord:timestamp, rspec and factorybot prevent us
+  # to set created_at and updated_at to arbitrary values.
+  # I could use TimeCop, but it would require multiple travels; let’s just set the values manually.
+  let(:day_0) { Time.new(2000,01,01,0,0,0,'+00:00') }
+  let(:day_1) { day_0 + 1.day  }
+  let(:day_2) { day_0 + 2.days }
+  let(:day_3) { day_0 + 3.days }
+
+  describe 'accidentally_touched_matches' do
+    let(:right_match_1) { create :match }
+    let(:right_match_2) { create :match }
+    let(:wrong_match_1) { create :match }
+    let(:wrong_match_2) { create :match }
+
+    before do
+      right_match_1.update_columns(created_at: day_0, taken_care_of_at: day_1, closed_at: day_2, updated_at: day_2)
+      right_match_2.update_columns(created_at: day_0, taken_care_of_at: day_1, closed_at: nil, updated_at: day_1)
+      wrong_match_1.update_columns(created_at: day_0, taken_care_of_at: day_1, closed_at: day_2, updated_at: day_3)
+      wrong_match_2.update_columns(created_at: day_0, taken_care_of_at: day_1, closed_at: nil, updated_at: day_3)
+    end
+
+    it do
+      Rake::Task['fixup_updated_at:accidentally_touched_matches'].invoke
+
+      expect(right_match_1.reload.updated_at).to eq day_2
+      expect(right_match_2.reload.updated_at).to eq day_1
+      expect(wrong_match_1.reload.updated_at).to eq day_2
+      expect(wrong_match_2.reload.updated_at).to eq day_1
+    end
+  end
+
+  describe 'accidentally_touched_feedbacks' do
+    let(:right_feedback) { create :feedback, :for_need }
+    let(:wrong_feedback) { create :feedback, :for_need }
+
+    before do
+      right_feedback.update_columns(created_at: day_0, updated_at: day_0)
+      wrong_feedback.update_columns(created_at: day_0, updated_at: day_1)
+    end
+
+    it do
+      Rake::Task['fixup_updated_at:accidentally_touched_feedbacks'].invoke
+
+      expect(right_feedback.reload.updated_at).to eq day_0
+      expect(wrong_feedback.reload.updated_at).to eq day_0
+    end
+  end
+
+  describe 'touch_needs' do
+    let(:need_1) { create :need }
+    let(:match_1) { create :match }
+    let(:need_2) { create :need }
+    let(:feedback_2) { create :feedback, :for_need }
+
+    before do
+      need_1.update_columns(created_at: day_0, updated_at: day_0)
+      match_1.update_columns(need_id: need_1.id, created_at: day_0, updated_at: day_1)
+
+      need_2.update_columns(created_at: day_0, updated_at: day_0)
+      feedback_2.update_columns(feedbackable_id: need_2.id, created_at: day_0, updated_at: day_1)
+    end
+
+    it do
+      Rake::Task['fixup_updated_at:touch_needs'].invoke
+
+      expect(need_1.reload.updated_at).to eq day_1
+      expect(need_2.reload.updated_at).to eq day_1
+    end
+  end
+
+  describe 'touch_diagnoses' do
+    let(:diagnosis_1) { create :diagnosis }
+    let(:need_1) { create :need }
+
+    before do
+      diagnosis_1.update_columns(created_at: day_0, updated_at: day_0)
+      need_1.update_columns(diagnosis_id: diagnosis_1.id, created_at: day_0, updated_at: day_1)
+    end
+
+    it do
+      Rake::Task['fixup_updated_at:touch_diagnoses'].invoke
+
+      expect(diagnosis_1.reload.updated_at).to eq day_1
+    end
+  end
+
+  describe 'touch_solicitations' do
+    let(:solicitation_1) { create :solicitation }
+    let(:diagnosis_1) { create :diagnosis }
+    let(:solicitation_2) { create :solicitation }
+    let(:feedback_2) { create :feedback, :for_solicitation }
+
+    before do
+      solicitation_1.update_columns(created_at: day_0, updated_at: day_0)
+      diagnosis_1.update_columns(solicitation_id: solicitation_1.id, created_at: day_0, updated_at: day_1)
+
+      solicitation_2.update_columns(created_at: day_0, updated_at: day_0)
+      feedback_2.update_columns(feedbackable_id: solicitation_2.id, created_at: day_0, updated_at: day_1)
+    end
+
+    it do
+      Rake::Task['fixup_updated_at:touch_solicitations'].invoke
+
+      expect(solicitation_1.reload.updated_at).to eq day_1
+      expect(solicitation_2.reload.updated_at).to eq day_1
+    end
+  end
+end

--- a/spec/models/need_spec.rb
+++ b/spec/models/need_spec.rb
@@ -190,39 +190,20 @@ RSpec.describe Need, type: :model do
     end
   end
 
-  describe 'last_activity_at' do
-    subject { need.last_activity_at.beginning_of_day }
-
+  describe 'abandoned' do
     let(:need) { create :need }
-    let(:match) { build :match, need: need }
-    let(:feedback) { build :feedback, feedbackable: need }
+    let(:old_need) { Timecop.freeze(2.months.ago) { create :need } }
 
-    let(:date1) { Time.zone.now.beginning_of_day }
-    let(:date2) { date1 + 5.days }
-    let(:date3) { date1 + 10.days }
+    it do
+      expect(need).not_to be_abandoned
+      expect(old_need).to be_abandoned
+      expect(described_class.abandoned).to match_array([old_need])
 
-    context 'with no match activity' do
-      it { is_expected.to eq date1 }
-    end
-
-    context 'with recent match activity' do
-      before do
-        Timecop.travel(date2) do
-          match.save
-        end
+      Timecop.freeze(2.months.from_now) do
+        expect(need).to be_abandoned
+        expect(old_need).to be_abandoned
+        expect(described_class.abandoned).to match_array([need, old_need])
       end
-
-      it { is_expected.to eq date2 }
-    end
-
-    context 'with recent feedback' do
-      before do
-        Timecop.travel(date3) do
-          feedback.save
-        end
-      end
-
-      it { is_expected.to eq date3 }
     end
   end
 


### PR DESCRIPTION
Related to #1023, #1024 and #940: this is moving a lot these days.

1. A rake task to fix and cleanup the updated_at values, following accidents and refactors (we have some baddata)
2. Removal of Need.last_activity_at, now that we can just use Need.updated_at. It was always clumsy.

WIP:
* [x] proper tests