### PR TITLE
Create matches before sending notifications

### DIFF
--- a/app/controllers/diagnoses/steps_controller.rb
+++ b/app/controllers/diagnoses/steps_controller.rb
@@ -51,6 +51,18 @@ class Diagnoses::StepsController < ApplicationController
   end
 
   def matches
+    # TODO: experimental/preliminary support for automatic diagnoses #940
+    if ENV['FEATURE_PRESELECT_DIAGNOSIS'].to_b && @diagnosis.matches.blank? && @diagnosis.solicitation.present?
+      institutions = @diagnosis.solicitation.preselected_institutions
+      @diagnosis.needs.each do |need|
+        relevant_expert_subjects = ExpertSubject.relevant_for(need)
+        relevant_expert_subjects = relevant_expert_subjects
+          .joins(institution_subject: :institution)
+          .where(institutions_subjects: { institution: institutions })
+        # do not filter with specialist/fallback here, the institution selection overrides this
+        need.matches = relevant_expert_subjects.map { |expert_subject| Match.new(expert: expert_subject.expert, subject: expert_subject.subject) }
+      end
+    end
   end
 
   def update_matches

--- a/app/models/diagnosis.rb
+++ b/app/models/diagnosis.rb
@@ -123,18 +123,6 @@ class Diagnosis < ApplicationRecord
 
   ## Matching
   #
-  def match_and_notify!(experts_and_subjects_for_needs)
-    update_result = self.transaction do
-      experts_and_subjects_for_needs.each do |need_id, experts_and_subjects_ids|
-        need = self.needs.find(need_id)
-        need.create_matches!(experts_and_subjects_ids)
-      end
-      self.update!(step: Diagnosis.steps[:completed])
-    end
-    notify_matches_made!
-    update_result
-  end
-
   def notify_matches_made!
     # Notify experts
     experts.each do |expert|

--- a/app/models/need.rb
+++ b/app/models/need.rb
@@ -41,6 +41,8 @@ class Need < ApplicationRecord
   validates :diagnosis, presence: true
   validates :subject, uniqueness: { scope: :diagnosis_id }
 
+  accepts_nested_attributes_for :matches, allow_destroy: true
+
   ## Through Associations
   #
   # :diagnosis
@@ -191,11 +193,4 @@ class Need < ApplicationRecord
   end
 
   include StatusHelper::StatusDescription
-
-  ##
-  #
-  def create_matches!(experts_subjects_ids)
-    experts_subjects = ExpertSubject.where(id: experts_subjects_ids)
-    self.matches.create(experts_subjects.map{ |es| es.slice(:expert, :subject) })
-  end
 end

--- a/app/views/diagnoses/steps/_expert_subject_checkboxes.html.haml
+++ b/app/views/diagnoses/steps/_expert_subject_checkboxes.html.haml
@@ -1,27 +1,23 @@
 .experts_subject_checkbox
-  = f.fields_for need.id.to_s do |fields|
+  = form.fields_for :needs, need do |need_form|
+    = need_form.hidden_field :id
     - experts_subjects.each do |expert_subject|
       - expert = expert_subject.expert
       .ui.field
         .ui.checkbox
-          :ruby
-            # TODO: experimental/preliminary support for automatic diagnoses #940
-            if ENV['FEATURE_PRESELECT_DIAGNOSIS'].to_b && need.diagnosis.solicitation.present?
-              institutions = need.diagnosis.solicitation.preselected_institutions || []
-              checked = expert_subject.institution_subject.institution.in? institutions
-            else
-              checked = true
-            end
-
-          = fields.check_box expert_subject.id, checked: checked
-          = fields.label expert_subject.id do
-            .ui.equal.width.grid
-              .row
-                .column
-                  %h4.ui.header
-                    = expert.full_name
-                    .sub.header= expert.role
-                    .sub.header= expert.antenne
-                .column
-                  .sub.header
-                    = expert_subject.full_user_description
+          - match = need.matches.where(expert: expert, subject: expert_subject.subject).first_or_initialize
+          = need_form.fields_for :matches, match do |match_form|
+            = match_form.hidden_field :expert_id
+            = match_form.hidden_field :subject_id
+            = match_form.check_box :_destroy, { checked: match.persisted? }, '0', '1'
+            = match_form.label :_destroy do
+              .ui.equal.width.grid
+                .row
+                  .column
+                    %h4.ui.header
+                      = expert.full_name
+                      .sub.header= expert.role
+                      .sub.header= expert.antenne
+                  .column
+                    .sub.header
+                      = expert_subject.full_user_description

--- a/app/views/diagnoses/steps/matches.html.haml
+++ b/app/views/diagnoses/steps/matches.html.haml
@@ -8,9 +8,8 @@
 
   = form_with model: @diagnosis,
     url: update_matches_diagnosis_path(@diagnosis),
-    scope: :matches,
     class: 'ui form',
-    data: { checkboxes_require_one_with: t(".select_at_least_one_expert") } do |f|
+    data: { checkboxes_require_one_with: t(".select_at_least_one_expert") } do |form|
     - @diagnosis.needs.ordered_for_interview.each do |need|
       .ui.segment.shadow-less
         %h3.ui.header= need.subject
@@ -18,15 +17,15 @@
         - experts_subjects_fallback = ExpertSubject.relevant_for(need).fallback
         - support_subject = ExpertSubject.support_for(@diagnosis)
         - if experts_subjects_specialists.present?
-          = render 'expert_subject_checkboxes', f: f, need: need, experts_subjects: experts_subjects_specialists
+          = render 'expert_subject_checkboxes', form: form, need: need, experts_subjects: experts_subjects_specialists
         - elsif experts_subjects_fallback.present?
-          = render 'expert_subject_checkboxes', f: f, need: need, experts_subjects: experts_subjects_fallback
+          = render 'expert_subject_checkboxes', form: form, need: need, experts_subjects: experts_subjects_fallback
         - elsif support_subject.present?
           .field.warning
             .ui.warning.message
               = t('.no_expert_subject')
               = t('.you_can_contact_support')
-          = render 'expert_subject_checkboxes', f: f, need: need, experts_subjects: support_subject
+          = render 'expert_subject_checkboxes', form: form, need: need, experts_subjects: support_subject
         - else
           %p= t('.no_expert_subject')
 

--- a/spec/models/diagnosis_spec.rb
+++ b/spec/models/diagnosis_spec.rb
@@ -97,35 +97,4 @@ RSpec.describe Diagnosis, type: :model do
       end
     end
   end
-
-  describe 'match_and_notify!' do
-    subject(:match_and_notify) { diagnosis.match_and_notify!(matches) }
-
-    let(:diagnosis) { create :diagnosis, step: :matches }
-    let(:need) { create :need, diagnosis: diagnosis }
-    let(:expert) { create :expert }
-    let(:experts_subjects) { create :expert_subject, expert: expert, subject: need.subject }
-    let(:matches) { { need.id => [experts_subjects.id] } }
-
-    context 'selected experts_subjects for related needs' do
-      it do
-        expect{ match_and_notify }.to change(Match, :count).by(1)
-        expect(Match.last.expert).to eq expert
-        expect(Match.last.subject).to eq need.subject
-        expect(diagnosis.step_completed?).to be true
-      end
-    end
-
-    context 'no selected expert_subjects' do
-      let(:matches) { { need.id => [] } }
-
-      it { expect{ match_and_notify }.to raise_error ActiveRecord::RecordInvalid }
-    end
-
-    context 'unrelated need' do
-      let(:need) { create :need }
-
-      it { expect{ match_and_notify }.to raise_error ActiveRecord::RecordNotFound }
-    end
-  end
 end


### PR DESCRIPTION
refs #940

* Refactor Steps#updates_matches parameters: 
  * Use nested attributes, instead of a custom serialization
* Preselect diagnoses matches by actually creating matches
  * Instead of just pre-checking the boxes in the UI. This means creating matches before sending the notifications!

After this change, all the automatic selection to diagnoses is done in the get actions of steps_controller; we now just have to move it all to methods in DiagnosisCreation.