### PR TITLE
More refactor for diagnosis creation

### DIFF
--- a/app/controllers/diagnoses/steps_controller.rb
+++ b/app/controllers/diagnoses/steps_controller.rb
@@ -26,8 +26,12 @@ class Diagnoses::StepsController < ApplicationController
 
   def visit
     if @diagnosis.visitee.nil? && @diagnosis.solicitation.present?
-      @diagnosis.visitee = Contact.new(full_name:  @diagnosis.solicitation.full_name, email: @diagnosis.solicitation.email,
-                            phone_number: @diagnosis.solicitation.phone_number)
+      visitee = Contact.create(full_name: @diagnosis.solicitation.full_name,
+                               email: @diagnosis.solicitation.email,
+                               phone_number: @diagnosis.solicitation.phone_number,
+                               company: @diagnosis.facility.company,
+                               role: t('contact.default_role_from_solicitation'))
+      @diagnosis.update(visitee: visitee)
     end
   end
 

--- a/app/models/concerns/diagnosis_creation.rb
+++ b/app/models/concerns/diagnosis_creation.rb
@@ -1,16 +1,18 @@
 module DiagnosisCreation
-  # Helpers for diagnosis creation forms:
-  # The creation params hash for a diagnosis has nested attributes for #facility and #facility#company.
+  # Helper for the diagnosis creation form:
   # Build a new diagnosis with an new facility and company:
+  # The creation params hash for a diagnosis has nested attributes for #facility and #facility#company.
   # These will be used `fields_for` form helpers.
   def self.new_diagnosis(solicitation)
     Diagnosis.new(solicitation: solicitation,
                   facility: Facility.new(company: Company.new(name: solicitation&.full_name)))
   end
 
+  # Actually create a diagnosis with nested attributes for #facility and #company
   def self.create_diagnosis(params)
     Diagnosis.transaction do
       if params[:facility_attributes].include? :siret
+        params = params.dup # avoid modifying the params hash at the call site
         # Facility attributes are nested in the hash; if there is no siret, we use the insee_code.
         # In particular, the facility.insee_code= setter will fetch the readable locality name from the geo api.
         # TODO: Get rid of UseCases::SearchFacility and handle implicitely in `facility#siret=`,

--- a/config/locales/models.fr.yml
+++ b/config/locales/models.fr.yml
@@ -465,5 +465,7 @@ fr:
     user: Conseiller
     visit: Visite
     visitee: Personne rencontrée
+  contact:
+    default_role_from_solicitation: "(Solicitation déposée sur Place des entreprises)"
   deleted_user:
     full_name: "(Compte supprimé)"

--- a/spec/models/concerns/diagnosis_creation_spec.rb
+++ b/spec/models/concerns/diagnosis_creation_spec.rb
@@ -1,0 +1,75 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe DiagnosisCreation do
+  describe 'new_diagnosis' do
+    context 'with a solicitation' do
+      subject(:diagnosis){ described_class.new_diagnosis(solicitation) }
+
+      let(:solicitation) { build :solicitation, full_name: 'my company' }
+
+      it do
+        expect(diagnosis.facility.company.name).to eq 'my company'
+      end
+    end
+  end
+
+  describe 'create_diagnosis' do
+    # the subject has to be called as a block (expect{create_diagnosis}) for raise matchers to work correctly.
+    subject(:create_diagnosis) { described_class.create_diagnosis(params) }
+
+    let(:advisor) { create :user }
+    let(:params) { { advisor: advisor, facility_attributes: facility_params } }
+
+    context 'with invalid facility data' do
+      let(:facility_params) { { invalid: 'value' } }
+
+      it do
+        expect{ create_diagnosis }.to raise_error ActiveModel::UnknownAttributeError
+      end
+    end
+
+    context 'with a facility siret' do
+      let(:siret) { '12345678901234' }
+      let(:facility_params) { { siret: siret } }
+
+      context 'when the siret is valid' do
+        before do
+          allow(UseCases::SearchFacility).to receive(:with_siret_and_save).with(siret) { create(:facility, siret: siret) }
+        end
+
+        it 'fetches info for ApiEntreprise and creates the diagnosis' do
+          expect{ create_diagnosis }.not_to raise_error
+          expect(create_diagnosis).to be_valid
+        end
+      end
+
+      context 'when the siret is unknown' do
+        before do
+          allow(UseCases::SearchFacility).to receive(:with_siret_and_save).with(siret) { raise ApiEntreprise::ApiEntrepriseError, 'some error message' }
+        end
+
+        it 'fetches info for ApiEntreprise and creates the diagnosis' do
+          expect{ create_diagnosis }.to raise_error ApiEntreprise::ApiEntrepriseError
+        end
+      end
+    end
+
+    context 'with manual facility info' do
+      let(:insee_code) { '78586' }
+      let(:facility_params) { { insee_code: insee_code, company_attributes: { name: 'Boucherie Sanzot' } } }
+
+      before do
+        city_json = JSON.parse(file_fixture('geo_api_communes_78586.json').read)
+        allow(ApiAdresse::Query).to receive(:city_with_code).with(insee_code) { city_json }
+      end
+
+      it 'creates a new diagnosis without siret' do
+        expect{ create_diagnosis }.not_to raise_error
+        expect(create_diagnosis).to be_valid
+        expect(create_diagnosis.company.name).to eq 'Boucherie Sanzot'
+      end
+    end
+  end
+end


### PR DESCRIPTION
more refactor for #940:
* split creation tests for diagnoses between controller related tests (i.e. http responses) and actual creation code
* in the visit step, _actually_ create the visitee in db using the details from the solicitation. This is in line with the behviour for the needs and matches steps.
* do not mark the solicitation as “processed” before the diagnosis is completed and the notifications are sent.