### PR TITLE
Fix weekly_statistics email delivery

### DIFF
--- a/app/models/clockwork.rb
+++ b/app/models/clockwork.rb
@@ -4,10 +4,10 @@ require './config/environment'
 
 module Clockwork
   every(1.week, 'send_app_administrators_statistics_email', at: 'Monday 07:30') do
-    AdminMailersService.send_statistics_email.deliver_later
+    AdminMailersService.delay.send_statistics_email
   end
 
   every(1.week, 'send_experts_reminders', at: 'Tuesday 9:00') do
-    ExpertReminderService.send_reminders.deliver_later
+    ExpertReminderService.delay.send_reminders
   end
 end

--- a/app/services/admin_mailers_service.rb
+++ b/app/services/admin_mailers_service.rb
@@ -30,14 +30,14 @@ class AdminMailersService
       recently_signed_up_users = User.created_last_week
       @information_hash[:signed_up_users] = {}
       @information_hash[:signed_up_users][:count] = recently_signed_up_users.count
-      @information_hash[:signed_up_users][:items] = recently_signed_up_users
+      @information_hash[:signed_up_users][:items] = recently_signed_up_users.to_a
     end
 
     def created_diagnoses_statistics
       created_diagnoses = @not_admin_diagnoses.in_progress.created_last_week
       @information_hash[:created_diagnoses] = {}
       @information_hash[:created_diagnoses][:count] = created_diagnoses.count
-      @information_hash[:created_diagnoses][:items] = created_diagnoses
+      @information_hash[:created_diagnoses][:items] = created_diagnoses.to_a
     end
 
     def updated_diagnoses_statistics
@@ -45,13 +45,13 @@ class AdminMailersService
       updated_diagnoses = updated_diagnoses.where('diagnoses.created_at < ?', 1.week.ago)
       @information_hash[:updated_diagnoses] = {}
       @information_hash[:updated_diagnoses][:count] = updated_diagnoses.count
-      @information_hash[:updated_diagnoses][:items] = updated_diagnoses
+      @information_hash[:updated_diagnoses][:items] = updated_diagnoses.to_a
     end
 
     def completed_diagnoses_statistics
       @information_hash[:completed_diagnoses] = {}
       @information_hash[:completed_diagnoses][:count] = @completed_diagnoses.count
-      @information_hash[:completed_diagnoses][:items] = @completed_diagnoses
+      @information_hash[:completed_diagnoses][:items] = @completed_diagnoses.to_a
     end
 
     def matches_count_statistics


### PR DESCRIPTION
broken in #738 (4 months ago.)

There are two bugs, and we never found out because we don’t have sentry running on clockwork.
* In clockwork.rb, we can’t use `deliver_later` for AdminMailersService.send_statistics_email and ExpertReminderService.send_reminders: deliver_later is a method of ActionMailer, the service methods don’t return mailers. They are simply meant to be run as regular jobs. Changing it in #738 was a mistake.
* For ExpertReminderService.send_reminders, this is not really a problem: the service method enqueues the mailer jobs, and returns an array; after that, the calling method in clockwork.rb crashes, but the actual mailer jobs are enqueued.
* In AdminMailersService.send_statistics_email, there is another unrelated issue: we’re using ActiveJob’s deliver_later to enqueue, instead of DelayedJob. There is now a crash when trying to enqueue the weekly_statistics mailer job, because some of the params in the hash are activerecord relations (queries). DelayedJob’s knows how to serialize these in postgresql, but ActiveJob cannot do that. The fix is then to convert these relations to actual arrays ourselves.

Anyway, we’ll revisit this weekly email soonish.