### PR TITLE
Make diagnosis advisor optional

### DIFF
--- a/app/controllers/diagnoses_controller.rb
+++ b/app/controllers/diagnoses_controller.rb
@@ -44,6 +44,7 @@ class DiagnosesController < ApplicationController
   def show
     authorize @diagnosis
     if @diagnosis.step_completed?
+      # let needs_controller handle completed diagnoses
       redirect_to need_path(@diagnosis)
     else
       redirect_to controller: 'diagnoses/steps', action: @diagnosis.step, id: @diagnosis

--- a/app/controllers/needs_controller.rb
+++ b/app/controllers/needs_controller.rb
@@ -53,6 +53,11 @@ class NeedsController < ApplicationController
   def show
     @diagnosis = retrieve_diagnosis
     authorize @diagnosis
+    unless @diagnosis.step_completed?
+      # let diagnoses_controller (and steps_controller) handle incomplete diagnoses
+      redirect_to @diagnosis and return
+    end
+
     @highlighted_experts = highlighted_experts
   end
 

--- a/app/models/diagnosis.rb
+++ b/app/models/diagnosis.rb
@@ -43,7 +43,7 @@ class Diagnosis < ApplicationRecord
   ## Associations
   #
   belongs_to :facility, inverse_of: :diagnoses
-  belongs_to :advisor, class_name: 'User', inverse_of: :sent_diagnoses
+  belongs_to :advisor, class_name: 'User', inverse_of: :sent_diagnoses, optional: true
   belongs_to :visitee, class_name: 'Contact', inverse_of: :diagnoses, optional: true
   belongs_to :solicitation, optional: true, inverse_of: :diagnoses, touch: true
 
@@ -54,6 +54,7 @@ class Diagnosis < ApplicationRecord
   validate :step_visit_has_needs
   validate :step_matches_has_visit_attributes
   validate :step_completed_has_matches
+  validate :step_completed_has_advisor
 
   accepts_nested_attributes_for :facility
   accepts_nested_attributes_for :needs, allow_destroy: true
@@ -161,6 +162,14 @@ class Diagnosis < ApplicationRecord
     if step_completed?
       if needs&.flat_map(&:matches)&.empty? # Note: we can’t rely on `self.matches` (a :through association) before the objects are actually saved
         errors.add(:step, 'can’t be step 5 with no matches')
+      end
+    end
+  end
+
+  def step_completed_has_advisor
+    if step_completed?
+      if advisor.nil?
+        errors.add(:advisor, :blank)
       end
     end
   end

--- a/app/models/diagnosis.rb
+++ b/app/models/diagnosis.rb
@@ -55,6 +55,7 @@ class Diagnosis < ApplicationRecord
   validate :step_matches_has_visit_attributes
   validate :step_completed_has_matches
   validate :step_completed_has_advisor
+  validate :without_solicitation_has_advisor
 
   accepts_nested_attributes_for :facility
   accepts_nested_attributes_for :needs, allow_destroy: true
@@ -168,6 +169,14 @@ class Diagnosis < ApplicationRecord
 
   def step_completed_has_advisor
     if step_completed?
+      if advisor.nil?
+        errors.add(:advisor, :blank)
+      end
+    end
+  end
+
+  def without_solicitation_has_advisor
+    if solicitation.nil?
       if advisor.nil?
         errors.add(:advisor, :blank)
       end

--- a/app/models/diagnosis.rb
+++ b/app/models/diagnosis.rb
@@ -9,8 +9,8 @@
 #  step            :integer          default("not_started")
 #  created_at      :datetime         not null
 #  updated_at      :datetime         not null
-#  advisor_id      :bigint(8)        not null
-#  facility_id     :bigint(8)
+#  advisor_id      :bigint(8)
+#  facility_id     :bigint(8)        not null
 #  solicitation_id :bigint(8)
 #  visitee_id      :bigint(8)
 #

--- a/app/models/diagnosis.rb
+++ b/app/models/diagnosis.rb
@@ -51,7 +51,6 @@ class Diagnosis < ApplicationRecord
 
   ## Validations and Callbacks
   #
-  validates :advisor, :facility, presence: true
   validate :step_visit_has_needs
   validate :step_matches_has_visit_attributes
   validate :step_completed_has_matches

--- a/db/migrate/20200527114540_tweak_diagnosis_belongs_tos.rb
+++ b/db/migrate/20200527114540_tweak_diagnosis_belongs_tos.rb
@@ -1,0 +1,6 @@
+class TweakDiagnosisBelongsTos < ActiveRecord::Migration[6.0]
+  def change
+    change_column_null :diagnoses, :facility_id, false # Diagnosis.facility should already be not null
+    change_column_null :diagnoses, :advisor_id, true # Diagnosis.advisor is becoming nullable for #940
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_05_25_134347) do
+ActiveRecord::Schema.define(version: 2020_05_27_114540) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -131,9 +131,9 @@ ActiveRecord::Schema.define(version: 2020_05_25_134347) do
     t.datetime "updated_at", null: false
     t.integer "step", default: 1
     t.datetime "archived_at"
-    t.bigint "advisor_id", null: false
+    t.bigint "advisor_id"
     t.bigint "visitee_id"
-    t.bigint "facility_id"
+    t.bigint "facility_id", null: false
     t.date "happened_on"
     t.bigint "solicitation_id"
     t.index ["advisor_id"], name: "index_diagnoses_on_advisor_id"

--- a/spec/models/diagnosis_spec.rb
+++ b/spec/models/diagnosis_spec.rb
@@ -5,7 +5,6 @@ require 'rails_helper'
 RSpec.describe Diagnosis, type: :model do
   it do
     is_expected.to have_many :needs
-    is_expected.to belong_to :advisor
     is_expected.to belong_to :facility
   end
 
@@ -59,6 +58,25 @@ RSpec.describe Diagnosis, type: :model do
 
       context 'with matches' do
         before { diagnosis.needs << build(:need, matches: [build(:match)]) }
+
+        it { is_expected.to be_valid }
+      end
+    end
+
+    describe 'step_completed_has_advisor' do
+      subject(:diagnosis) { build :diagnosis, step: :completed, needs: [build(:need, matches: [build(:match)])], advisor: advisor }
+
+      before { diagnosis.validate }
+
+      context 'without advisor' do
+        let(:advisor) { nil }
+
+        it { is_expected.not_to be_valid }
+        it { expect(diagnosis.errors.details).to eq({ advisor: [{ error: :blank }] }) }
+      end
+
+      context 'with advisor' do
+        let(:advisor) { build :user }
 
         it { is_expected.to be_valid }
       end

--- a/spec/models/diagnosis_spec.rb
+++ b/spec/models/diagnosis_spec.rb
@@ -64,7 +64,28 @@ RSpec.describe Diagnosis, type: :model do
     end
 
     describe 'step_completed_has_advisor' do
-      subject(:diagnosis) { build :diagnosis, step: :completed, needs: [build(:need, matches: [build(:match)])], advisor: advisor }
+      subject(:diagnosis) { build :diagnosis, solicitation: solicitation, step: :completed, needs: [build(:need, matches: [build(:match)])], advisor: advisor }
+
+      let(:solicitation) { build :solicitation }
+
+      before { diagnosis.validate }
+
+      context 'without advisor' do
+        let(:advisor) { nil }
+
+        it { is_expected.not_to be_valid }
+        it { expect(diagnosis.errors.details).to eq({ advisor: [{ error: :blank }] }) }
+      end
+
+      context 'with advisor' do
+        let(:advisor) { build :user }
+
+        it { is_expected.to be_valid }
+      end
+    end
+
+    describe 'without_solicitation_has_advisor' do
+      subject(:diagnosis) { build :diagnosis, solicitation: nil, advisor: advisor }
 
       before { diagnosis.validate }
 

--- a/spec/models/diagnosis_spec.rb
+++ b/spec/models/diagnosis_spec.rb
@@ -10,38 +10,55 @@ RSpec.describe Diagnosis, type: :model do
   end
 
   describe 'custom validations' do
-    describe 'last_step_has_matches' do
-      subject(:diagnosis) { build :diagnosis, step: described_class.steps[:completed] }
+    describe 'step_visit_has_needs' do
+      subject(:diagnosis) { build :diagnosis, step: :visit, needs: needs }
+
+      before { diagnosis.validate }
+
+      context 'without needs' do
+        let(:needs) { [] }
+
+        it { is_expected.not_to be_valid }
+        it { expect(diagnosis.errors.details).to eq({ needs: [{ error: :blank }] }) }
+      end
+
+      context 'with needs' do
+        let(:needs) { build_list :need, 2 }
+
+        it { is_expected.to be_valid }
+      end
+    end
+
+    describe 'step_matches_has_visit_attributes' do
+      subject(:diagnosis) { build :diagnosis, step: :matches, visitee: visitee, happened_on: happened_on }
+
+      before { diagnosis.validate }
+
+      context 'missing attributes' do
+        let(:visitee) { nil }
+        let(:happened_on) { nil }
+
+        it { is_expected.not_to be_valid }
+        it { expect(diagnosis.errors.details).to eq({ visitee: [{ error: :blank }], happened_on: [{ error: :blank }] }) }
+      end
+
+      context 'with matches' do
+        let(:visitee) { build :contact_with_email }
+        let(:happened_on) { Date.today }
+
+        it { is_expected.to be_valid }
+      end
+    end
+
+    describe 'step_completed_has_matches' do
+      subject(:diagnosis) { build :diagnosis, step: :completed }
 
       context 'no matches' do
         it { is_expected.not_to be_valid }
       end
 
       context 'with matches' do
-        before do
-          diagnosis.needs << build(:need, matches: [build(:match)])
-        end
-
-        it { is_expected.to be_valid }
-      end
-    end
-
-    describe 'step_4_has_visit_attributes' do
-      subject(:diagnosis) { build :diagnosis, step: :matches, visitee: visitee, happened_on: happened_on }
-
-      context 'missing attributes' do
-        let(:visitee) { nil }
-        let(:happened_on) { nil }
-
-        before { diagnosis.validate }
-
-        it { is_expected.not_to be_valid }
-        it { expect(diagnosis.errors.details.keys).to match_array [:visitee, :happened_on] }
-      end
-
-      context 'with matches' do
-        let(:visitee) { build :contact_with_email }
-        let(:happened_on) { Date.today }
+        before { diagnosis.needs << build(:need, matches: [build(:match)]) }
 
         it { is_expected.to be_valid }
       end

--- a/spec/models/diagnosis_spec.rb
+++ b/spec/models/diagnosis_spec.rb
@@ -7,8 +7,6 @@ RSpec.describe Diagnosis, type: :model do
     is_expected.to have_many :needs
     is_expected.to belong_to :advisor
     is_expected.to belong_to :facility
-    is_expected.to validate_presence_of :advisor
-    is_expected.to validate_presence_of :facility
   end
 
   describe 'custom validations' do


### PR DESCRIPTION
refs #940: when we create diagnoses automatically for received solicitations, there is no _current_user_ making the diagnosis.

This is WIP: Apparently, there is no place in the app when we try to display the diagnosis’ advisor before the diagnosis is complete, but I want to make some more tests.