### PR TITLE
Fixup for automatic visitee creation (prepare_visitee_from_solicitation)

### DIFF
--- a/app/controllers/diagnoses/steps_controller.rb
+++ b/app/controllers/diagnoses/steps_controller.rb
@@ -31,10 +31,6 @@ class Diagnoses::StepsController < ApplicationController
     diagnosis_params = params_for_visit
     diagnosis_params[:visitee_attributes][:company_id] = @diagnosis.facility.company.id
     diagnosis_params[:step] = :matches
-    visitee = Contact.find_by(id: params[:diagnosis][:visitee_attributes][:id]) || Contact.new
-    visitee_params = params.require(:diagnosis).permit(visitee_attributes: [:full_name, :role, :email, :phone_number])[:visitee_attributes]
-    visitee.update(visitee_params)
-    @diagnosis.visitee = visitee
 
     if @diagnosis.update(diagnosis_params)
       redirect_to action: :matches

--- a/app/models/concerns/diagnosis_creation.rb
+++ b/app/models/concerns/diagnosis_creation.rb
@@ -53,13 +53,13 @@ module DiagnosisCreation
     def prepare_visitee_from_solicitation
       return unless solicitation.present? && visitee.blank?
 
-      self.create_visitee(full_name: solicitation.full_name,
+      self.build_visitee(full_name: solicitation.full_name,
                           email: solicitation.email,
                           phone_number: solicitation.phone_number,
                           company: facility.company,
                           role: I18n.t('contact.default_role_from_solicitation'))
 
-      self.validate # If create failed, make the error go up from the visitee to the diagnosis
+      self.save # Validate and save both the new visitee and the diagnosis
 
       self
     end


### PR DESCRIPTION
Fixup after #1071 and #1066

I should have read the doc better:

> The create_association method returns a new object of the associated type. This object will be instantiated from the passed attributes, the link through this object's foreign key will be set, and, once it passes all of the validations specified on the associated model, the associated object will be saved.

“The _associated_ object will be saved”, not the origin object of the relationship. In our case, that means the Contact was saved, but not the Diagnosis. I actually had changed the code the other way round because it seemed better to juste call create, instead of build and save.

🤷🏻‍♂️