### PR TITLE
Prepare diagnosis

### DIFF
--- a/app/controllers/landings_controller.rb
+++ b/app/controllers/landings_controller.rb
@@ -21,6 +21,7 @@ class LandingsController < PagesController
       if ENV['FEATURE_SEND_ADMIN_SOLICITATION_EMAIL'].to_b
         AdminMailer.solicitation(@solicitation).deliver_later
       end
+      @solicitation.delay.prepare_diagnosis(nil)
     end
 
     render :new_solicitation # rerender the form on error, render the thankyou partial on success

--- a/app/controllers/solicitations_controller.rb
+++ b/app/controllers/solicitations_controller.rb
@@ -1,5 +1,5 @@
 class SolicitationsController < ApplicationController
-  before_action :find_solicitation, only: [:show, :update_status, :update_badges]
+  before_action :find_solicitation, only: [:show, :update_status, :update_badges, :prepare_diagnosis]
   before_action :authorize_index_solicitation, only: [:index, :processed, :canceled]
   before_action :authorize_update_solicitation, only: [:update_status]
   before_action :set_category_content, only: %i[index processed canceled]
@@ -44,6 +44,16 @@ class SolicitationsController < ApplicationController
 
   def update_badges
     @solicitation.update(params.require(:solicitation).permit(badge_ids: []))
+  end
+
+  def prepare_diagnosis
+    diagnosis = @solicitation.prepare_diagnosis(current_user)
+    if diagnosis
+      redirect_to diagnosis
+    else
+      # TODO: redirect to @solicitation. See discussion in #1089
+      redirect_to action: :index
+    end
   end
 
   private

--- a/app/helpers/solicitation_helper.rb
+++ b/app/helpers/solicitation_helper.rb
@@ -59,4 +59,14 @@ module SolicitationHelper
 
     tags.join.html_safe
   end
+
+  def link_to_diagnosis(diagnosis)
+    if diagnosis.step_completed?
+      text = t('helpers.solicitation.view_completed_analysis')
+    else
+      text = t('helpers.solicitation.analysis_in_progress', step: t("diagnoses.steps.#{diagnosis.step}.title"))
+    end
+
+    link_to text, diagnosis, class: 'ui item'
+  end
 end

--- a/app/models/concerns/diagnosis_creation.rb
+++ b/app/models/concerns/diagnosis_creation.rb
@@ -67,11 +67,7 @@ module DiagnosisCreation
     def prepare_matches_from_solicitation
       return unless solicitation.present? && matches.blank?
 
-      institutions = solicitation.preselected_institutions
-      if institutions.empty?
-        self.errors.add(:matches, :solicitation_has_no_preselected_institution)
-        return self
-      end
+      institutions = solicitation.preselected_institutions || Institution.all
 
       self.needs.each do |need|
         expert_subjects = ExpertSubject

--- a/app/models/solicitation.rb
+++ b/app/models/solicitation.rb
@@ -2,19 +2,20 @@
 #
 # Table name: solicitations
 #
-#  id                    :bigint(8)        not null, primary key
-#  description           :string
-#  email                 :string
-#  form_info             :jsonb
-#  full_name             :string
-#  landing_options_slugs :string           is an Array
-#  landing_slug          :string           not null
-#  options_deprecated    :jsonb
-#  phone_number          :string
-#  siret                 :string
-#  status                :integer          default("in_progress")
-#  created_at            :datetime         not null
-#  updated_at            :datetime         not null
+#  id                               :bigint(8)        not null, primary key
+#  description                      :string
+#  email                            :string
+#  form_info                        :jsonb
+#  full_name                        :string
+#  landing_options_slugs            :string           is an Array
+#  landing_slug                     :string           not null
+#  options_deprecated               :jsonb
+#  phone_number                     :string
+#  prepare_diagnosis_errors_details :jsonb
+#  siret                            :string
+#  status                           :integer          default("in_progress")
+#  created_at                       :datetime         not null
+#  updated_at                       :datetime         not null
 #
 # Indexes
 #
@@ -23,6 +24,8 @@
 #
 
 class Solicitation < ApplicationRecord
+  include DiagnosisCreation::SolicitationMethods
+
   enum status: { in_progress: 0, processed: 1, canceled: 2 }, _prefix: true
 
   ## Associations

--- a/app/views/solicitations/_solicitation_actions.html.haml
+++ b/app/views/solicitations/_solicitation_actions.html.haml
@@ -1,9 +1,25 @@
 .ui.compact.inverted.green.menu
   - diagnoses = solicitation.diagnoses
   - if diagnoses.blank?
-    = link_to new_diagnosis_path(solicitation: solicitation.id), class: 'ui item' do
-      = t('.create_diagnosis')
-      %i.right.chevron.icon
+    - if solicitation.may_prepare_diagnosis?
+      - if solicitation.prepare_diagnosis_errors.present?
+        .ui.item
+          - error_text = solicitation.prepare_diagnosis_errors.full_messages.to_sentence
+          .ui.icon{ data: { tooltip: error_text, variation: 'fixed' } }
+            %i.warning.sign.icon
+            = t('.prepare_diagnosis_errors', count: solicitation.prepare_diagnosis_errors.count)
+        = link_to prepare_diagnosis_solicitation_path(solicitation), class: 'ui item', method: :post do
+          = t('.prepare_diagnosis_retry')
+          %i.right.chevron.icon
+      - else
+        = link_to prepare_diagnosis_solicitation_path(solicitation), class: 'ui item', method: :post do
+          %i.rocket.icon
+          = t('.prepare_diagnosis')
+          %i.right.chevron.icon
+    - else
+      = link_to new_diagnosis_path(solicitation: solicitation.id), class: 'ui item' do
+        = t('.start_diagnosis')
+        %i.right.chevron.icon
   - elsif diagnoses.size == 1
     - diagnosis = diagnoses.first
     = link_to_diagnosis(diagnosis)
@@ -22,4 +38,4 @@
       .item.show-feedbacks-form{ 'data-solicitation': "#{solicitation.id}" }= t('.add_feedback')
       - if diagnoses.present?
         = link_to new_diagnosis_path(solicitation: solicitation.id), class: 'item' do
-          = t('.create_another_diagnosis')
+          = t('.start_another_diagnosis')

--- a/app/views/solicitations/_solicitation_actions.html.haml
+++ b/app/views/solicitations/_solicitation_actions.html.haml
@@ -6,16 +6,14 @@
       %i.right.chevron.icon
   - elsif diagnoses.size == 1
     - diagnosis = diagnoses.first
-    = link_to need_path(diagnosis), class: 'ui item' do
-      = t('.view_diagnosis', name: diagnosis)
+    = link_to_diagnosis(diagnosis)
   - else
     .ui.item.dropdown
       = t('.view_diagnoses', count: diagnoses.size)
       %i.dropdown.icon
       .ui.menu
         - diagnoses.each do |diagnosis|
-          = link_to need_path(diagnosis), class: 'ui item' do
-            = t('.view_diagnosis', name: diagnosis)
+          = link_to_diagnosis(diagnosis)
   .ui.item.dropdown
     %i.settings.icon
     .ui.menu

--- a/config/application.rb
+++ b/config/application.rb
@@ -29,6 +29,7 @@ module PlaceDesEntreprises
     config.i18n.load_path += Dir[Rails.root.join('config', 'locales', '**', '*.{rb,yml}')]
     config.i18n.default_locale = :fr
     config.i18n.fallbacks = true
+    config.active_model.i18n_customize_full_message = true
 
     config.action_mailer.default_url_options = { host: ENV['HOST_NAME'] }
 

--- a/config/brakeman.ignore
+++ b/config/brakeman.ignore
@@ -1,13 +1,33 @@
 {
   "ignored_warnings": [
     {
+      "warning_type": "Redirect",
+      "warning_code": 18,
+      "fingerprint": "1f1b672745ecf49a2432f8d852d69e16a72c48c9612aad5b19cd5eee424845f0",
+      "check_name": "Redirect",
+      "message": "Possible unprotected redirect",
+      "file": "app/controllers/solicitations_controller.rb",
+      "line": 40,
+      "link": "https://brakemanscanner.org/docs/warning_types/redirect/",
+      "code": "redirect_to(Solicitation.find(params[:id]).prepare_diagnosis(current_user))",
+      "render_path": null,
+      "location": {
+        "type": "method",
+        "class": "SolicitationsController",
+        "method": "prepare_diagnosis"
+      },
+      "user_input": "Solicitation.find(params[:id]).prepare_diagnosis(current_user)",
+      "confidence": "High",
+      "note": ""
+    },
+    {
       "warning_type": "Mass Assignment",
       "warning_code": 105,
       "fingerprint": "8c0cf3dade4441e78ad5e8f205c8b119a75fd588ae9cab646729864072d6853c",
       "check_name": "PermitAttributes",
       "message": "Potentially dangerous key allowed for mass assignment",
       "file": "app/controllers/experts_controller.rb",
-      "line": 39,
+      "line": 43,
       "link": "https://brakemanscanner.org/docs/warning_types/mass_assignment/",
       "code": "params.require(:expert).permit(:full_name, :phone_number, :role, :experts_subjects_attributes => ({}))",
       "render_path": null,
@@ -41,6 +61,6 @@
       "note": "The crafted SQL query is a list of \"(?)\" placeholders; it is essentially a workaround for a limitation of ActiveRecord."
     }
   ],
-  "updated": "2020-03-25 18:51:10 +0100",
-  "brakeman_version": "4.8.0"
+  "updated": "2020-05-29 17:11:11 +0200",
+  "brakeman_version": "4.8.2"
 }

--- a/config/locales/models.fr.yml
+++ b/config/locales/models.fr.yml
@@ -248,6 +248,14 @@ fr:
           attributes:
             email:
               blank: Le contact doit avoir au moins une adresse e-mail ou un numéro de téléphone.
+        diagnosis:
+          attributes:
+            matches:
+              format: 'Mises en relation : %{message}.'
+              preselected_institution_has_no_relevant_experts: aucun référent de l’institution préselectionnée ne peut prendre en charge cette entreprise
+            needs:
+              format: 'Besoins : %{message}.'
+              solicitation_has_no_preselected_subjects: il n’y a pas de sujet préselectionné
         user:
           attributes:
             email:

--- a/config/locales/views.fr.yml
+++ b/config/locales/views.fr.yml
@@ -218,6 +218,9 @@ fr:
           one: "<b>1</b> %{entry_name}"
           other: "<b>%{count}</b> %{entry_name}"
           zero: Aucune %{entry_name}
+    solicitation:
+      analysis_in_progress: Analyse en cours (%{step})
+      view_completed_analysis: Voir l’analyse réalisée
   landings:
     hero:
       title: 'Place des Entreprises : le guichet public et gratuit d’accompagnement des TPE & PME en Hauts-de-France'
@@ -505,7 +508,6 @@ fr:
       create_another_diagnosis: Démarrer une autre analyse
       create_diagnosis: Démarrer une analyse
       view_diagnoses: "%{count} analyses"
-      view_diagnosis: Voir l’analyse de %{name}
     solicitation_badges:
       add_remove_badges: Ajouter / Enlever des tags
     solicitations_tabs:

--- a/config/locales/views.fr.yml
+++ b/config/locales/views.fr.yml
@@ -505,8 +505,13 @@ fr:
       slug: 'Page thématique :'
     solicitation_actions:
       add_feedback: Ajouter un commentaire
-      create_another_diagnosis: Démarrer une autre analyse
-      create_diagnosis: Démarrer une analyse
+      prepare_diagnosis: Préparer l’analyse
+      prepare_diagnosis_errors:
+        one: Erreur à la préparation
+        other: "%{count} erreurs à préparation"
+      prepare_diagnosis_retry: Réessayer
+      start_another_diagnosis: Démarrer une autre analyse
+      start_diagnosis: Démarrer une analyse
       view_diagnoses: "%{count} analyses"
     solicitation_badges:
       add_remove_badges: Ajouter / Enlever des tags

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -50,6 +50,7 @@ Rails.application.routes.draw do
     member do
       post :update_status
       post :update_badges
+      post :prepare_diagnosis
     end
     collection do
       get :processed, path: 'traitees'

--- a/db/migrate/20200528151220_add_diagnosis_errors_to_solicitation.rb
+++ b/db/migrate/20200528151220_add_diagnosis_errors_to_solicitation.rb
@@ -1,0 +1,5 @@
+class AddDiagnosisErrorsToSolicitation < ActiveRecord::Migration[6.0]
+  def change
+    add_column :solicitations, :prepare_diagnosis_errors_details, :jsonb, default: {}
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_05_28_090057) do
+ActiveRecord::Schema.define(version: 2020_05_28_151220) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -313,6 +313,7 @@ ActiveRecord::Schema.define(version: 2020_05_28_090057) do
     t.string "landing_slug", null: false
     t.string "landing_options_slugs", array: true
     t.index ["email"], name: "index_solicitations_on_email"
+    t.jsonb "prepare_diagnosis_errors_details", default: {}
     t.index ["landing_slug"], name: "index_solicitations_on_landing_slug"
   end
 

--- a/spec/models/concerns/diagnosis_creation_spec.rb
+++ b/spec/models/concerns/diagnosis_creation_spec.rb
@@ -34,24 +34,23 @@ RSpec.describe DiagnosisCreation do
       let(:siret) { '12345678901234' }
       let(:facility_params) { { siret: siret } }
 
-      context 'when the siret is valid' do
+      context 'when ApiEntreprise accepts the SIRET' do
         before do
           allow(UseCases::SearchFacility).to receive(:with_siret_and_save).with(siret) { create(:facility, siret: siret) }
         end
 
         it 'fetches info for ApiEntreprise and creates the diagnosis' do
-          expect{ create_diagnosis }.not_to raise_error
           expect(create_diagnosis).to be_valid
         end
       end
 
-      context 'when the siret is unknown' do
+      context 'when ApiEntreprise returns an error' do
         before do
           allow(UseCases::SearchFacility).to receive(:with_siret_and_save).with(siret) { raise ApiEntreprise::ApiEntrepriseError, 'some error message' }
         end
 
-        it 'fetches info for ApiEntreprise and creates the diagnosis' do
-          expect{ create_diagnosis }.to raise_error ApiEntreprise::ApiEntrepriseError
+        it 'returns the message in the errors' do
+          expect(create_diagnosis.errors.details).to eq({ facility: [{ error: 'some error message' }] })
         end
       end
     end
@@ -66,7 +65,6 @@ RSpec.describe DiagnosisCreation do
       end
 
       it 'creates a new diagnosis without siret' do
-        expect{ create_diagnosis }.not_to raise_error
         expect(create_diagnosis).to be_valid
         expect(create_diagnosis.company.name).to eq 'Boucherie Sanzot'
       end

--- a/spec/models/concerns/diagnosis_creation_spec.rb
+++ b/spec/models/concerns/diagnosis_creation_spec.rb
@@ -136,41 +136,28 @@ RSpec.describe DiagnosisCreation do
              expert: create(:expert, communes: communes)
     end
     let(:institution) { create :institution }
+    let(:preselected_institutions) { [institution] }
 
     before do
       allow(solicitation).to receive(:preselected_institutions).and_return(preselected_institutions)
       diagnosis.prepare_matches_from_solicitation
     end
 
-    context 'solicitation has preselected institutions that match the need' do
-      let(:preselected_institutions) { [institution] }
+    context 'there are relevant experts' do
+      let(:the_subject) { need.subject }
+      let(:communes) { [need.facility.commune] }
 
-      context 'there are relevant experts' do
-        let(:the_subject) { need.subject }
-        let(:communes) { [need.facility.commune] }
-
-        it 'creates the matches' do
-          expect(diagnosis.matches).not_to be_empty
-        end
-      end
-
-      context 'there are no relevant experts' do
-        let(:the_subject) { create :subject }
-        let(:communes) { [need.facility.commune] }
-
-        it 'sets an error' do
-          expect(diagnosis.errors.details).to eq({ matches: [{ error: :preselected_institution_has_no_relevant_experts }] })
-        end
+      it 'creates the matches' do
+        expect(diagnosis.matches).not_to be_empty
       end
     end
 
-    context 'solicitation has no preselected institutions' do
-      let(:the_subject) { need.subject }
+    context 'there are no relevant experts' do
+      let(:the_subject) { create :subject }
       let(:communes) { [need.facility.commune] }
-      let(:preselected_institutions) { [] }
 
       it 'sets an error' do
-        expect(diagnosis.errors.details).to eq({ matches: [{ error: :solicitation_has_no_preselected_institution }] })
+        expect(diagnosis.errors.details).to eq({ matches: [{ error: :preselected_institution_has_no_relevant_experts }] })
       end
     end
   end

--- a/spec/models/concerns/diagnosis_creation_spec.rb
+++ b/spec/models/concerns/diagnosis_creation_spec.rb
@@ -71,6 +71,52 @@ RSpec.describe DiagnosisCreation do
     end
   end
 
+  describe 'prepare_diagnosis' do
+    let(:solicitation) { create :solicitation }
+    let(:user) { create :user }
+
+    before do
+      allow(solicitation).to receive(:may_prepare_diagnosis?).and_return(true)
+      allow(described_class).to receive(:create_diagnosis) { diagnosis }
+      allow_any_instance_of(Diagnosis).to(receive(:prepare_needs_from_solicitation)) { prepare_needs }
+      allow_any_instance_of(Diagnosis).to receive(:prepare_happened_on_from_solicitation)
+      allow_any_instance_of(Diagnosis).to receive(:prepare_visitee_from_solicitation)
+      allow_any_instance_of(Diagnosis).to receive(:prepare_matches_from_solicitation)
+
+      solicitation.prepare_diagnosis(user)
+    end
+
+    context 'all is well' do
+      let(:diagnosis) { create :diagnosis, solicitation: solicitation, advisor: user }
+      let(:prepare_needs) {}
+
+      it do
+        expect(solicitation.diagnoses).not_to be_empty
+        expect(solicitation.prepare_diagnosis_errors).to be_empty
+      end
+    end
+
+    context 'creation fails' do
+      let(:diagnosis) { Diagnosis.create(facility: nil, advisor: user) }
+      let(:prepare_needs) {}
+
+      it do
+        expect(solicitation.diagnoses).to be_empty
+        expect(solicitation.prepare_diagnosis_errors.details).to eq({ facility: [{ error: :blank }] })
+      end
+    end
+
+    context 'preparation fails' do
+      let(:diagnosis) { create :diagnosis, solicitation: solicitation, advisor: user }
+      let(:prepare_needs) { diagnosis.errors.add(:needs, :some_failure) }
+
+      it do
+        expect(solicitation.diagnoses).to be_empty
+        expect(solicitation.prepare_diagnosis_errors.details).to eq({ needs: [{ error: :some_failure }] })
+      end
+    end
+  end
+
   describe 'prepare_needs_from_solicitation' do
     let(:diagnosis) { create :diagnosis, solicitation: solicitation }
     let(:solicitation) { create :solicitation }


### PR DESCRIPTION
refs #940

Si un diagnosis peut être préparé automatiquement, le bouton “démarrer une analyse” est remplacé par celui-ci:
![](https://user-images.githubusercontent.com/139391/83276675-42d95e80-a1d1-11ea-8f6b-2ee5391be914.png)

Si la préparation échoue, par exemple parce que le SIRET est invalide ou qu’aucun référent de l’institution préselectionné n’est sur la zone de l’entreprise, un message d’erreur s’affiche:
![](https://user-images.githubusercontent.com/139391/83276865-859b3680-a1d1-11ea-80c1-7b867f6c91df.png)

Une fois l’analyse préparée, le bouton devient “Analyse en cours”. La sollicitation reste dans l’onglet “à traiter”: 
![](https://user-images.githubusercontent.com/139391/83276921-9ba8f700-a1d1-11ea-90f1-39d7b2af9691.png)

Pour les autres sollicitations, où la préparation automatique est impossible, le bouton “Démarrer une analyse” continue d’exister.
![](https://user-images.githubusercontent.com/139391/83277028-c6934b00-a1d1-11ea-9a61-878adae8dff8.png)
