### PR TITLE
Ne pas sortir les analyses des relances quand un commentaire est déposé

### DIFF
--- a/db/migrate/20200603115449_add_last_activity_at_to_needs.rb
+++ b/db/migrate/20200603115449_add_last_activity_at_to_needs.rb
@@ -1,0 +1,14 @@
+class AddLastActivityAtToNeeds < ActiveRecord::Migration[6.0]
+  def up
+    add_column :needs, :last_activity_at, :timestamp, default: -> { 'NOW()' }, null: false
+
+    Need.all.each do |need|
+      last_activity = need.matches.pluck(:updated_at).max || need.updated_at
+      need.update(last_activity_at: last_activity)
+    end
+  end
+
+  def down
+    remove_column :needs, :last_activity_at
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_05_28_151220) do
+ActiveRecord::Schema.define(version: 2020_06_03_115449) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -283,6 +283,7 @@ ActiveRecord::Schema.define(version: 2020_05_28_151220) do
     t.text "content"
     t.integer "matches_count"
     t.datetime "archived_at"
+    t.datetime "last_activity_at", default: -> { "now()" }, null: false
     t.index ["archived_at"], name: "index_needs_on_archived_at"
     t.index ["diagnosis_id"], name: "index_needs_on_diagnosis_id"
     t.index ["subject_id", "diagnosis_id"], name: "index_needs_on_subject_id_and_diagnosis_id", unique: true
@@ -312,8 +313,8 @@ ActiveRecord::Schema.define(version: 2020_05_28_151220) do
     t.string "full_name"
     t.string "landing_slug", null: false
     t.string "landing_options_slugs", array: true
-    t.index ["email"], name: "index_solicitations_on_email"
     t.jsonb "prepare_diagnosis_errors_details", default: {}
+    t.index ["email"], name: "index_solicitations_on_email"
     t.index ["landing_slug"], name: "index_solicitations_on_landing_slug"
   end
 


### PR DESCRIPTION
closes #1097 

@n-b je me souviens qu'on s'était dit qu'on avait peut-être cassé quelque chose en ajoutant `touch: true` sur la relation d'un commentaire et d'une analyse. Et c'est le cas, il ne faut pas que les analyses sortent de l'onglet "relance" quand un commentaire est ajouté. Et j'ai l'impression que ce n'est pas utile non plus sur les sollicitations, mais je rate peut-être quelque chose