### PR TITLE
Amélioration au retour de “voir le site comme…”

### DIFF
--- a/app/views/shared/_user_impersonate.html.haml
+++ b/app/views/shared/_user_impersonate.html.haml
@@ -9,5 +9,5 @@
     = " (ID #{current_user&.id})"
 
   .impersonate-buttons
-    = form_with url: impersonate_engine.revert_impersonate_user_url, method: :delete, class: 'revert-form' do |f|
+    = form_with url: impersonate_engine.revert_impersonate_user_url, method: :delete, local: true, class: 'revert-form' do |f|
       = f.submit 'Retourner a l’admin'

--- a/config/initializers/user_impersonate.rb
+++ b/config/initializers/user_impersonate.rb
@@ -22,7 +22,7 @@ module UserImpersonate
     config.redirect_on_impersonate = '/mon_compte'
 
     # Redirect to this path when leaving impersonate mode
-    config.redirect_on_revert = '/admin/users'
+    config.redirect_on_revert = -> (env) { "/admin/users/#{current_user.id}" }
 
     # Devise filter method used to protect impersonation controller
     # For Active Admin "AdminUser" model, change to 'authenticate_admin_user!'


### PR DESCRIPTION
* corrige le bouton retour depuis les pages public du site (PLACE-DES-ENTREPRISES-74)
* retour sur la page de l’utilisateur en question, plutôt que sur /admin/users (qui est longue à charger, en plus)