### PR TITLE
Fix a crash when creating several matches for the same need

### DIFF
--- a/app/models/need.rb
+++ b/app/models/need.rb
@@ -202,7 +202,7 @@ class Need < ApplicationRecord
   private
 
   def update_last_activity_at
-    last_activity = matches.pluck(:updated_at).max || updated_at
+    last_activity = matches.pluck(:updated_at).compact.max || updated_at
     update_columns last_activity_at: last_activity
   end
 end


### PR DESCRIPTION
When two or more matches are created, the after_touch callback is triggered once for every match; as the other matches are not persisted yet, their :updated_at value is nil.

followup #1098 PLACE-DES-ENTREPRISES-8B