### PR TITLE
Filter sent matches in Expert#received_matches

### DIFF
--- a/app/models/expert.rb
+++ b/app/models/expert.rb
@@ -45,7 +45,7 @@ class Expert < ApplicationRecord
   has_and_belongs_to_many :users, inverse_of: :experts
 
   has_many :experts_subjects, dependent: :destroy, inverse_of: :expert
-  has_many :received_matches, class_name: 'Match', inverse_of: :expert, dependent: :nullify
+  has_many :received_matches, -> { sent }, class_name: 'Match', inverse_of: :expert, dependent: :nullify
 
   ## Validations
   #

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -88,7 +88,7 @@ class User < ApplicationRecord
   has_many :sent_matches, through: :sent_diagnoses, source: :matches, inverse_of: :advisor
 
   # :experts
-  has_many :received_matches, -> { sent }, through: :experts, source: :received_matches, inverse_of: :contacted_users
+  has_many :received_matches, through: :experts, source: :received_matches, inverse_of: :contacted_users
   has_many :received_needs, through: :experts, source: :received_needs, inverse_of: :contacted_users
   has_many :received_diagnoses, through: :experts, source: :received_diagnoses, inverse_of: :contacted_users
   has_and_belongs_to_many :relevant_experts, -> { relevant_for_skills }, class_name: 'Expert'

--- a/spec/factories/diagnoses.rb
+++ b/spec/factories/diagnoses.rb
@@ -20,5 +20,11 @@ FactoryBot.define do
     trait :archived do
       archived_at { Time.now }
     end
+
+    after(:create) do |diagnosis, _|
+      if diagnosis.matches.present?
+        diagnosis.update_columns(step: :completed)
+      end
+    end
   end
 end

--- a/spec/factories/matches.rb
+++ b/spec/factories/matches.rb
@@ -5,5 +5,9 @@ FactoryBot.define do
     association :need
     association :expert
     association :subject
+
+    after(:create) do |match, _|
+      match.diagnosis.update_columns(step: :completed)
+    end
   end
 end

--- a/spec/factories/needs.rb
+++ b/spec/factories/needs.rb
@@ -10,5 +10,11 @@ FactoryBot.define do
         need.matches = create_list(:match, 1, need: need)
       end
     end
+
+    after(:create) do |need, _|
+      if need.matches.present?
+        need.diagnosis.update_columns(step: :completed)
+      end
+    end
   end
 end

--- a/spec/models/need_spec.rb
+++ b/spec/models/need_spec.rb
@@ -252,7 +252,7 @@ RSpec.describe Need, type: :model do
     let(:need) { Timecop.freeze(date1) { create :need } }
     let(:match) { Timecop.freeze(date2) { create :match, need: need } }
 
-    before { match }
+    before { need.reload; match }
 
     subject { need.reload.last_activity_at }
 
@@ -265,7 +265,7 @@ RSpec.describe Need, type: :model do
     context 'when a feedback is added to a match' do
       let(:feedback) { Timecop.freeze(date3) { create :feedback, feedbackable: need } }
 
-      before { feedback }
+      before { need.reload; feedback }
 
       it { is_expected.to eq date2 }
     end


### PR DESCRIPTION
That way, all the through relations that rely on Expert#received_matches are filtered too:
* Expert.received_needs
* Expert.received_diagnoses
* User.received_matches
* User.received_needs
* User.received_diagnoses

followup #1115, PLACE-DES-ENTREPRISES-88