### PR TITLE
Don't log sentry errors for sitemap queries of the wrong type

### DIFF
--- a/app/controllers/shared_controller.rb
+++ b/app/controllers/shared_controller.rb
@@ -4,6 +4,7 @@ class SharedController < ActionController::Base
   NOT_FOUND_ERROR_CLASSES = [
     ActionController::RoutingError,
     ActionController::UrlGenerationError,
+    ActionController::UnknownFormat,
     ActiveRecord::RecordNotFound,
     ActionView::MissingTemplate,
     Pundit::NotAuthorizedError


### PR DESCRIPTION
followup #1101

TLDR: Basically, our custom error rendering (in SharedController#render_error) gets in the way of the normal Rails handling. We should get rid of it.

We're getting requests for sitemap.txt. The only supported type is xml, and a ActionController::UnknownFormat exception is raised. According to [the docs](https://apidock.com/rails/ActionController/ImplicitRender) (See also this [relevant PR](https://github.com/rails/rails/issues/20666),  this should result in a 406. However, we rescue in render_error: our handler can only return 404 ou 500, and only returns 404 for a very specific set of errors, so our 406 is changed to a 500.

In fact, this facility shouldn’t even exist. Our custom 404 and 500 pages were maybe meant to be customised at some point, but they are not. We should just use the default rails and use static 404.html etc. pages in /public. There's one catch with Sentry/Raven, as we still want to avoid reporting 404s to sentry, but it can be configured for it, see :excluded_exceptions and :should_capture. Maybe the default configuration just works™.

Fixes PLACE-DES-ENTREPRISES-8C