### PR TITLE
Permettre de servir toutes les pages de landing dans un iframe

### DIFF
--- a/app/admin/landing.rb
+++ b/app/admin/landing.rb
@@ -62,6 +62,7 @@ ActiveAdmin.register Landing do
         row :title
         row :subtitle
         row :logos
+        row :custom_css
       end
     end
 
@@ -136,6 +137,7 @@ ActiveAdmin.register Landing do
         f.input :title
         f.input :subtitle
         f.input :logos
+        f.input :custom_css, as: :text, input_html: { style: 'width:70%', rows: 10 }
       end
     end
 

--- a/app/assets/javascripts/pages/iframe_external_links.js
+++ b/app/assets/javascripts/pages/iframe_external_links.js
@@ -1,0 +1,31 @@
+(function() {
+  // Make external links work properly when the site is inside an iframe.
+  // This adds target="_parent" to all <a> whose url isn't ours.
+
+  this.onload = function() {
+    if(inIframe()) {
+      makeExternalLinksOpenInParent();
+    }
+  }
+
+  function inIframe() {
+    try {
+      return window.self !== window.top;
+    } catch (e) {
+      return true;
+    }
+  }
+
+  function makeExternalLinksOpenInParent() {
+    var links = document.getElementsByTagName("a")
+    for (var i = 0; i < links.length; ++i) {
+      targetParentIfExternal(links[i]);
+    }
+  }
+
+  function targetParentIfExternal(link) {
+    if(link.host !== window.location.host) {
+      link.target = "_parent";
+    }
+  }
+})();

--- a/app/controllers/concerns/iframe_prefix.rb
+++ b/app/controllers/concerns/iframe_prefix.rb
@@ -1,0 +1,71 @@
+# frozen_string_literal: true
+
+module IframePrefix
+  extend ActiveSupport::Concern
+  # Allow the routes of a controller to be served inside an optional iframe,
+  # with working navigation inside the iframe.
+  # The routes for the controller must be scoped, like that:
+  # scope path: "(:iframe_prefix)", iframe_prefix: /my_nice_prefix?/, defaults: {iframe_prefix: nil}
+  included do
+    helper OverrideUrlFor # Insert our implementation in the helpers stack to customize url_for.
+
+    prepend_before_action :detect_iframe_prefix
+
+    skip_forgery_protection if: -> { in_iframe? }
+    after_action :allow_in_iframe, if: -> { in_iframe? }
+  end
+
+  def detect_iframe_prefix
+    params # side-effect: Make sure @iframe_prefix is set.
+  end
+
+  def params
+    clean_params = super
+    @iframe_prefix ||= clean_params.delete(:iframe_prefix)
+    clean_params
+  end
+
+  def allow_in_iframe
+    response.headers.except! 'X-Frame-Options'
+  end
+
+  # We want in_iframe? to be available both in template (as a helper method) and in controllers
+  module InIframe
+    extend ActiveSupport::Concern
+    included { helper_method :in_iframe? }
+
+    def in_iframe?
+      @iframe_prefix.present?
+    end
+  end
+
+  # Override :url_for
+  module OverrideUrlFor
+    # :url_for is called, via :link_to or the `*_path` helpers, in the view templates.
+    def url_for(args)
+      prefix_url_if_needed(super)
+    end
+
+    private
+
+    # We want iframe-compatible local urls to open _inside_ the iframe,
+    # and we want to include the prefix automatically.
+    def prefix_url_if_needed(raw_url)
+      return raw_url unless in_iframe?
+
+      # Avoid prefixing urls to other sites.
+      url = URI.parse(raw_url)
+      is_local_url = url.hostname.blank? ||
+        url.hostname == default_url_options[:host] && url.port == default_url_options[:port]
+      return raw_url unless is_local_url
+
+      # Only prefix urls to routes compatible with iframes
+      controller = Rails.application.routes.recognize_path(url.path)[:controller]
+      klass = (controller.camelize + 'Controller').constantize
+      return raw_url unless klass.ancestors.include?(IframePrefix)
+
+      url.path = "/#{@iframe_prefix}" + url.path
+      url.to_s
+    end
+  end
+end

--- a/app/controllers/landings_controller.rb
+++ b/app/controllers/landings_controller.rb
@@ -2,6 +2,8 @@ class LandingsController < PagesController
   before_action :save_form_info, only: %i[index show]
   before_action :retrieve_landing, except: %i[index subscribe_newsletter]
 
+  include IframePrefix
+
   def index
     @landings = Rails.cache.fetch('landings', expires_in: 3.minutes) do
       Landing.ordered_for_home.to_a

--- a/app/controllers/shared_controller.rb
+++ b/app/controllers/shared_controller.rb
@@ -20,6 +20,8 @@ class SharedController < ActionController::Base
     raise ActionController::RoutingError, 'Not Found'
   end
 
+  include IframePrefix::InIframe
+
   private
 
   def render_error(exception)

--- a/app/models/landing.rb
+++ b/app/models/landing.rb
@@ -35,6 +35,7 @@ class Landing < ApplicationRecord
     meta_title meta_description
     emphasis
     title subtitle logos
+    custom_css
     landing_topic_title message_under_landing_topics
     description_example form_bottom_message
     form_promise_message thank_you_message

--- a/app/views/external_solicitations/new.haml
+++ b/app/views/external_solicitations/new.haml
@@ -2,7 +2,7 @@
   = render :partial => 'thank_you'
 
 - else
-  #solicitation-form
+  %section.section#solicitation-form
     #flashes
     - if @style[:branding].to_b
       .branding

--- a/app/views/landings/_new_solicitation_form.html.haml
+++ b/app/views/landings/_new_solicitation_form.html.haml
@@ -29,6 +29,6 @@
       = f.email_field 'email', placeholder: t('.email.placeholder'), required: true
       .notification.error= solicitation.errors.full_messages_for(:email).to_sentence
   .form__group
-    - if landing.form_bottom_message.present? && solicitation.partner_token.blank? && solicitation.institution_slug.blank?
+    - if landing.form_bottom_message.present? && in_iframe?
       %p= landing.form_bottom_message.html_safe
     = f.submit t('.button.title'), class: 'button large'

--- a/app/views/landings/_show_landing.html.haml
+++ b/app/views/landings/_show_landing.html.haml
@@ -1,3 +1,5 @@
+%style= landing.custom_css
+
 = render 'hero' unless in_iframe?
 
 = render 'shared/flashes_pages'

--- a/app/views/landings/_show_landing.html.haml
+++ b/app/views/landings/_show_landing.html.haml
@@ -1,10 +1,11 @@
-= render 'hero'
+= render 'hero' unless in_iframe?
 
 = render 'shared/flashes_pages'
 
-%section.section.section-white#section-details
-  .container.text-center
-    = render 'show_landing_details', landing: landing
+- unless in_iframe?
+  %section.section.section-white#section-details
+    .container.text-center
+      = render 'show_landing_details', landing: landing
 
 %section.section.section-grey#section-exemples
   .container
@@ -15,10 +16,11 @@
     %h2
       = link_to t('.submit_request'), new_solicitation_landing_path, class: 'button blue'
 
-%section.section.section-white
-  .container#container-newsletter
-    = render 'newsletter'
+- unless in_iframe?
+  %section.section.section-white
+    .container#container-newsletter
+      = render 'newsletter'
 
-%section.section.section-white#section-institutions
-  .container
-    = render 'show_landing_institutions', landing: landing
+  %section.section.section-white#section-institutions
+    .container
+      = render 'show_landing_institutions', landing: landing

--- a/app/views/landings/index.haml
+++ b/app/views/landings/index.haml
@@ -1,29 +1,32 @@
 - meta title: t('.meta.title'), description: t('.meta.description')
 
-= render 'hero'
+= render 'hero' unless in_iframe?
 
-%section.section.section-white#section-description
-  .container.text-center
-    = image_tag('place-des-entreprises-logo.png', alt: "logo Place des Entreprises", id: 'logo-pde')
-    %h2.lead-text
-      = t('.question')
-    %h2.lead-text
-      = t('.answer')
-    = link_to t('.submit_request'), '#section-thematiques', class: 'button blue'
-    - cache('institutions', expires_in: 1.hour) do
-      = render 'index_institutions'
+- unless in_iframe?
+  %section.section.section-white#section-description
+    .container.text-center
+      = image_tag('place-des-entreprises-logo.png', alt: "logo Place des Entreprises", id: 'logo-pde')
+      %h2.lead-text
+        = t('.question')
+      %h2.lead-text
+        = t('.answer')
+      = link_to t('.submit_request'), '#section-thematiques', class: 'button blue'
+      - cache('institutions', expires_in: 1.hour) do
+        = render 'index_institutions'
 
 %section.section.section-color#section-thematiques
   .container
     = render 'index_landing_cards', landings: @landings
 
-%section.section.section-grey#section-testimonials
-  .container
-    = render 'index_testimonials'
+- unless in_iframe?
+  %section.section.section-grey#section-testimonials
+    .container
+      = render 'index_testimonials'
 
-%section.section.section-grey#section-stats
-  .container.container-medium
-    - cache('ministats', expires_in: 1.hour) do
-      = render 'stats/ministats'
+- unless in_iframe?
+  %section.section.section-grey#section-stats
+    .container.container-medium
+      - cache('ministats', expires_in: 1.hour) do
+        = render 'stats/ministats'
 
 

--- a/app/views/landings/new_solicitation.html.haml
+++ b/app/views/landings/new_solicitation.html.haml
@@ -3,7 +3,7 @@
   meta_description = @landing.meta_description.presence || @landing.subtitle
   meta title: meta_title, description: meta_description
 
-= render 'hero'
+= render 'hero' unless in_iframe?
 
 - if @solicitation.persisted?
   %section.section.section-grey#section-thankyou
@@ -11,15 +11,17 @@
       = render 'new_solicitation_thank_you', landing: @landing
 
 - if @solicitation.new_record?
-  %section.section.section-white#section-retour
-    .container.container-medium
-      %h3
-        = link_to t('.back_to_landing'), @landing
-  %section.section.section-grey#section-formulaire
+  - if @landing.landing_options.present?
+    %section.section.section-white#section-retour
+      .container.container-medium
+        %h3
+          = link_to t('.back_to_landing'), @landing
+  %section.section.section-grey{ id: in_iframe? ? '' : 'section-formulaire' }
     .container.container-medium
       - landing_option = @solicitation.landing_options.first
       = tag.h2(landing_option&.form_title&.html_safe || t('.default_title'), class: 'section__title')
       - if landing_option&.form_description.present?
         = tag.p(landing_option.form_description.html_safe)
       = render 'new_solicitation_form', landing: @landing, solicitation: @solicitation, path: create_solicitation_landing_path
-      = tag.p((@landing.form_promise_message.presence || t('.default_promise_message')).html_safe)
+      - unless in_iframe?
+        = tag.p((@landing.form_promise_message.presence || t('.default_promise_message')).html_safe)

--- a/app/views/landings/new_solicitation.html.haml
+++ b/app/views/landings/new_solicitation.html.haml
@@ -3,6 +3,8 @@
   meta_description = @landing.meta_description.presence || @landing.subtitle
   meta title: meta_title, description: meta_description
 
+%style= @landing.custom_css
+
 = render 'hero' unless in_iframe?
 
 - if @solicitation.persisted?

--- a/app/views/landings/show.haml
+++ b/app/views/landings/show.haml
@@ -3,7 +3,7 @@
   meta_description = @landing.meta_description.presence || @landing.subtitle
   meta title: meta_title, description: meta_description
 
-- cache_unless(flash.present?, @landing) do
+- cache_unless(flash.present?, [@landing, in_iframe?]) do
   = render 'show_landing', landing: @landing
 
 - unless in_iframe?

--- a/app/views/landings/show.haml
+++ b/app/views/landings/show.haml
@@ -6,8 +6,9 @@
 - cache_unless(flash.present?, @landing) do
   = render 'show_landing', landing: @landing
 
-%section.section.section-grey#stats
-  .container.container-medium
-    - cache('ministats', expires_in: 1.hour) do
-      = render 'stats/ministats'
+- unless in_iframe?
+  %section.section.section-grey#stats
+    .container.container-medium
+      - cache('ministats', expires_in: 1.hour) do
+        = render 'stats/ministats'
 

--- a/app/views/layouts/pages.html.haml
+++ b/app/views/layouts/pages.html.haml
@@ -14,9 +14,9 @@
     = matomo_script
 
   %body
-    = render 'navbar'
-    = render 'environment_ribbon'
-    = render 'user_impersonate'
+    = render 'navbar' unless in_iframe?
+    = render 'environment_ribbon' unless in_iframe?
+    = render 'user_impersonate' unless in_iframe?
     = yield
-    = render 'footer'
+    = render 'footer' unless in_iframe?
 

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -34,7 +34,7 @@ Rails.application.routes.draw do
   end
 
   # Pages
-  scope path: "(:iframe_prefix)", iframe_prefix: /w?/, defaults: { iframe_prefix: nil } do
+  scope path: "(:iframe_prefix)", iframe_prefix: /e?/, defaults: { iframe_prefix: nil } do
     root controller: :landings, action: :index
     resources :landings, param: :slug, only: %i[show], path: 'aide-entreprises' do
       member do

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -34,13 +34,15 @@ Rails.application.routes.draw do
   end
 
   # Pages
-  root controller: :landings, action: :index
-  resources :landings, param: :slug, only: %i[show], path: 'aide-entreprises' do
-    member do
-      get 'demande(/:option_slug)', action: :new_solicitation, as: :new_solicitation
-      # as the form to create solicitations is on the landings show page,
-      # we’re using the same path the show landings and to view solicitations.
-      post :create_solicitation, path: ''
+  scope path: "(:iframe_prefix)", iframe_prefix: /w?/, defaults: { iframe_prefix: nil } do
+    root controller: :landings, action: :index
+    resources :landings, param: :slug, only: %i[show], path: 'aide-entreprises' do
+      member do
+        get 'demande(/:option_slug)', action: :new_solicitation, as: :new_solicitation
+        # as the form to create solicitations is on the landings show page,
+        # we’re using the same path the show landings and to view solicitations.
+        post :create_solicitation, path: ''
+      end
     end
   end
 
@@ -86,7 +88,6 @@ Rails.application.routes.draw do
   end
 
   resources :external_solicitations, only: %i[new create]
-
 
   controller :sitemap do
     get :sitemap
@@ -154,7 +155,6 @@ Rails.application.routes.draw do
   resources :badges, only: %i[index create destroy]
 
   get 'profile' => 'users#show'
-
 
   ## Redirection for compatibility
   get '/entreprise/:slug', to: redirect(path: '/aide-entreprises/%{slug}')

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -81,6 +81,13 @@ Rails.application.routes.draw do
     end
   end
 
+  controller :user_pages do
+    get :tutoriels
+  end
+
+  resources :external_solicitations, only: %i[new create]
+
+
   controller :sitemap do
     get :sitemap
   end
@@ -146,13 +153,8 @@ Rails.application.routes.draw do
 
   resources :badges, only: %i[index create destroy]
 
-  controller :user_pages do
-    get :tutoriels
-  end
-
   get 'profile' => 'users#show'
 
-  resources :external_solicitations, only: %i[new create]
 
   ## Redirection for compatibility
   get '/entreprise/:slug', to: redirect(path: '/aide-entreprises/%{slug}')

--- a/spec/views/iframe_test_page.html
+++ b/spec/views/iframe_test_page.html
@@ -1,0 +1,41 @@
+<!DOCTYPE html>
+<html>
+<head>
+ <meta charset="UTF-8">
+ <title>Page de test de formulaire</title>
+ <style>
+   * { margin: 0; }
+   body { background: papayawhip; }
+	 h1 { margin: 0.8em ;text-align: center; font-family: sans-serif; }
+   .container { max-width: 1000px; margin: 0 auto; }
+   form { margin: 1em }
+   input[type='text'] { width: 90%; margin: 1em }
+ </style>
+</head>
+<body>
+  <script type="text/javascript">
+    let base_url = "http://0.0.0.0:3000/"
+    let default_path = ''
+    window.onload=function(){
+      document.getElementById('textinput').value = default_path
+      document.getElementById('iframe').src = base_url + default_path
+      document.getElementById('form').addEventListener("submit", function(e) {
+        e.preventDefault()
+        document.getElementById('iframe').src = base_url + document.getElementById('textinput').value
+      });
+    }
+  </script>
+  <h1>🙂</h1>
+  <div>
+    <div class="container">
+      <form id='form'>
+        <input type="text" id="textinput"/>
+        <input type="submit" value="Go"/>
+      </form>
+      <iframe id='iframe' width="100%" height="1000px" frameborder="0" style="background:peachpuff;"></iframe>
+    </div>
+  </div>
+  <h1>🙃</h1>
+</body>
+</html>
+

--- a/spec/views/iframe_test_page.html
+++ b/spec/views/iframe_test_page.html
@@ -15,7 +15,7 @@
 <body>
   <script type="text/javascript">
     let base_url = "http://0.0.0.0:3000/"
-    let default_path = 'w/'
+    let default_path = 'e/'
     window.onload=function(){
       document.getElementById('textinput').value = default_path
       document.getElementById('iframe').src = base_url + default_path

--- a/spec/views/iframe_test_page.html
+++ b/spec/views/iframe_test_page.html
@@ -15,7 +15,7 @@
 <body>
   <script type="text/javascript">
     let base_url = "http://0.0.0.0:3000/"
-    let default_path = ''
+    let default_path = 'w/'
     window.onload=function(){
       document.getElementById('textinput').value = default_path
       document.getElementById('iframe').src = base_url + default_path


### PR DESCRIPTION
Plus gros morceau de refs #1094.

Le concern IframePrefix permet de servir toutes les actions de `landings` avec un préfixe optionnel `/w`. S’il est présent, alors `in_iframe?` devient true, ce qui permet de faire un layout différent, d'ajuster les options et les urls des liens. La difficulté principale est de s'assurer que les liens générés gardent le préfixe `/w` quand on va d'une page à l'autre, mais pas pour les liens sortants.

En bonus:
* Une page html pour tester l'iframe. On peut l'ouvrir telle quelle, mais Rubymine propose en menu contextuel “Open in browser”, qui crée en fait un mini serveur web local: c‘est sans doute plus réaliste.
* un mini fix de layout pour external_solicitations, même si c’est temporaire
