### PR TITLE
Fix zeitwerk complaining about wrong required modules

### DIFF
--- a/app/services/csv_export/models/match.rb
+++ b/app/services/csv_export/models/match.rb
@@ -1,10 +1,11 @@
 module CsvExport
-  module Match
-    extend ActiveSupport::Concern
-    class_methods do
-      def csv_fields
-        {
-          id: :id,
+  module Models
+    module Match
+      extend ActiveSupport::Concern
+      class_methods do
+        def csv_fields
+          {
+            id: :id,
             need: :need_id,
             company: :company,
             siret: -> { facility.siret },
@@ -23,21 +24,22 @@ module CsvExport
             taken_care_of_at: :taken_care_of_at,
             closed_at: :closed_at,
             page_analyse: :need_url_route
-        }
+          }
+        end
+
+        def csv_included_associations
+          [
+            :need, :diagnosis, :facility, :company, :related_matches,
+            :advisor, :advisor_antenne, :advisor_institution,
+            :expert, :expert_antenne, :expert_institution,
+            :subject, :theme
+          ]
+        end
       end
 
-      def csv_included_associations
-        [
-          :need, :diagnosis, :facility, :company, :related_matches,
-          :advisor, :advisor_antenne, :advisor_institution,
-          :expert, :expert_antenne, :expert_institution,
-          :subject, :theme
-        ]
+      def need_url_route
+        Rails.application.routes.url_helpers.need_url(self.diagnosis)
       end
-    end
-
-    def need_url_route
-      Rails.application.routes.url_helpers.need_url(self.diagnosis)
     end
   end
 end

--- a/app/services/csv_export_service.rb
+++ b/app/services/csv_export_service.rb
@@ -2,7 +2,7 @@
 
 require 'csv_export/models/match'
 
-Match.include CsvExport::Match
+Match.include CsvExport::Models::Match
 
 class CsvExportService
   def self.build(model)


### PR DESCRIPTION
running `RAILS_ENV=production rails s` failed with
```
.../gems/zeitwerk-2.3.0/lib/zeitwerk/loader.rb:381:in `const_get': uninitialized constant CsvExport::Models::Match (NameError)
Did you mean?  CsvExport::Match
               Math
```