### PR TITLE
Corrige les meta description et title sur les landing pages

### DIFF
--- a/app/views/landings/_show_landing.html.haml
+++ b/app/views/landings/_show_landing.html.haml
@@ -1,8 +1,3 @@
-:ruby
-  meta_title = landing.meta_title.presence || landing.title
-  meta_description = landing.meta_description.presence || landing.subtitle
-  meta title: meta_title, description: meta_description
-
 = render 'hero'
 
 = render 'shared/flashes_pages'

--- a/app/views/landings/show.haml
+++ b/app/views/landings/show.haml
@@ -1,3 +1,8 @@
+:ruby
+  meta_title = @landing.meta_title.presence || @landing.title
+  meta_description = @landing.meta_description.presence || @landing.subtitle
+  meta title: meta_title, description: meta_description
+
 - cache_unless(flash.present?, @landing) do
   = render 'show_landing', landing: @landing
 


### PR DESCRIPTION
Ils n'étaient par réellement pris en compte: le code ruby `meta` n'est pas appelé si le cache du template est utilisé (c'est-à-dire la plupart du temps, en principe!)

fait en passant pour #1127