### PR TITLE
Do not include the port number in urls in production

### DIFF
--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -1,7 +1,7 @@
 Rails.application.configure do
   # Settings specified here will take precedence over those in config/application.rb.
 
-  Rails.application.routes.default_url_options = { host: ENV['HOST_NAME'], port: ENV['PORT'] }
+  Rails.application.routes.default_url_options = { host: ENV['HOST_NAME'] }
 
   # Code is not reloaded between requests.
   config.cache_classes = true


### PR DESCRIPTION
PORT isn't set in production environment, which leads to urls ending with a weird `:0`.