### PR TITLE
First automated a11y tests

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -76,6 +76,7 @@ group :test do
   gem 'shoulda-matchers'
   gem 'webmock'
   gem 'timecop'
+  gem 'axe-matchers', require: false
 end
 
 group :development, :test do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -97,6 +97,13 @@ GEM
     autoprefixer-rails (9.7.6)
       execjs
     awesome_print (1.8.0)
+    axe-matchers (2.6.1)
+      dumb_delegator (~> 0.8)
+      virtus (~> 1.0)
+    axiom-types (0.1.1)
+      descendants_tracker (~> 0.0.4)
+      ice_nine (~> 0.11.0)
+      thread_safe (~> 0.3, >= 0.3.1)
     bcrypt (3.1.13)
     bindex (0.8.1)
     bootsnap (1.4.6)
@@ -117,6 +124,8 @@ GEM
     clockwork (2.0.4)
       activesupport
       tzinfo
+    coercible (1.0.0)
+      descendants_tracker (~> 0.0.1)
     coffee-rails (5.0.0)
       coffee-script (>= 2.2.0)
       railties (>= 5.2.0)
@@ -139,6 +148,8 @@ GEM
     delayed_job_active_record (4.1.4)
       activerecord (>= 3.0, < 6.1)
       delayed_job (>= 3.0, < 5)
+    descendants_tracker (0.0.4)
+      thread_safe (~> 0.3, >= 0.3.1)
     devise (4.7.1)
       bcrypt (~> 3.0)
       orm_adapter (~> 0.1)
@@ -158,6 +169,8 @@ GEM
     dotenv-rails (2.7.5)
       dotenv (= 2.7.5)
       railties (>= 3.2, < 6.1)
+    dumb_delegator (0.8.1)
+    equalizer (0.0.11)
     erubi (1.9.0)
     erubis (2.7.0)
     execjs (2.7.0)
@@ -240,6 +253,7 @@ GEM
       rails-i18n
       rainbow (>= 2.2.2, < 4.0)
       terminal-table (>= 1.5.1)
+    ice_nine (0.11.2)
     inherited_resources (1.11.0)
       actionpack (>= 5.0, < 6.1)
       has_scope (~> 0.6)
@@ -494,6 +508,11 @@ GEM
     unicode-display_width (1.7.0)
     user_impersonate2 (0.12.0)
       rails (>= 5.1.0)
+    virtus (1.0.5)
+      axiom-types (~> 0.1)
+      coercible (~> 1.0)
+      descendants_tracker (~> 0.0, >= 0.0.3)
+      equalizer (~> 0.0, >= 0.0.9)
     wannabe_bool (0.7.1)
     warden (1.2.8)
       rack (>= 2.0.6)
@@ -524,6 +543,7 @@ DEPENDENCIES
   annotate
   audited
   awesome_print
+  axe-matchers
   bootsnap
   brakeman
   browser

--- a/app/views/landings/_newsletter.html.haml
+++ b/app/views/landings/_newsletter.html.haml
@@ -6,5 +6,5 @@
 = form_with url: subscribe_newsletter_path, method: :post, local: true do |f|
   .form__group
     .input__group
-      = f.email_field :email, placeholder: t('.placeholder_email'), required: 'required'
+      = f.email_field :email, placeholder: t('.placeholder_email'), 'aria-label': t('.placeholder_email'), required: 'required'
       = f.submit t('.subscribe'), class: 'button'

--- a/app/views/layouts/pages.html.haml
+++ b/app/views/layouts/pages.html.haml
@@ -1,5 +1,5 @@
 !!!
-%html
+%html{ lang: 'fr' }
   %head
     = metamagic site: t('app_name'), title: %i[title site], separator: ' | '
     %meta{ name: 'viewport', content: 'width=device-width, initial-scale=1.0' }
@@ -17,6 +17,7 @@
     = render 'navbar' unless in_iframe?
     = render 'environment_ribbon'
     = render 'user_impersonate'
-    = yield
+    %main
+      = yield
     = render 'footer' unless in_iframe?
 

--- a/app/views/layouts/pages.html.haml
+++ b/app/views/layouts/pages.html.haml
@@ -15,8 +15,8 @@
 
   %body
     = render 'navbar' unless in_iframe?
-    = render 'environment_ribbon' unless in_iframe?
-    = render 'user_impersonate' unless in_iframe?
+    = render 'environment_ribbon'
+    = render 'user_impersonate'
     = yield
     = render 'footer' unless in_iframe?
 

--- a/app/views/shared/_environment_ribbon.html.haml
+++ b/app/views/shared/_environment_ribbon.html.haml
@@ -1,4 +1,4 @@
 - if !Rails.env.production?
-  .environment-ribbon-wrapper.right
+  .environment-ribbon-wrapper.right{ 'aria-hidden': 'true' }
     .environment-ribbon
       %a= Rails.env

--- a/spec/a11y/a11y_spec.rb
+++ b/spec/a11y/a11y_spec.rb
@@ -1,0 +1,33 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+describe 'a11y', type: :feature, js: true do
+  subject { page }
+
+  before do
+    create :landing, home_sort_order: 0,
+           home_title: 'Premier Test',
+           home_description: 'Ceci est un test.',
+           title: 'Premier titre',
+           subtitle: 'Premier sous-titre'
+
+    create :landing, home_sort_order: 1,
+           home_title: 'Second test',
+           home_description: 'Encore un test.',
+           title: 'Second titre',
+           subtitle: 'Second sous-titre'
+  end
+
+  describe '/' do
+    before { visit '/' }
+
+    it { is_expected.to be_accessible }
+  end
+
+  describe '/aide-entreprises/:slug' do
+    before { visit "/aide-entreprises/#{Landing.last.slug}" }
+
+    it { is_expected.to be_accessible }
+  end
+end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -3,6 +3,7 @@
 # See http://rubydoc.info/gems/rspec-core/RSpec/Core/Configuration
 require 'webmock/rspec'
 require "pundit/rspec"
+require 'axe/rspec'
 
 RSpec.configure do |config|
   config.expect_with :rspec do |expectations|

--- a/spec/support/axe/matchers/be_accessible.rb
+++ b/spec/support/axe/matchers/be_accessible.rb
@@ -1,0 +1,19 @@
+module SpecHelpers
+  module Axe
+    module BeAccessibleMatcherDescription
+      # RSpec::Matchers wants matchers to implement #description, otherwise it complains loudly.
+      # From `generated_descriptions.rb`:
+      #
+      # > RSpec expects the matcher to have a #description method. You should either
+      # > add a String to the example this matcher is being used in, or give it a
+      # > description method. Then you won't have to suffer this lengthy warning again.
+      #
+      # As of version 2.6.1 of axe-matchers, Axe::Matchers::BeAccessible lacks a #description method.
+      # Well.
+      def description
+        'be accessible'
+      end
+    end
+    ::Axe::Matchers::BeAccessible.include BeAccessibleMatcherDescription
+  end
+end


### PR DESCRIPTION
Add `axe-matcher` and basic automated accessibility tests for `/` and landing pages.

refs #1102

