### PR TITLE
Use ActiveSupport’s travel_to instead of Timecop

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -75,7 +75,6 @@ group :test do
   gem 'selenium-webdriver'
   gem 'shoulda-matchers'
   gem 'webmock'
-  gem 'timecop'
   gem 'axe-matchers', require: false
 end
 

--- a/spec/models/badge_spec.rb
+++ b/spec/models/badge_spec.rb
@@ -11,17 +11,20 @@ RSpec.describe Badge, type: :model do
     let(:date2) { date1 + 1.minute }
     let(:date3) { date1 + 2.minutes }
 
-    let(:solicitation) { Timecop.freeze(date1) { create :solicitation, badges: initial_badges } }
-    let(:badge) { Timecop.freeze(date2) { create :badge } }
+    let(:solicitation) { travel_to(date1) { create :solicitation, badges: initial_badges } }
+    let(:badge) { travel_to(date2) { create :badge } }
 
-    before { solicitation }
+    before do
+      badge
+      solicitation
+    end
 
     subject { solicitation.reload.updated_at }
 
     context 'when a badge is added to a solicitation' do
       let(:initial_badges) { [] }
 
-      before { Timecop.freeze(date3) { solicitation.badges = [badge] } }
+      before { travel_to(date3) { solicitation.badges = [badge] } }
 
       it { is_expected.to eq date3 }
     end
@@ -29,7 +32,7 @@ RSpec.describe Badge, type: :model do
     context 'when a badge is removed from a solicitation' do
       let(:initial_badges) { [badge] }
 
-      before { Timecop.freeze(date3) { solicitation.badges = [] } }
+      before { travel_to(date3) { solicitation.badges = [] } }
 
       it { is_expected.to eq date3 }
     end
@@ -37,7 +40,7 @@ RSpec.describe Badge, type: :model do
     context 'when a badge is updated' do
       let(:initial_badges) { [badge] }
 
-      before { Timecop.freeze(date3) { badge.update(title: 'New title') } }
+      before { travel_to(date3) { badge.update(title: 'New title') } }
 
       it { is_expected.to eq date3 }
     end

--- a/spec/models/feedback_spec.rb
+++ b/spec/models/feedback_spec.rb
@@ -40,32 +40,41 @@ RSpec.describe Feedback, type: :model do
     let(:date2) { date1 + 1.minute }
     let(:date3) { date1 + 2.minutes }
 
-    let(:solicitation) { Timecop.freeze(date1) { create :solicitation } }
+    let(:solicitation) { travel_to(date1) { create :solicitation } }
 
     before { solicitation }
 
     subject { solicitation.reload.updated_at }
 
     context 'when a feedback is added to a solicitation' do
-      let(:feedback) { Timecop.freeze(date3) { create :feedback, feedbackable: solicitation } }
+      let(:feedback) { travel_to(date3) { create :feedback, feedbackable: solicitation } }
 
-      before { Timecop.freeze(date3) { solicitation.feedbacks = [feedback] } }
+      before do
+        feedback
+        travel_to(date3) { solicitation.feedbacks = [feedback] }
+      end
 
       it { is_expected.to eq date3 }
     end
 
     context 'when a feedback is removed from a solicitation' do
-      let(:feedback) { Timecop.freeze(date1) { create :feedback, feedbackable: solicitation } }
+      let(:feedback) { travel_to(date1) { create :feedback, feedbackable: solicitation } }
 
-      before { Timecop.freeze(date3) { feedback.destroy } }
+      before do
+        feedback
+        travel_to(date3) { feedback.destroy }
+      end
 
       it { is_expected.to eq date3 }
     end
 
     context 'when a feedback is updated' do
-      let(:feedback) { Timecop.freeze(date1) { create :feedback, feedbackable: solicitation } }
+      let(:feedback) { travel_to(date1) { create :feedback, feedbackable: solicitation } }
 
-      before { Timecop.freeze(date3) { feedback.update(description: 'New description') } }
+      before do
+        feedback
+        travel_to(date3) { feedback.update(description: 'New description') }
+      end
 
       it { is_expected.to eq date3 }
     end

--- a/spec/models/need_spec.rb
+++ b/spec/models/need_spec.rb
@@ -193,14 +193,14 @@ RSpec.describe Need, type: :model do
   describe 'abandoned' do
     let(:need) { create :need }
     let(:date1) { Time.zone.now - 2.months }
-    let(:old_need) { Timecop.freeze(date1) { create :need, last_activity_at: date1 } }
+    let(:old_need) { travel_to(date1) { create :need, last_activity_at: date1 } }
 
     it do
       expect(need).not_to be_abandoned
       expect(old_need).to be_abandoned
       expect(described_class.abandoned).to match_array([old_need])
 
-      Timecop.freeze(2.months.from_now) do
+      travel_to(2.months.from_now) do
         expect(need).to be_abandoned
         expect(old_need).to be_abandoned
         expect(described_class.abandoned).to match_array([need, old_need])
@@ -213,32 +213,41 @@ RSpec.describe Need, type: :model do
     let(:date2) { date1 + 1.minute }
     let(:date3) { date1 + 2.minutes }
 
-    let(:diagnosis) { Timecop.freeze(date1) { create :diagnosis } }
+    let(:diagnosis) { travel_to(date1) { create :diagnosis } }
 
     before { diagnosis }
 
     subject { diagnosis.reload.updated_at }
 
     context 'when a need is added to a diagnosis' do
-      let(:need) { Timecop.freeze(date3) { create :need, diagnosis: diagnosis } }
+      let(:need) { travel_to(date3) { create :need, diagnosis: diagnosis } }
 
-      before { Timecop.freeze(date3) { diagnosis.needs = [need] } }
+      before do
+        need
+        travel_to(date3) { diagnosis.needs = [need] }
+      end
 
       it { is_expected.to eq date3 }
     end
 
     context 'when a need is removed from a diagnosis' do
-      let(:need) { Timecop.freeze(date1) { create :need, diagnosis: diagnosis } }
+      let(:need) { travel_to(date1) { create :need, diagnosis: diagnosis } }
 
-      before { Timecop.freeze(date3) { need.destroy } }
+      before do
+        need
+        travel_to(date3) { need.destroy }
+      end
 
       it { is_expected.to eq date3 }
     end
 
     context 'when a need is updated' do
-      let(:need) { Timecop.freeze(date1) { create :need, diagnosis: diagnosis } }
+      let(:need) { travel_to(date1) { create :need, diagnosis: diagnosis } }
 
-      before { Timecop.freeze(date3) { need.update(content: 'New content') } }
+      before do
+        need
+        travel_to(date3) { need.update(content: 'New content') }
+      end
 
       it { is_expected.to eq date3 }
     end
@@ -249,21 +258,21 @@ RSpec.describe Need, type: :model do
     let(:date2) { date1 + 1.minute }
     let(:date3) { date1 + 2.minutes }
 
-    let(:need) { Timecop.freeze(date1) { create :need } }
-    let(:match) { Timecop.freeze(date2) { create :match, need: need } }
+    let(:need) { travel_to(date1) { create :need } }
+    let(:match) { travel_to(date2) { create :match, need: need } }
 
     before { need.reload; match }
 
     subject { need.reload.last_activity_at }
 
     context 'when a match is updated' do
-      before { Timecop.freeze(date3) { match.update(status: :done) } }
+      before { travel_to(date3) { match.update(status: :done) } }
 
       it { is_expected.to eq date3 }
     end
 
     context 'when a feedback is added to a match' do
-      let(:feedback) { Timecop.freeze(date3) { create :feedback, feedbackable: need } }
+      let(:feedback) { travel_to(date3) { create :feedback, feedbackable: need } }
 
       before { need.reload; feedback }
 

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -4,8 +4,11 @@
 require 'webmock/rspec'
 require "pundit/rspec"
 require 'axe/rspec'
+require 'active_support/testing/time_helpers'
 
 RSpec.configure do |config|
+  config.include ActiveSupport::Testing::TimeHelpers
+
   config.expect_with :rspec do |expectations|
     expectations.include_chain_clauses_in_custom_matcher_descriptions = true
   end


### PR DESCRIPTION
We don’t need Timecop’s advanced features, and travel_to complains when nesting travels, which is actually helpful.