### PR TITLE
Landing css tweaks

### DIFF
--- a/app/assets/stylesheets/pages.sass
+++ b/app/assets/stylesheets/pages.sass
@@ -141,8 +141,6 @@ section.section#section-details
 section.section#section-formulaire
   .section__title
     text-align: initial
-  form
-    margin: initial
   .notification.success.delay
     display: flex
     flex-wrap: wrap

--- a/app/assets/stylesheets/pages/landing.sass
+++ b/app/assets/stylesheets/pages/landing.sass
@@ -34,30 +34,30 @@
       max-width: 100%
 
 section#section-formulaire .solicitation-form
-  margin-top: 3rem
-  display: flex
-  form
-    flex: 1 0 60%
-    &.in-iframe
-      margin: 0 auto
-    label
-      font-weight: bold
-  .description
+  form label
+    font-weight: bold
+  &:not(.in-iframe)
+    margin-top: 3rem
     display: flex
-    flex-direction: column
-    padding: 0 2rem 4rem 2rem
-    #description-explanation
-      flex: 1 1 auto
-      align-items: flex-end
-      display: flex
-      div
-        height: 14.3rem
-  @media(max-width: 750px)
-    flex-wrap: wrap
-    flex-direction: column-reverse
+    form
+      margin: 0
+      flex: 1 0 60%
     .description
-      padding: 0 0.5rem
-      margin-bottom: 2rem
+      display: flex
+      flex-direction: column
+      padding: 0 2rem 4rem 2rem
       #description-explanation
+        flex: 1 1 auto
+        align-items: flex-end
+        display: flex
         div
-          height: auto
+          height: 14.3rem
+    @media(max-width: 750px)
+      flex-wrap: wrap
+      flex-direction: column-reverse
+      .description
+        padding: 0 0.5rem
+        margin-bottom: 2rem
+        #description-explanation
+          div
+            height: auto

--- a/app/assets/stylesheets/pages/section_examples.sass
+++ b/app/assets/stylesheets/pages/section_examples.sass
@@ -16,7 +16,7 @@ section.section#section-exemples
       padding-right: 9rem
       margin-top: 2rem
       flex: 0 0 50%
-      a
+      .button
         font-weight: bold
         padding: 0.25rem 1.5rem
       h3
@@ -52,5 +52,5 @@ section.section#section-exemples
     .landing-topics .landing-topic
       flex: 0 0 100%
       padding-right: 0
-      a
+      .button
         width: auto

--- a/app/views/landings/_new_solicitation_form.html.haml
+++ b/app/views/landings/_new_solicitation_form.html.haml
@@ -1,4 +1,4 @@
-= form_with(model: solicitation, url: path, local: true, html: { honeypot: true, class: "#{'in-iframe' if in_iframe?}" }) do |f|
+= form_with(model: solicitation, url: path, local: true, html: { honeypot: true }) do |f|
   - if solicitation.errors.present?
     :javascript
       _paq.push(['trackEvent', 'contact-entreprise', 'failure']);

--- a/app/views/landings/new_solicitation.html.haml
+++ b/app/views/landings/new_solicitation.html.haml
@@ -30,7 +30,7 @@
             = t('.five_days_contact_html')
           .asterisk
             = t('.five_days_asterisk')
-      .solicitation-form
+      .solicitation-form{ class: "#{'in-iframe' if in_iframe?}" }
         = render 'new_solicitation_form', landing: @landing, solicitation: @solicitation, path: create_solicitation_landing_path
         .description
           - if landing_option&.form_description.present?

--- a/spec/views/iframe_test_page.html
+++ b/spec/views/iframe_test_page.html
@@ -7,7 +7,7 @@
    * { margin: 0; }
    body { background: papayawhip; }
 	 h1 { margin: 0.8em ;text-align: center; font-family: sans-serif; }
-   .container { max-width: 1000px; margin: 0 auto; }
+   .container { max-width: 730px; margin: 0 auto; }
    form { margin: 1em }
    input[type='text'] { width: 90%; margin: 1em }
  </style>
@@ -32,7 +32,7 @@
         <input type="text" id="textinput"/>
         <input type="submit" value="Go"/>
       </form>
-      <iframe id='iframe' width="100%" height="1000px" frameborder="0" style="background:peachpuff;"></iframe>
+      <iframe id='iframe' width="100%" height="900px" frameborder="0" style="background:peachpuff;"></iframe>
     </div>
   </div>
   <h1>🙃</h1>


### PR DESCRIPTION
* Tweak the iframe test page to look like what our partners are doing
* Fix layout for links in landing topics contents. This broke in the coronavirus page, where we had lots in a links in the topics contents.
* Fix form width when in-iframe. We had conflicting rules overriding each other for the form margin