### PR TITLE
Ajout d’un test d’accessibilité sur la page formulaire

### DIFF
--- a/app/views/landings/new_solicitation.html.haml
+++ b/app/views/landings/new_solicitation.html.haml
@@ -11,7 +11,7 @@
     .container
       .landing-header
         .title
-          %h1= landing_option&.form_title
+          %h1= landing_option&.form_title || @landing.title
           %p.subtitle= @landing.subtitle
 
   = render 'pages/breadcrumbs', landing: @landing, landing_option: landing_option

--- a/app/views/landings/new_solicitation.html.haml
+++ b/app/views/landings/new_solicitation.html.haml
@@ -11,7 +11,7 @@
     .container
       .landing-header
         .title
-          %h1= landing_option&.form_title || @landing.title
+          %h1= landing_option&.form_title.presence || @landing.title
           %p.subtitle= @landing.subtitle
 
   = render 'pages/breadcrumbs', landing: @landing, landing_option: landing_option

--- a/spec/a11y/a11y_spec.rb
+++ b/spec/a11y/a11y_spec.rb
@@ -30,4 +30,10 @@ describe 'a11y', type: :feature, js: true do
 
     it { is_expected.to be_accessible }
   end
+
+  describe '/aide-entreprises/:slug/demande' do
+    before { visit "/aide-entreprises/#{Landing.last.slug}/demande" }
+
+    it { is_expected.to be_accessible }
+  end
 end


### PR DESCRIPTION
Je pense qu’on peut clôturer #1102 avec ça.

(Il y avait une broutille sur la page `/demande`, sans landing_option, ce qui donnait un `h1` vide. C’est corrigé.)