### PR TITLE
Ne par proposer d’ajouter les experts sans sujets

### DIFF
--- a/app/controllers/needs_controller.rb
+++ b/app/controllers/needs_controller.rb
@@ -66,6 +66,7 @@ class NeedsController < ApplicationController
     @query = params.require('query')&.strip
 
     @experts = Expert.omnisearch(@query)
+      .with_subjects
       .where.not(id: @need.experts)
       .limit(15)
       .includes(:antenne, experts_subjects: :institution_subject)


### PR DESCRIPTION
À l'ajout d'experts additionnels pour un besoin existant, ne pas proposer les experts sans sujets (typiquement, les personal_skillsets de membres d’équipes).
