### PR TITLE
amélioration des liens vers les sollicitations et analyses précédentes pour une même personne

### DIFF
--- a/app/helpers/person_helper.rb
+++ b/app/helpers/person_helper.rb
@@ -10,10 +10,20 @@ module PersonHelper
 
     params = {
       name: person.full_name,
-      role: "#{person.role} - #{person.antenne.name}",
+      role: detailed_role(person),
       email: person.email,
       phone_number: person.phone_number
     }
     person_block_raw(params.merge(extra_params))
+  end
+
+  private
+
+  def detailed_role(person)
+    if defined? person.antenne
+      "#{person.role} - #{person.antenne.name}"
+    else
+      person.role
+    end
   end
 end

--- a/app/views/diagnoses/_related_diagnoses.html.haml
+++ b/app/views/diagnoses/_related_diagnoses.html.haml
@@ -5,21 +5,21 @@
       - solicitation = diagnosis.solicitation
       %tr
         %td
-          = link_to diagnosis_path(diagnosis), target: '_blank', rel: 'noopener' do
-            %h3.ui.header
-              - if solicitation.present?
-                = t('.solicited_at', date: I18n.l(diagnosis.display_date))
-              - else
-                = t('.visited_at', date: I18n.l(diagnosis.display_date))
-              .sub.header
-                - if solicitation.present?
-                  = t('.solicited_by_html', name: solicitation.full_name, email: solicitation.email)
-                - else
-                  - advisor = diagnosis.advisor
-                  = t('.visited_by_html', name: advisor.full_name, role: advisor.role, antenne: advisor.antenne.name, email: advisor.email)
-          .diagnosis-links
+          %h3.ui.header
             - if solicitation.present?
-              = link_to t('.solicitation_related'), solicitation, class: 'ui basic blue label'
+              = t('.solicited_at', date: I18n.l(diagnosis.display_date))
+            - else
+              = t('.visited_at', date: I18n.l(diagnosis.display_date))
+            .sub.header
+              - if solicitation.present?
+                = t('.solicited_by_html', name: solicitation.full_name, email: solicitation.email)
+              - else
+                - advisor = diagnosis.advisor
+                = t('.visited_by_html', name: advisor.full_name, role: advisor.role, antenne: advisor.antenne.name, email: advisor.email)
+          .diagnosis-links
+            = link_to t('.diagnosis_related'), diagnosis_path(diagnosis), target: '_blank', rel: 'noopener', class: 'ui basic blue label'
+            - if solicitation.present?
+              = link_to t('.solicitation_related'), solicitation, class: 'ui basic teal label'
         %td.collapsing
           .ui.middle.aligned.list
             .item

--- a/config/locales/views.fr.yml
+++ b/config/locales/views.fr.yml
@@ -135,6 +135,7 @@ fr:
       title: Saisie manuelle
     related_diagnoses:
       diagnoses_completed: Analyses completées
+      diagnosis_related: Analyse associée
       matches:
         one: 1 mise en relation
         other: "%{count} mises en relation"


### PR DESCRIPTION
Ajoute un bouton vers l'analyse associée plutôt qu'une zone cliquable pas intuitive. 
Corrige un bug de turbolink qui ne scrollait pas vers la sollicitation au clic sur "Sollicitation liée"

<img width="936" alt="Capture d’écran 2020-08-17 à 15 34 05" src="https://user-images.githubusercontent.com/22002486/90402029-24338700-e09f-11ea-9c4a-2183eb1c086a.png">

closes #1191