### PR TITLE
Cloturer / Mettre en échec depuis l'onglet relance

### DIFF
--- a/app/controllers/needs_controller.rb
+++ b/app/controllers/needs_controller.rb
@@ -3,6 +3,7 @@
 class NeedsController < ApplicationController
   before_action :maybe_review_expert_subjects
   before_action :retrieve_variables_for_index, only: %i[index taking_care]
+  before_action :retrieve_need, only: %i[archive unarchive]
 
   def index
     @needs = current_user.needs_quo.or(current_user.needs_others_taking_care).page params[:page]
@@ -94,6 +95,20 @@ class NeedsController < ApplicationController
     end
   end
 
+  def archive
+    authorize @need, :archive?
+    @need.archive!
+    flash[:notice] = t('.subjet_achived')
+    redirect_to need_path(@need.diagnosis)
+  end
+
+  def unarchive
+    authorize @need, :archive?
+    @need.update(archived_at: nil)
+    flash[:notice] = t('.subjet_unachived')
+    redirect_to need_path(@need.diagnosis)
+  end
+
   private
 
   def highlighted_experts
@@ -106,6 +121,10 @@ class NeedsController < ApplicationController
 
   def retrieve_diagnosis
     Diagnosis.find(params.require(:id))
+  end
+
+  def retrieve_need
+    @need = Need.find(params.require(:id))
   end
 
   def retrieve_variables_for_index

--- a/app/helpers/status_helper.rb
+++ b/app/helpers/status_helper.rb
@@ -31,6 +31,18 @@ module StatusHelper
     end
   end
 
+  def admin_match_actions_buttons(match)
+    if match.allowed_new_status.include? :done
+      form_with(model: match, url: match_path(match)) do |f|
+        title = Match.human_attribute_value(:status, :done, context: :action)
+        classes = %w[ui small button] + STATUS_COLORS[:done]
+        f.button :submit, name: :status, value: :done, class: classes.join(' ') do
+          status_icon(:done) + title
+        end
+      end
+    end
+  end
+
   def status_label(need_or_match)
     status = need_or_match.status
     title = need_or_match.human_attribute_value(:status, context: :short)

--- a/app/policies/match_policy.rb
+++ b/app/policies/match_policy.rb
@@ -2,4 +2,8 @@ class MatchPolicy < ApplicationPolicy
   def update?
     admin? || @record.contacted_users.include?(@user)
   end
+
+  def mark_as_done?
+    admin?
+  end
 end

--- a/app/policies/need_policy.rb
+++ b/app/policies/need_policy.rb
@@ -4,4 +4,8 @@ class NeedPolicy < ApplicationPolicy
       scope.all
     end
   end
+
+  def archive?
+    admin?
+  end
 end

--- a/app/views/matches/_match.haml
+++ b/app/views/matches/_match.haml
@@ -22,5 +22,8 @@
     - if for_me
       .meta
         = match_actions_buttons match
+    - elsif policy(match).mark_as_done?
+      .meta
+        = admin_match_actions_buttons match
   .match-status
     = status_label(match)

--- a/app/views/needs/_archive.haml
+++ b/app/views/needs/_archive.haml
@@ -1,0 +1,9 @@
+.ui.hidden.divider
+.ui.aligned.grid
+  .right.aligned.wide.column
+    - if need.archived_at?
+      = form_with(model: need, url: unarchive_need_url(need), local: true, method: :post) do |f|
+        = f.button t('.unarchive'), class: 'ui orange small button no-margin'
+    - else
+      = form_with(model: need, url: archive_need_url(need), local: true, method: :post) do |f|
+        = f.button t('.archive'), class: 'ui red small button no-margin'

--- a/app/views/needs/_need.haml
+++ b/app/views/needs/_need.haml
@@ -7,3 +7,5 @@
     = render 'feedbacks/form', feedback: need.feedbacks.new
     = render need.matches.order(:created_at), highlighted_experts: highlighted_experts
     = render 'additional_experts', need: need
+    - if current_user.is_admin?
+      = render 'archive', need: need

--- a/config/locales/views.fr.yml
+++ b/config/locales/views.fr.yml
@@ -417,6 +417,10 @@ fr:
       match_with: 'Mise en relation avec :'
       thats_you: C’est vous !
   needs:
+    archive:
+      archive: Mettre en échec
+      subjet_achived: Le sujet a été mis en échec
+      unarchive: Annuler la mise en échec
     archives:
       browse_active_needs: Voir les demandes reçues
       title: Demandes archivées
@@ -455,6 +459,8 @@ fr:
         zero: En attente de réponse
     show:
       title: Visite de la société « %{company} »
+    unarchive:
+      subjet_unachived: Le sujet n’est plus en échec
     visit_summary:
       advisor_has_diagnosed_n_needs:
         one: "%{advisor} a identifié un besoin."

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -140,6 +140,8 @@ Rails.application.routes.draw do
     member do
       get :additional_experts
       post :add_match
+      post :archive
+      post :unarchive
     end
   end
 


### PR DESCRIPTION
Permet de clôturer un besoin ou le mettre en échec quand on est admin

<img width="762" alt="Capture d’écran 2020-08-18 à 17 32 04" src="https://user-images.githubusercontent.com/22002486/90533427-c4111380-e178-11ea-9831-a89ebe4bb408.png">

closes #1192