### PR TITLE
Affiche le nom de l'antenne au lieu de l'institution sur la fiche entreprise

### DIFF
--- a/app/views/matches/_match.haml
+++ b/app/views/matches/_match.haml
@@ -17,7 +17,7 @@
         = t('.match_with')
     .summary
       .user.popup-hover{ class: ('expert-highlighted' if highlight) }
-        #{match.expert.full_name} - #{match.expert.institution.name}
+        #{match.expert.full_name} - #{match.expert.antenne.name}
       .ui.popup= person_block(match.expert)
     - if for_me
       .meta


### PR DESCRIPTION
Avant
<img width="736" alt="Capture d’écran 2020-08-24 à 15 14 34" src="https://user-images.githubusercontent.com/22002486/91058049-4e99bd00-e628-11ea-80c3-f9f7b95ec265.png">
Après
<img width="733" alt="Capture d’écran 2020-08-24 à 16 32 45" src="https://user-images.githubusercontent.com/22002486/91058076-548f9e00-e628-11ea-9427-5572dbab597b.png">

closes #1207 