### PR TITLE
Change the DB name after the scalingo region migration

### DIFF
--- a/lib/tasks/import_dump.rake
+++ b/lib/tasks/import_dump.rake
@@ -16,8 +16,9 @@ namespace :import_dump do
     env = `scalingo -a reso-production env`.lines
     pg_url = env.find{ |i| i[/SCALINGO_POSTGRESQL_URL=/] }
     pw = pg_url[/.*:(.*)@/,1]
+    dbname = 'reso_produc_4107'
 
-    sh "PGPASSWORD=#{pw} pg_dump --no-owner --no-acl e_conseils_2947 > tmp/export.pgsql  -h localhost -p 10000 -U e_conseils_2947"
+    sh "PGPASSWORD=#{pw} pg_dump --no-owner --no-acl #{dbname} > tmp/export.pgsql  -h localhost -p 10000 -U #{dbname}"
 
     kill_tunnel
   end


### PR DESCRIPTION
It was also necessary to reconfigure the CLI:
> scalingo config --region osc-fr1

see also #1213