### PR TITLE
Import CSV des antennes et conseillers 

### DIFF
--- a/app/assets/javascripts/application/semantic-ui.js
+++ b/app/assets/javascripts/application/semantic-ui.js
@@ -1,5 +1,6 @@
 addEventListener('turbolinks:load', function(event) {
   $('.ui.modal').modal( { closable: false }).modal('show'); // Show modal before activating other elements that may be inside the modal
+  $('.popup-click').popup({ on: "click" });
   $('.popup-hover').popup({ hoverable: true });
   $('select.ui.selection.search.dropdown').dropdown({ fullTextSearch: 'exact', ignoreDiacritics: true });
   $('.ui.dropdown').not('.simple').dropdown();

--- a/app/controllers/institutions_controller.rb
+++ b/app/controllers/institutions_controller.rb
@@ -39,8 +39,25 @@ class InstitutionsController < ApplicationController
           .merge(User.csv_fields_for_relevant_expert_subjects(@institutions_subjects))
         csv = CsvExportService.csv(@advisors, additional_fields)
         filename = CsvExportService.filename(@advisors)
+
         send_data csv, type: 'text/csv; charset=utf-8', disposition: "filename=#{filename}.csv"
       end
+    end
+  end
+
+  def import_antennes
+    @result = CsvImport::AntenneImporter.import(params.require(:file))
+    if @result.success?
+      flash[:table_highlighted_ids] = @result.objects.map(&:id)
+      redirect_to action: :antennes
+    end
+  end
+
+  def import_advisors
+    @result = CsvImport::UserImporter.import(params.require(:file), @institution)
+    if @result.success?
+      flash[:table_highlighted_ids] = @result.objects.map(&:id)
+      redirect_to action: :advisors
     end
   end
 

--- a/app/models/concerns/many_communes.rb
+++ b/app/models/concerns/many_communes.rb
@@ -10,7 +10,10 @@ module ManyCommunes
   def insee_codes=(codes_raw)
     wanted_codes = codes_raw.split(/[,\s]/).delete_if(&:empty?)
     if wanted_codes.any? { |code| code !~ Commune::INSEE_CODE_FORMAT }
-      raise 'Invalid city codes'
+      self.insee_codes_error = :invalid_insee_codes
+      return
+    else
+      self.insee_codes_error = nil
     end
 
     if wanted_codes.present?
@@ -20,6 +23,18 @@ module ManyCommunes
     end
 
     self.communes = Commune.where(insee_code: wanted_codes)
+  end
+
+  ## Validation Support
+  # The error is set in the insee_codes= setter, and checked in the validation method
+  included do
+    attr_accessor :insee_codes_error
+
+    validate do
+      if insee_codes_error.present?
+        errors.add(:insee_codes, insee_codes_error)
+      end
+    end
   end
 
   ## Territories description

--- a/app/models/expert_subject.rb
+++ b/app/models/expert_subject.rb
@@ -72,6 +72,14 @@ class ExpertSubject < ApplicationRecord
   ## used for serialization in advisors csv
   #
   def csv_description
-    [human_attribute_value(:role), description].to_csv(col_sep: ':').strip
+    [human_attribute_value(:role), description.presence].compact.to_csv(col_sep: ':').strip
+  end
+
+  def csv_description=(csv)
+    role, description = CSV.parse_line(csv, col_sep: ':').to_a
+    role = ExpertSubject.human_attribute_values(:role).key(role)
+    description = "" if description.nil?
+
+    self.assign_attributes(role: role, description: description)
   end
 end

--- a/app/models/institution_subject.rb
+++ b/app/models/institution_subject.rb
@@ -55,6 +55,6 @@ class InstitutionSubject < ApplicationRecord
   ## used for serialization in advisors csv
   #
   def csv_identifier
-    [theme, subject, description].to_csv(col_sep: ':').strip
+    [theme, subject, description.presence].compact.to_csv(col_sep: ':').strip
   end
 end

--- a/app/policies/institution_policy.rb
+++ b/app/policies/institution_policy.rb
@@ -8,18 +8,22 @@ class InstitutionPolicy < ApplicationPolicy
   end
 
   def subjects?
-    show?
+    admin?
   end
 
   def antennes?
-    show?
+    admin?
   end
 
   def advisors?
-    show?
+    admin?
   end
 
-  def update?
+  def import_antennes?
+    admin?
+  end
+
+  def import_advisors?
     admin?
   end
 end

--- a/app/services/csv_export/models/user.rb
+++ b/app/services/csv_export/models/user.rb
@@ -40,7 +40,7 @@ module CsvExport
               # See `object.instance_exec(&lambda)` in CsvExportService.
               # We’re using `&` instead of .merge to use the preloaded relations instead of doing a new DB query.
               experts_subjects = relevant_expert.experts_subjects & institution_subject.experts_subjects
-              experts_subjects.map(&:csv_description).to_csv.strip
+              experts_subjects.map(&:csv_description).to_csv.strip.presence
             }
             [title, lambda]
           end.to_h

--- a/app/services/csv_import/antenne_importer.rb
+++ b/app/services/csv_import/antenne_importer.rb
@@ -1,0 +1,23 @@
+module CsvImport
+  class AntenneImporter < BaseImporter
+    def mapping
+      @mapping ||=
+        %i[institution name insee_codes]
+          .index_by{ |k| Antenne.human_attribute_name(k) }
+    end
+
+    def check_headers(headers)
+      headers.map do |header|
+        UnknownHeaderError.new(header) unless mapping.include? header
+      end.compact
+    end
+
+    def preprocess(attributes)
+      attributes[:institution] = Institution.find_by(name: attributes[:institution])
+    end
+
+    def find_instance(attributes)
+      Antenne.find_or_initialize_by(institution: attributes[:institution], name: attributes[:name])
+    end
+  end
+end

--- a/app/services/csv_import/base_importer.rb
+++ b/app/services/csv_import/base_importer.rb
@@ -1,0 +1,90 @@
+module CsvImport
+  class Result
+    attr_reader :rows, :objects, :header_errors
+
+    def initialize(rows:, header_errors:, objects:)
+      @rows, @header_errors, @objects = rows, header_errors, objects
+    end
+
+    def success?
+      @header_errors.blank? && @objects.all?(&:valid?)
+    end
+  end
+
+  class UnknownHeaderError < StandardError
+    attr_reader :header
+
+    def initialize(header)
+      @header = header
+      super("En-tête non reconnu: « #{header} »")
+    end
+  end
+
+  class BaseImporter
+    def self.import(input, *args)
+      self.new(input, *args).import
+    end
+
+    def initialize(input, *args)
+      @input = input
+    end
+
+    def import
+      begin
+        if @input.respond_to?(:open)
+          # Unfortunately, CSV::read only takes files…
+          # … and CSV::new takes strings or IO, but the IO needs to be already open.
+          # @input is a file:
+          csv = CSV.read(@input, headers: true)
+        else
+          # @input is a string:
+          csv = CSV.new(@input, headers: true).read
+        end
+      rescue CSV::MalformedCSVError => e
+        return Result.new(rows: [], header_errors: [e], objects: [])
+      end
+
+      header_errors = check_headers(csv.headers)
+
+      rows = csv.map(&:to_h)
+      objects = []
+      ActiveRecord::Base.transaction do
+        # Convert CSV rows to attributes
+        objects = rows.each_with_index.map do |row|
+          # Convert row to user attributes
+          attributes = row.slice(*mapping.keys)
+            .transform_keys{ |k| mapping[k] }
+
+          preprocess(attributes)
+
+          # Create objects
+          object = find_instance(attributes)
+          object.update(attributes)
+
+          postprocess(object, row)
+
+          object
+        end
+
+        # Build all objects to collect errors, but rollback everything on error
+        if objects.any?(&:invalid?)
+          raise ActiveRecord::Rollback
+        end
+      end
+
+      Result.new(rows: rows, header_errors: header_errors, objects: objects)
+    end
+
+    ## subclasses override points
+    #
+    def mapping; end
+
+    def check_headers(headers); end
+
+    def preprocess(attributes); end
+
+    def find_instance(attributes); end
+
+    def postprocess(object, attributes); end
+  end
+end

--- a/app/services/csv_import/user_importer.rb
+++ b/app/services/csv_import/user_importer.rb
@@ -1,0 +1,90 @@
+module CsvImport
+  class UserImporter < BaseImporter
+    def initialize(file, institution)
+      @institution = institution
+      super(file)
+    end
+
+    def mapping
+      @mapping ||=
+        %i[institution antenne full_name email phone_number role]
+          .index_by{ |k| User.human_attribute_name(k) }
+    end
+
+    def check_headers(headers)
+      all_known_headers = mapping.keys + team_mapping.keys + subjects_mapping.keys
+      headers.map do |header|
+        UnknownHeaderError.new(header) unless all_known_headers.include? header
+      end.compact
+    end
+
+    def preprocess(attributes)
+      institution = Institution.find_by(name: attributes[:institution])
+      antenne = Antenne.find_by(institution: institution, name: attributes[:antenne])
+      attributes.delete(:institution)
+      attributes[:antenne] = antenne
+    end
+
+    def find_instance(attributes)
+      User.find_or_initialize_by(email: attributes[:email])
+    end
+
+    def postprocess(user, attributes)
+      team = import_team(user, attributes)
+      expert = team || user.personal_skillsets.first
+      if expert.present?
+        import_subjects(expert, attributes)
+      end
+    end
+
+    def team_mapping
+      @team_mapping ||=
+        %i[team_email team_full_name team_phone_number team_role]
+          .index_by{ |k| User.human_attribute_name(k) }
+    end
+
+    def import_team(user, all_attributes)
+      attributes = all_attributes.slice(*team_mapping.keys)
+        .transform_keys{ |k| team_mapping[k] }
+        .transform_keys{ |k| k.to_s.delete_prefix('team_').to_sym }
+        .select { |_, v| v.present? }
+
+      if attributes[:email].present?
+        attributes[:antenne] = user.antenne
+        team = Expert.find_or_initialize_by(email: attributes[:email])
+        team.update(attributes)
+
+        unless user.experts.include? team
+          user.experts << team
+        end
+
+        team
+      end
+    end
+
+    def subjects_mapping
+      @subjects_mapping ||=
+        @institution.institutions_subjects
+          .index_by(&:csv_identifier)
+    end
+
+    def import_subjects(expert, all_attributes)
+      attributes = all_attributes.slice(*subjects_mapping.keys)
+        .transform_keys{ |k| subjects_mapping[k] }
+
+      experts_subjects = attributes.map do |institution_subject, serialized_description|
+        # TODO: serialized_description may be an array of hashes
+        if serialized_description.present?
+          expert_subject_attributes = {
+            institution_subject: institution_subject,
+            csv_description: serialized_description
+          }
+
+          ExpertSubject.new(expert_subject_attributes)
+        end
+      end
+
+      expert.experts_subjects = experts_subjects.compact
+    end
+  end
+end

--- a/app/views/institutions/_advisors_table.html.haml
+++ b/app/views/institutions/_advisors_table.html.haml
@@ -35,7 +35,8 @@
       - teams.each_with_index do |key_and_value, index_in_antenne|
         - advisors = key_and_value.last
         - advisors.each_with_index do |user, index_in_team|
-          %tr
+          - highlighted_ids = flash[:table_highlighted_ids]
+          %tr{ class: highlighted_ids&.include?(user.id) ? 'blue' : '' }
             - if index_in_antenne == 0 && index_in_team == 0
               %td{ rowspan: teams.values.sum(&:size) }= antenne
             - else
@@ -76,6 +77,15 @@
     %tr
       %th
       %th{ colspan: 2 + institutions_subjects.size }
-        %a.ui.right.floated.small.labeled.icon.button{ href: advisors_institution_path(format: 'csv') }
+        %a.ui.left.floated.small.labeled.icon.button{ href: advisors_institution_path(format: 'csv') }
           %i.download.icon
           = t('export')
+        .ui.left.floated.small.labeled.icon.button.popup-click
+          %i.upload.icon
+          = t('import')
+        .ui.popup
+          = form_with url: import_advisors_institution_path, local: true, class: 'ui form' do |f|
+            .ui.inline.field
+              = f.file_field :file, accept: 'text/csv', required: true
+            = f.submit t('submit'), class: 'ui right floated button'
+

--- a/app/views/institutions/_antennes_table.html.haml
+++ b/app/views/institutions/_antennes_table.html.haml
@@ -6,7 +6,9 @@
   %tbody
     - antennes.each do |antenne|
       %tr
-        %td= antenne.name
+        - highlighted_ids = flash[:table_highlighted_ids]
+        %td{ class: ('left marked blue' if highlighted_ids&.include?(antenne.id)) }
+          = antenne.name
         %td
           %ul
             - summary = antenne.intervention_zone_summary
@@ -18,6 +20,14 @@
     %tr
       %th
       %th
-        %a.ui.right.floated.small.labeled.icon.button{ href: antennes_institution_path(format: 'csv') }
+        %a.ui.left.floated.small.labeled.icon.button{ href: antennes_institution_path(format: 'csv') }
           %i.download.icon
           = t('export')
+        .ui.left.floated.small.labeled.icon.button.popup-click
+          %i.upload.icon
+          = t('import')
+        .ui.popup
+          = form_with url: import_antennes_institution_path, local: true, class: 'ui form' do |f|
+            .ui.inline.field
+              = f.file_field :file, accept: 'text/csv', required: true
+            = f.submit t('submit'), class: 'ui right floated button'

--- a/app/views/institutions/_import_errors.html.haml
+++ b/app/views/institutions/_import_errors.html.haml
@@ -1,0 +1,31 @@
+- unless result.success?
+  .ui.icon.error.message
+    %i.icon.exclamation.triangle
+    .content
+      .header= t('.import_failed')
+      - result.header_errors.each do |error|
+        %p= error.message
+
+- if result.rows.present?
+  .wide-scrolling
+    %table.sticky-left.ui.definition.celled.table
+      %thead
+        %tr
+          %th
+          - result.rows.first.each_key do |header|
+            %th= header
+      %tbody
+        - result.rows.each_with_index do |row, index|
+          - object = result.objects[index]
+          %tr
+            %td{ rowspan: object.invalid? ? 2 : 1 }
+              #{index + 1}
+            - row.each_value do |value|
+              %td= value
+          - if object.invalid?
+            %tr.red
+              %td.rowspanned
+              %td{ colspan: row.count + 1 }
+                = object.errors.full_messages.to_sentence
+
+

--- a/app/views/institutions/import_advisors.html.haml
+++ b/app/views/institutions/import_advisors.html.haml
@@ -1,0 +1,6 @@
+- meta title: @institution.name
+- content_for :header, render('header', institution: @institution)
+- content_for :menu, render('menu', institution: @institution)
+
+.wide-scrolling
+  = render 'import_errors', result: @result

--- a/app/views/institutions/import_antennes.html.haml
+++ b/app/views/institutions/import_antennes.html.haml
@@ -1,0 +1,6 @@
+- meta title: @institution.name
+- content_for :header, render('header', institution: @institution)
+- content_for :menu, render('menu', institution: @institution)
+
+
+= render 'import_errors', result: @result

--- a/config/locales/fr.yml
+++ b/config/locales/fr.yml
@@ -167,6 +167,7 @@ fr:
       update: Modifier ce(tte) %{model}
   honeypot_captcha:
     comment: Laissez ce champ vide !
+  import: Importer
   needs:
     additional_experts:
       add_match_with: Voulez-vous contacter %{name} au sujet de ce besoin (%{subject}) ?
@@ -235,6 +236,7 @@ fr:
         message_html: Cette erreur était inattendue…</br>Nous avons été prévenus de son apparition et nous allons la réparer dès que possible !
         title: Erreur !
   sign_in: Connexion
+  submit: Envoyer
   support:
     array:
       last_word_connector: " et "

--- a/config/locales/views.fr.yml
+++ b/config/locales/views.fr.yml
@@ -235,6 +235,9 @@ fr:
     solicitation:
       analysis_in_progress: Analyse en cours (%{step})
       view_completed_analysis: Voir l’analyse réalisée
+  institutions:
+    import_errors:
+      import_failed: Échec de l’import
   landing_topics:
     landing_topic:
       choose: Choisir

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -35,9 +35,11 @@ Rails.application.routes.draw do
 
   resources :institutions, param: :slug, only: %i[index show] do
     member do
-      get :subjects, path: 'competences'
+      get :subjects, path: 'domaines'
       get :antennes
       get :advisors, path: 'conseillers'
+      post :import_antennes, path: 'antennes/import'
+      post :import_advisors, path: 'conseillers/import'
     end
   end
 

--- a/spec/models/concerns/many_communes_spec.rb
+++ b/spec/models/concerns/many_communes_spec.rb
@@ -26,11 +26,14 @@ RSpec.describe ManyCommunes do
       let(:territory) { create :territory }
 
       context 'with invalid data' do
-        subject(:set_insee_codes) { territory.insee_codes = raw_codes }
-
         let(:raw_codes) { 'baddata morebaddata' }
 
-        it { expect { set_insee_codes }.to raise_error 'Invalid city codes' }
+        before { territory.insee_codes = raw_codes }
+
+        it do
+          expect(territory).to be_invalid
+          expect(territory.errors.details).to eq({ insee_codes: [{ error: :invalid_insee_codes }] })
+        end
       end
 
       context 'with empty data' do

--- a/spec/models/expert_subject_spec.rb
+++ b/spec/models/expert_subject_spec.rb
@@ -41,4 +41,48 @@ RSpec.describe ExpertSubject, type: :model do
       end
     end
   end
+
+  describe 'csv_description' do
+    subject { expert_subject.csv_description }
+
+    let(:expert_subject) { build :expert_subject, role: role, description: description }
+
+    context 'with description' do
+      let(:role) { 'specialist' }
+      let(:description) { 'Longue description du rôle' }
+
+      it { is_expected.to eq 'spécialiste:Longue description du rôle' }
+    end
+
+    context 'empty description' do
+      let(:role) { 'fallback' }
+      let(:description) { '' }
+
+      it { is_expected.to eq 'suppléant' }
+    end
+  end
+
+  describe 'csv_description=' do
+    before { expert_subject.csv_description = csv }
+
+    let(:expert_subject) { build :expert_subject, role: nil, description: nil }
+
+    context 'with description' do
+      let(:csv) { 'spécialiste:Longue description du rôle' }
+
+      it do
+        expect(expert_subject.role).to eq 'specialist'
+        expect(expert_subject.description).to eq 'Longue description du rôle'
+      end
+    end
+
+    context 'empty description' do
+      let(:csv) { 'suppléant' }
+
+      it do
+        expect(expert_subject.role).to eq 'fallback'
+        expect(expert_subject.description).to eq ''
+      end
+    end
+  end
 end

--- a/spec/models/institution_subject_spec.rb
+++ b/spec/models/institution_subject_spec.rb
@@ -9,4 +9,24 @@ RSpec.describe InstitutionSubject, type: :model do
       is_expected.to belong_to :institution
     end
   end
+
+  describe 'csv_identifier' do
+    subject { institution_subject.csv_identifier }
+
+    let(:institution_subject) { create :institution_subject, subject: the_subject, description: description }
+    let(:the_subject) { create :subject, theme: theme, label: 'Label of the subject' }
+    let(:theme) { create :theme, label: 'Label of the theme' }
+
+    context 'with a description' do
+      let(:description) { 'Description détaillée' }
+
+      it{ is_expected.to eq 'Label of the theme:Label of the subject:Description détaillée' }
+    end
+
+    context 'with no description' do
+      let(:description) { '' }
+
+      it{ is_expected.to eq 'Label of the theme:Label of the subject' }
+    end
+  end
 end

--- a/spec/services/csv_import_service_spec.rb
+++ b/spec/services/csv_import_service_spec.rb
@@ -1,0 +1,184 @@
+require 'rails_helper'
+
+describe CsvImport do
+  describe 'import antennes' do
+    subject(:result) { CsvImport::AntenneImporter.import(csv) }
+
+    context 'malformed file' do
+      let(:csv) do
+        <<~CSV
+          Institution,"
+        CSV
+      end
+
+      it do
+        expect(result).not_to be_success
+        expect(result.header_errors.map(&:message)).to eq ["Unclosed quoted field in line 1."]
+      end
+    end
+
+    context 'invalid headers' do
+      let(:csv) do
+        <<~CSV
+          Foo,Bar
+        CSV
+      end
+
+      it do
+        expect(result).not_to be_success
+        expect(result.header_errors.map(&:message)).to eq [
+          'En-tête non reconnu: « Foo »',
+          'En-tête non reconnu: « Bar »'
+        ]
+      end
+    end
+
+    context 'invalid rows' do
+      before do
+        create :institution, name: 'Test Institution'
+      end
+
+      let(:csv) do
+        <<~CSV
+          Institution,Nom,Codes commune
+          Test Institution,Antenne1,invalid_code
+        CSV
+      end
+
+      it do
+        expect(result).not_to be_success
+        expect(result.header_errors).to be_empty
+        expect(result.objects.first.errors.details).to eq({ insee_codes: [{ error: :invalid_insee_codes }] })
+      end
+    end
+
+    context 'two antennes' do
+      before do
+        create :institution, name: 'Test Institution'
+      end
+
+      let(:csv) do
+        <<~CSV
+          Institution,Nom,Codes commune
+          Test Institution,Antenne1,00001 00002
+          Test Institution,Antenne2,00003 00004
+        CSV
+      end
+
+      it do
+        expect(result).to be_success
+        expect(result.objects.count).to eq 2
+        expect(result.objects.map(&:name)).to eq %w[Antenne1 Antenne2]
+        expect(Commune.pluck(:insee_code)).to match_array %w[00001 00002 00003 00004]
+      end
+    end
+
+    context 'existing antenne overwrite' do
+      before do
+        institution = create :institution, name: 'Test Institution'
+        create :antenne, institution: institution, name: 'Antenne1', insee_codes: '00001'
+      end
+
+      let(:csv) do
+        <<~CSV
+          Institution,Nom,Codes commune
+          Test Institution,Antenne1,00002
+        CSV
+      end
+
+      it do
+        expect(result).to be_success
+        expect(Antenne.find_by(name: 'Antenne1').insee_codes).to eq '00002'
+      end
+    end
+  end
+
+  describe 'import advisors' do
+    subject(:result) { CsvImport::UserImporter.import(csv, institution) }
+
+    let(:institution) { create :institution, name: 'Institution0' }
+    let(:theme) { create :theme, label: 'Theme0' }
+    let(:the_subject) { create :subject, label: 'Subject0', theme: theme }
+
+    before do
+      create :antenne, name: 'Antenne0', institution: institution
+      create :institution_subject, institution: institution, subject: the_subject, description: 'Description1'
+      create :institution_subject, institution: institution, subject: the_subject, description: 'Description2'
+    end
+
+    context 'two users, no team' do
+      let(:csv) do
+        <<~CSV
+          Institution,Antenne,Prénom et nom,E-mail,Téléphone,Fonction
+          Institution0,Antenne0,Marie Dupont,marie.dupont@antenne.com,0123456789,Cheffe
+          Institution0,Antenne0,Mario Dupont,mario.dupont@antenne.com,0123456789,Sous-Chef
+        CSV
+      end
+
+      it do
+        expect(result).to be_success
+        expect(institution.advisors.pluck(:email)).to match_array(['marie.dupont@antenne.com', 'mario.dupont@antenne.com'])
+      end
+    end
+
+    context 'set teams' do
+      let(:csv) do
+        <<~CSV
+          Institution,Antenne,Prénom et nom,E-mail,Téléphone,Fonction,Nom de l’équipe,E-mail de l’équipe,Téléphone de l’équipe,Fonction de l’équipe
+          Institution0,Antenne0,Marie Dupont,marie.dupont@antenne.com,0123456789,Cheffe,Equipe,equipe@antenne.com,0987654321,Equipe des chefs
+          Institution0,Antenne0,Mario Dupont,mario.dupont@antenne.com,0123456789,Sous-Chef,Equipe,equipe@antenne.com,0987654321,Equipe des chefs
+        CSV
+      end
+
+      it do
+        expect(result).to be_success
+        expect(institution.experts.teams.count).to eq 1
+        team = institution.experts.teams.first
+        expect(team.email).to eq 'equipe@antenne.com'
+        expect(team.role).to eq 'Equipe des chefs'
+        expect(team.users.pluck(:email)).to match_array(['marie.dupont@antenne.com', 'mario.dupont@antenne.com'])
+      end
+    end
+
+    context 'set subjects' do
+      let(:csv) do
+        <<~CSV
+          Institution,Antenne,Prénom et nom,E-mail,Téléphone,Fonction,Theme0:Subject0:Description1,Theme0:Subject0:Description2
+          Institution0,Antenne0,Marie Dupont,marie.dupont@antenne.com,0123456789,Cheffe,spécialiste:description1,
+        CSV
+      end
+
+      it do
+        expect(result).to be_success
+        marie = result.objects.first
+        expect(marie.personal_skillsets.count).to eq 1
+        expect(marie.experts.teams.count).to eq 0
+        skillet = marie.personal_skillsets.first
+        expect(skillet.experts_subjects.count).to eq 1
+        expect(skillet.experts_subjects.first.description).to eq 'description1'
+        expect(skillet.experts_subjects.first.subject).to eq the_subject
+      end
+    end
+
+    context 'overwrite existing user' do
+      let(:other_antenne) { create :antenne, name: 'Other' }
+      let!(:existing_user) { create :user, full_name: 'TestUser', email: 'test@test.com', phone_number: '4321', antenne: other_antenne }
+
+      let(:csv) do
+        <<~CSV
+          Institution,Antenne,Prénom et nom,E-mail,Téléphone,Fonction
+          Institution0,Antenne0,Marie Dupont,test@test.com,0123456789,Cheffe
+        CSV
+      end
+
+      it do
+        expect(result).to be_success
+        existing_user.reload
+        expect(result.objects).to eq [existing_user]
+        expect(existing_user.full_name).to eq 'Marie Dupont'
+        expect(existing_user.institution).to eq institution
+        expect(other_antenne.advisors).to be_empty
+      end
+    end
+  end
+end


### PR DESCRIPTION
fixes #1119 and 1243

* [x] merge #1221, #1222, #1223, #1224 first
* Finish tests
  * [x] antennes
  * [x] basic errors
  * [x] advisors
  * [x] csv_description and csv_identifier
* Additional Features (maybe in another PR)
  * [x] automatic support for `;` or `,` separators
  * Subjects matching
    * [x] Support single-column subject for advisors
    * [x] Less strict matching for subject headers
  Both involve reworking UserImpoerter#subjects_mapping. We also want to return an error if both the unique Subject column and subject-specific column are present
   * [ ] Support multiple subjects in importing serialized_description
* UI (in another PR)
  * [ ] Find a nicer way to implement wide layout, where all the screen real estate is used, _and_ it is scrollable
  * [ ] Make re-uploading after an error easier. At least, provide a link to the form.
* Cleanup (in another PR)
  * Make the importer and exporter similar, as much as reasonable
  * Move them together in a CSVIO namespace
  * Move the “serialized_identifier” and “serialized_description” methods to the CSVIO namespace
