### PR TITLE
Make sure very wide tables can scroll

### DIFF
--- a/app/assets/stylesheets/application/semantic-ui_extensions.sass
+++ b/app/assets/stylesheets/application/semantic-ui_extensions.sass
@@ -32,3 +32,13 @@
 
 .ui.popup
   max-width: 400px
+
+.ui
+  .wide-scrolling  // Make sure very wide tables can scroll
+    overflow-x: auto
+  table.ui.table.sticky-left // And try to keep the first column visible
+    thead tr th:first-of-type, tbody tr td:first-of-type
+      position: sticky
+      left: 0
+    tbody tr td:first-of-type
+      background: rgb(248, 248, 248) // Default is rgba(0, 0, 0, 0.03): we want the same grey, but opaque.

--- a/app/views/institutions/_advisors_table.html.haml
+++ b/app/views/institutions/_advisors_table.html.haml
@@ -1,4 +1,4 @@
-%table.ui.definition.celled.table
+%table.sticky-left.ui.definition.celled.table
   %thead
     -# For the subjects columns, we'll build our header on 3 rows: theme, subject and institutions_subject.
     - grouped_subjects = institutions_subjects.group_by(&:theme).transform_values{ |is| is.group_by(&:subject) }

--- a/app/views/institutions/advisors.html.haml
+++ b/app/views/institutions/advisors.html.haml
@@ -2,4 +2,5 @@
 - content_for :header, render('header', institution: @institution)
 - content_for :menu, render('menu', institution: @institution)
 
-= render 'advisors_table', institutions_subjects: @institutions_subjects, advisors: @advisors
+.wide-scrolling
+  = render 'advisors_table', institutions_subjects: @institutions_subjects, advisors: @advisors


### PR DESCRIPTION
I haven’t found a simple way to make the table visually overflow, but have the whole layout scroll (which was already the behaviour in Safari). Well, that’ll do.

fixup #1223