### PR TITLE
Fix admin/match status edition

### DIFF
--- a/app/admin/match.rb
+++ b/app/admin/match.rb
@@ -103,7 +103,7 @@ ActiveAdmin.register Match do
   permit_params :expert_id, :subject_id, :status
   form do |f|
     f.inputs do
-      f.input :status
+      f.input :status, as: :select, collection: Match.human_attribute_values(:status).invert
       f.input :expert, as: :ajax_select, data: { url: :admin_experts_path, search_fields: [:full_name] }
       themes = Theme.all
       collection = option_groups_from_collection_for_select(themes, :subjects, :label, :id, :label, resource.subject_id)


### PR DESCRIPTION
Following #1215

ActiveAdmin (Formtastic, really) doesn’t like real enum types. I considered implementing EnumInput as per https://github.com/formtastic/formtastic/issues/718, but  really I don’t want to go there. Also, it’s an issue from 2011.