### PR TITLE
Import improvements

### DIFF
--- a/app/admin/expert.rb
+++ b/app/admin/expert.rb
@@ -224,8 +224,7 @@ ActiveAdmin.register Expert do
     if resource.institution.present?
       f.inputs t('attributes.experts_subjects.other') do
         f.has_many :experts_subjects, allow_destroy: true do |sub_f|
-          collection = resource.institution.institutions_subjects.ordered_for_interview
-            .includes(:theme).group_by(&:theme)
+          collection = resource.institution.available_subjects
             .map do |t, s|
               [t.label, s.map { |s| ["#{s.subject.label}: #{s.description}", s.id] }]
             end

--- a/app/models/institution.rb
+++ b/app/models/institution.rb
@@ -59,12 +59,25 @@ class Institution < ApplicationRecord
   #
   scope :ordered_logos, -> { not_deleted.where.not(logo_sort_order: nil).order(:logo_sort_order) }
 
+  ## Institution subjects helpers
+  #
+
+  # All the subjects that can be assigned to an expert of this institution
   def available_subjects
     institutions_subjects
       .ordered_for_interview
       .includes(:theme)
       .merge(Subject.archived(false))
       .group_by { |is| is.theme } # Enumerable#group_by maintains ordering
+  end
+
+  # Find the one subject that matches the passed label
+  # return nil if there’s an ambiguity
+  def find_institution_subject(label)
+    matches = institutions_subjects.filter do |is|
+      label.in? [is.description, is.subject.label, is.theme.label, is.csv_identifier]
+    end
+    matches.first if matches.count == 1
   end
 
   ##

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -74,10 +74,7 @@ class User < ApplicationRecord
   validates :full_name, :phone_number, presence: true, unless: :deleted?
   after_create :create_personal_skillset_if_needed
   after_update :synchronize_personal_skillsets
-
-  def ensure_has_expert
-    create_matching_expert
-  end
+  validate :validate_experts_are_valid, on: :import
 
   ## “Through” Associations
   #
@@ -257,5 +254,15 @@ class User < ApplicationRecord
 
   def synchronize_personal_skillsets
     self.personal_skillsets.update_all(self.attributes_shared_with_personal_skills)
+  end
+
+  ## Support for validation on import
+  #
+
+  def validate_experts_are_valid
+    # I somewhat expected it to be implicit. I’m not entirely sure why it’s needed.
+    experts.filter(&:invalid?).each do |expert|
+      errors.add(:experts, expert.errors.details)
+    end
   end
 end

--- a/app/services/csv_import/base_importer.rb
+++ b/app/services/csv_import/base_importer.rb
@@ -7,7 +7,7 @@ module CsvImport
     end
 
     def success?
-      @header_errors.blank? && @objects.all?(&:valid?)
+      @header_errors.blank? && @objects.all?{ |object| object.valid?(:import) }
     end
   end
 
@@ -58,7 +58,7 @@ module CsvImport
         end
 
         # Build all objects to collect errors, but rollback everything on error
-        if objects.any?(&:invalid?)
+        if objects.any?{ |object| object.invalid?(:import) }
           raise ActiveRecord::Rollback
         end
       end

--- a/app/services/csv_import/base_importer.rb
+++ b/app/services/csv_import/base_importer.rb
@@ -30,18 +30,9 @@ module CsvImport
     end
 
     def import
-      begin
-        if @input.respond_to?(:open)
-          # Unfortunately, CSV::read only takes files…
-          # … and CSV::new takes strings or IO, but the IO needs to be already open.
-          # @input is a file:
-          csv = CSV.read(@input, headers: true)
-        else
-          # @input is a string:
-          csv = CSV.new(@input, headers: true).read
-        end
-      rescue CSV::MalformedCSVError => e
-        return Result.new(rows: [], header_errors: [e], objects: [])
+      csv = open_with_best_separator(@input)
+      if csv.is_a? CSV::MalformedCSVError
+        return Result.new(rows: [], header_errors: [csv], objects: [])
       end
 
       header_errors = check_headers(csv.headers)
@@ -75,8 +66,40 @@ module CsvImport
       Result.new(rows: rows, header_errors: header_errors, objects: objects)
     end
 
+    private
+
+    def open_with_separator(input, col_sep)
+      begin
+        if input.respond_to?(:open)
+          # Unfortunately, CSV::read only takes files…
+          # … and CSV::new takes strings or IO, but the IO needs to be already open.
+          # @input is a file:
+          CSV.read(input, headers: true, col_sep: col_sep)
+        else
+          # @input is a string:
+          CSV.new(input, headers: true, col_sep: col_sep).read
+        end
+      rescue CSV::MalformedCSVError => e
+        return e
+      end
+    end
+
+    def open_with_best_separator(input)
+      separators = %w[, ;]
+      attempted = separators.map { |separator| open_with_separator(input, separator) }
+
+      opened_files = attempted.filter { |csv| !csv.is_a? CSV::MalformedCSVError }
+      return attempted.first if opened_files.empty?
+
+      # Find the separator that find the most headers
+      best_index = opened_files.map(&:headers).map(&:count).each_with_index.max.second
+      opened_files[best_index]
+    end
+
     ## subclasses override points
     #
+    public
+
     def mapping; end
 
     def check_headers(headers); end

--- a/spec/models/institution_spec.rb
+++ b/spec/models/institution_spec.rb
@@ -33,4 +33,32 @@ RSpec.describe Institution, type: :model do
       end
     end
   end
+
+  describe 'find_institution_subject' do
+    subject { institution.find_institution_subject(label) }
+
+    let(:institution) { create :institution, name: 'The Institution' }
+    let(:theme) { create :theme, label: 'The Theme' }
+    let(:the_subject) { create :subject, label: 'The Subject', theme: theme }
+    let!(:is1) { create :institution_subject, institution: institution, subject: the_subject, description: 'First IS' }
+    let!(:is2) { create :institution_subject, institution: institution, subject: the_subject, description: 'Second IS' }
+
+    context 'label is not found' do
+      let(:label) { 'other' }
+
+      it{ is_expected.to be_nil }
+    end
+
+    context 'label is found and unique' do
+      let(:label) { 'First IS' }
+
+      it{ is_expected.to eq is1 }
+    end
+
+    context 'label is found but not unique' do
+      let(:label) { 'The Subject' }
+
+      it{ is_expected.to be_nil }
+    end
+  end
 end

--- a/spec/services/csv_import_service_spec.rb
+++ b/spec/services/csv_import_service_spec.rb
@@ -96,22 +96,22 @@ describe CsvImport do
   describe 'import advisors' do
     subject(:result) { CsvImport::UserImporter.import(csv, institution) }
 
-    let(:institution) { create :institution, name: 'Institution0' }
-    let(:theme) { create :theme, label: 'Theme0' }
-    let(:the_subject) { create :subject, label: 'Subject0', theme: theme }
+    let(:institution) { create :institution, name: 'The Institution' }
+    let(:theme) { create :theme, label: 'The Theme' }
+    let(:the_subject) { create :subject, label: 'The Subject', theme: theme }
 
     before do
-      create :antenne, name: 'Antenne0', institution: institution
-      create :institution_subject, institution: institution, subject: the_subject, description: 'Description1'
-      create :institution_subject, institution: institution, subject: the_subject, description: 'Description2'
+      create :antenne, name: 'The Antenne', institution: institution
+      create :institution_subject, institution: institution, subject: the_subject, description: 'First IS'
+      create :institution_subject, institution: institution, subject: the_subject, description: 'Second IS'
     end
 
     context 'two users, no team' do
       let(:csv) do
         <<~CSV
           Institution,Antenne,Prénom et nom,E-mail,Téléphone,Fonction
-          Institution0,Antenne0,Marie Dupont,marie.dupont@antenne.com,0123456789,Cheffe
-          Institution0,Antenne0,Mario Dupont,mario.dupont@antenne.com,0123456789,Sous-Chef
+          The Institution,The Antenne,Marie Dupont,marie.dupont@antenne.com,0123456789,Cheffe
+          The Institution,The Antenne,Mario Dupont,mario.dupont@antenne.com,0123456789,Sous-Chef
         CSV
       end
 
@@ -125,8 +125,8 @@ describe CsvImport do
       let(:csv) do
         <<~CSV
           Institution,Antenne,Prénom et nom,E-mail,Téléphone,Fonction,Nom de l’équipe,E-mail de l’équipe,Téléphone de l’équipe,Fonction de l’équipe
-          Institution0,Antenne0,Marie Dupont,marie.dupont@antenne.com,0123456789,Cheffe,Equipe,equipe@antenne.com,0987654321,Equipe des chefs
-          Institution0,Antenne0,Mario Dupont,mario.dupont@antenne.com,0123456789,Sous-Chef,Equipe,equipe@antenne.com,0987654321,Equipe des chefs
+          The Institution,The Antenne,Marie Dupont,marie.dupont@antenne.com,0123456789,Cheffe,Equipe,equipe@antenne.com,0987654321,Equipe des chefs
+          The Institution,The Antenne,Mario Dupont,mario.dupont@antenne.com,0123456789,Sous-Chef,Equipe,equipe@antenne.com,0987654321,Equipe des chefs
         CSV
       end
 
@@ -143,8 +143,8 @@ describe CsvImport do
     context 'set subjects' do
       let(:csv) do
         <<~CSV
-          Institution,Antenne,Prénom et nom,E-mail,Téléphone,Fonction,Theme0:Subject0:Description1,Theme0:Subject0:Description2
-          Institution0,Antenne0,Marie Dupont,marie.dupont@antenne.com,0123456789,Cheffe,spécialiste:description1,
+          Institution,Antenne,Prénom et nom,E-mail,Téléphone,Fonction,The Theme:The Subject:First IS,The Theme:The Subject:Second IS
+          The Institution,The Antenne,Marie Dupont,marie.dupont@antenne.com,0123456789,Cheffe,spécialiste:First IS,
         CSV
       end
 
@@ -155,7 +155,7 @@ describe CsvImport do
         expect(marie.experts.teams.count).to eq 0
         skillet = marie.personal_skillsets.first
         expect(skillet.experts_subjects.count).to eq 1
-        expect(skillet.experts_subjects.first.description).to eq 'description1'
+        expect(skillet.experts_subjects.first.description).to eq 'First IS'
         expect(skillet.experts_subjects.first.subject).to eq the_subject
       end
     end
@@ -167,7 +167,7 @@ describe CsvImport do
       let(:csv) do
         <<~CSV
           Institution,Antenne,Prénom et nom,E-mail,Téléphone,Fonction
-          Institution0,Antenne0,Marie Dupont,test@test.com,0123456789,Cheffe
+          The Institution,The Antenne,Marie Dupont,test@test.com,0123456789,Cheffe
         CSV
       end
 


### PR DESCRIPTION
Suite de #1225, refs #1253

* [x] automatic support for `;` or `,` separators
* Subjects matching
  * [x] Support single-column subject for advisors
  * [x] Less strict matching for subject headers
