### PR TITLE
Add a help comment to find one’s SIRET

### DIFF
--- a/app/views/landings/_new_solicitation_form.html.haml
+++ b/app/views/landings/_new_solicitation_form.html.haml
@@ -8,14 +8,18 @@
     - solicitation.required_fields.each do |field|
       .form__group
         = f.label field
+        - help = t(".attributes.help.#{field}_html", default: [".attributes.help.#{field}".to_sym, ''])
+        - if help.present?
+          %span= help
+
         = f.text_field field,
-          placeholder: t("attributes.placeholder.#{field}"),
+          placeholder: t(".attributes.placeholder.#{field}"),
           type: Solicitation::FIELD_TYPES[field],
           required: true
         .notification.error= solicitation.errors.full_messages_for(field).to_sentence
   .form__group
     = f.label 'description'
-    = f.text_area 'description', placeholder: t("attributes.placeholder.description"), rows: 6, required: true
+    = f.text_area 'description', placeholder: t(".attributes.placeholder.description"), rows: 6, required: true
     .notification.error= solicitation.errors.full_messages_for(:description).to_sentence
   .form__group
     = f.submit t('.button.title'), class: 'button large'

--- a/config/i18n-tasks.yml
+++ b/config/i18n-tasks.yml
@@ -93,6 +93,7 @@ ignore_unused:
   - 'active_admin.flag.*'
   - 'active_admin.move'
   - 'attributes.*'
+  - 'landings.new_solicitation_form.attributes.*'
   - 'mailers.admin_mailer.weekly_statistics.needs_abandoned.scopes.*'
   - 'mailers.user_mailer.notify_match_status.expert_and_status.*'
   - 'stats.stats_table.*'

--- a/config/locales/models.fr.yml
+++ b/config/locales/models.fr.yml
@@ -466,14 +466,10 @@ fr:
       other: Besoins identifiés
     phone_number: Téléphone
     placeholder:
-      description: Décrivez votre demande.
       email: marie.dupont@exemple.fr
       full_name: 'ex: Marie Dupont'
-      location: Hauts-de-France; région de Milly-la-forêt; 91260…
       phone_number: 06 12 34 56 78
-      requested_help_amount: 8 000 €
       role: Conseiller entreprise, Chargé de mission…
-      siret: 123 456 789 00010
       team_name: Équipe formation, Cellule-conseil aux entreprises…
     received_matches:
       one: Mise en relation reçue

--- a/config/locales/views.fr.yml
+++ b/config/locales/views.fr.yml
@@ -272,6 +272,19 @@ fr:
       give_my_opinion_alt: Je donne mon avis
       give_my_opinion_title: Je donne mon avis sur cette démarche
     new_solicitation_form:
+      attributes:
+        help:
+          siret_html: Vous ne le connaissez pas par cœur ? Retrouvez-le sur <a href='https://entreprise.data.gouv.fr'>entreprise.data.gouv.fr</a>.
+        placeholder:
+          description: Décrivez votre demande.
+          email: marie.dupont@exemple.fr
+          full_name: 'ex: Marie Dupont'
+          location: Hauts-de-France; région de Milly-la-forêt; 91260…
+          phone_number: 06 12 34 56 78
+          requested_help_amount: 8 000 €
+          role: Conseiller entreprise, Chargé de mission…
+          siret: 123 456 789 00010
+          team_name: Équipe formation, Cellule-conseil aux entreprises…
       button:
         title: Envoyer ma demande
       form: Formulaire


### PR DESCRIPTION
fixes #1280

Also move the landing attributes i18n to views.fr.yml, separate from the attributes placeholders used for the user/login forms.

<img width="633" alt="image" src="https://user-images.githubusercontent.com/139391/94837307-61b45f80-0414-11eb-9e9c-dc1a34da8bb3.png">
