### PR TITLE
Allow admins to change user emails

### DIFF
--- a/app/controllers/users/registrations_controller.rb
+++ b/app/controllers/users/registrations_controller.rb
@@ -35,7 +35,7 @@ module Users
       if params.include? 'password'
         resource.update_with_password(params)
       else
-        # See also configure_permitted_parameters and User#update_without_password:
+        # See also configure_permitted_parameters
         # Users can’t modify their own email.
         resource.update_without_password(params)
       end
@@ -45,8 +45,9 @@ module Users
 
     def configure_permitted_parameters
       editable_attributes = %i[full_name institution role phone_number antenne_id]
-      devise_parameter_sanitizer.permit(:sign_up, keys: editable_attributes)
-      devise_parameter_sanitizer.permit(:account_update, keys: editable_attributes)
+      not_editable_attributes = %i[email]
+      devise_parameter_sanitizer.permit(:sign_up, keys: editable_attributes, except: not_editable_attributes)
+      devise_parameter_sanitizer.permit(:account_update, keys: editable_attributes, except: not_editable_attributes)
     end
   end
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -184,12 +184,6 @@ class User < ApplicationRecord
     end
   end
 
-  # Override from Devise::Models::DatabaseAuthenticatable
-  def update_without_password(params, *options)
-    params.delete(:email)
-    super(params)
-  end
-
   # Override from Devise::Models::Recoverable:
   # * If the user has been invited, but hasn’t clicked the invitation link yet, resend them the invitation.
   # * Otherwise just send a password reset email.


### PR DESCRIPTION
But not users themselves: :email isn’t a permitted parameter in registrations_controller.

This behaviour was introduced in f6120b404f2eea22146643a3ce73d9e0e5c42f31 in #837.

refs #1285, later.