### PR TITLE
Properly raise a 404 with custom ActiveAdmin finders

### DIFF
--- a/app/admin/institution.rb
+++ b/app/admin/institution.rb
@@ -13,7 +13,7 @@ ActiveAdmin.register Institution do
   config.sort_order = 'slug_asc'
 
   controller do
-    defaults :finder => :find_by_slug
+    defaults :finder => :find_by_slug!
   end
 
   index do

--- a/app/admin/landing.rb
+++ b/app/admin/landing.rb
@@ -4,7 +4,7 @@ ActiveAdmin.register Landing do
   includes :landing_topics, :landing_options
 
   controller do
-    defaults :finder => :find_by_slug
+    defaults :finder => :find_by_slug!
   end
 
   ## Index


### PR DESCRIPTION
`find_by_slug!` raises an ActiveRecord::RecordNotFound, while `find_by_slug` returns nil if not found, which, in ActiveAdmin triggers another exception later. (namely, "NoMethodError: undefined method `slug' for nil:NilClass").

RecordNotFound is properly returned as a 404 error, while NoMethodError is returned as a 500 :(

fixes PLACE-DES-ENTREPRISES-A8 and PLACE-DES-ENTREPRISES-A7