### PR TITLE
Merge the subjects of individual users in a team

### DIFF
--- a/app/services/csv_import/user_importer.rb
+++ b/app/services/csv_import/user_importer.rb
@@ -91,7 +91,6 @@ module CsvImport
         end
       end.compact
 
-      expert.experts_subjects.clear
       expert.experts_subjects.new(experts_subjects_attributes)
       expert.save
     end
@@ -106,7 +105,6 @@ module CsvImport
 
       institution_subject = InstitutionSubject.find_with_name(expert.institution, name)
 
-      expert.experts_subjects.clear
       expert.experts_subjects.new(institution_subject: institution_subject)
       expert.save
     end


### PR DESCRIPTION
When importing users of a same team, the subjects are set on the team. Typically, partners will provide csv with each member of the team having only their subject selected. The team must have all the subjects of its members.

This also means that when importing users, we only add subjects, never remove them.

fixes #1310

~~WIP:~~
* [x] merge #1302 first