### PR TITLE
petits ajustements pour les iframes

### DIFF
--- a/app/views/landings/_index_landing_cards.html.haml
+++ b/app/views/landings/_index_landing_cards.html.haml
@@ -1,8 +1,9 @@
-- @landing_emphasis.each do |landing|
-  .emphasis
-    = simple_format("#{landing.home_title} : ", {}, wrapper_tag: 'h2')
-    = simple_format(landing.home_description, {}, wrapper_tag: 'span')
-    #button-discover= link_to t('.discover_measures'), landing, class: 'button-outline small primary'
+- unless in_iframe?
+  - @landing_emphasis.each do |landing|
+    .emphasis
+      = simple_format("#{landing.home_title} : ", {}, wrapper_tag: 'h2')
+      = simple_format(landing.home_description, {}, wrapper_tag: 'span')
+      #button-discover= link_to t('.discover_measures'), landing, class: 'button-outline small primary'
 
 - landings.each_slice(3) do |landings_slice|
   .row

--- a/config/locales/views.fr.yml
+++ b/config/locales/views.fr.yml
@@ -278,7 +278,7 @@ fr:
           role: Conseiller entreprise, Chargé de mission…
           siret: 123 456 789 00010
           team_name: Équipe formation, Cellule-conseil aux entreprises…
-      better_taking_care: 'Pour une meilleur prise en charge de votre demande, indiquez :'
+      better_taking_care: 'Pour une meilleure prise en charge de votre demande, indiquez en quelques phrase :'
       button:
         title: Envoyer ma demande
       description: Description de votre demande


### PR DESCRIPTION
- N'affiche pas la landing mise en avant sur la home si c'est une iframe. Par contre il faudra peut-être réfléchir à une solution pour l'afficher sur certaines iframes
- Affiche un texte différent en dessous des landings topics si c'est une iframe qui redirige vers le formulaires "/e/aide-entreprises/contactez-nous/demande/autre_demande"
- Met à jour le texte d'aide au remplissage de la description d'une sollicitation