### PR TITLE
Correction sur l’import/export CSV

### DIFF
--- a/app/controllers/institutions_controller.rb
+++ b/app/controllers/institutions_controller.rb
@@ -34,7 +34,7 @@ class InstitutionsController < ApplicationController
     respond_to do |format|
       format.html
       format.csv do
-        result = @advisors.export_csv(institutions_subjects: @institutions_subjects)
+        result = @advisors.export_csv(include_expert_team: true, institutions_subjects: @institutions_subjects)
         send_data result.csv, type: 'text/csv; charset=utf-8', disposition: "attachment; filename=#{result.filename}.csv"
       end
     end

--- a/app/helpers/nested_errors_helper.rb
+++ b/app/helpers/nested_errors_helper.rb
@@ -18,6 +18,8 @@ module NestedErrorsHelper
     errors = object.errors
     return if errors.empty?
 
+    return if level > 3 # safety net: relationships may indefinitely nest errors
+
     main_message = errors.full_messages.to_sentence || object.to_s
     main_message = '• ' * level + main_message + "\n"
 

--- a/app/services/csv_import.rb
+++ b/app/services/csv_import.rb
@@ -21,7 +21,7 @@ module CsvImport
     end
 
     def success?
-      @success ||= @header_errors.blank? && @objects.all?{ |object| object.valid?(:import) }
+      @success ||= @header_errors.blank? && @objects.none?{ |object| object.errors.present? }
     end
   end
 

--- a/app/services/csv_import/user_importer.rb
+++ b/app/services/csv_import/user_importer.rb
@@ -82,7 +82,12 @@ module CsvImport
       attributes = all_attributes.slice(*several_subjects_mapping.keys)
         .transform_keys{ |k| several_subjects_mapping[k] }
 
-      experts_subjects_attributes = attributes.map do |institution_subject, serialized_description|
+      # Avoid duplicate ExpertsSubjects
+      filtered_attributes = attributes.reject do |institution_subject, _|
+        expert.institutions_subjects.include? institution_subject
+      end
+
+      experts_subjects_attributes = filtered_attributes.map do |institution_subject, serialized_description|
         if serialized_description.present?
           {
             institution_subject: institution_subject,
@@ -104,6 +109,9 @@ module CsvImport
       return if name.blank?
 
       institution_subject = InstitutionSubject.find_with_name(expert.institution, name)
+
+      # Avoid duplicate ExpertsSubjects
+      return if expert.institutions_subjects.include? institution_subject
 
       expert.experts_subjects.new(institution_subject: institution_subject)
       expert.save

--- a/app/views/institutions/_import_errors.html.haml
+++ b/app/views/institutions/_import_errors.html.haml
@@ -20,7 +20,7 @@
       - result.rows.each_with_index do |row, index|
         - object = result.objects[index]
         %tr
-          - has_errors = object.invalid?(:import)
+          - has_errors = object.errors.present?
           %td{ rowspan: has_errors ? 2 : 1 }
             #{index + 1}
           - row.each_value do |value|

--- a/spec/services/csv_import/user_importer_spec.rb
+++ b/spec/services/csv_import/user_importer_spec.rb
@@ -87,19 +87,21 @@ describe CsvImport::UserImporter, CsvImport do
       end
     end
 
-    context 'merge the subjects of two users in the same team' do
+    context 'merge the subjects of users in the same team' do
       let(:csv) do
         <<~CSV
           Institution,Antenne,Prénom et nom,E-mail,Téléphone,Fonction,Nom de l’équipe,E-mail de l’équipe,Téléphone de l’équipe,Fonction de l’équipe,First IS,Second IS
           The Institution,The Antenne,Marie,marie@a.a,0123456789,Superchef,Equipe,equipe@a.a,0123456789,Equipe,oui,
           The Institution,The Antenne,Marco,marco@a.a,0123456789,Directeur,Equipe,equipe@a.a,0123456789,Equipe,,oui
+          The Institution,The Antenne,Maria,maria@a.a,0123456789,Directora,Equipe,equipe@a.a,0123456789,Equipe,,
+          The Institution,The Antenne,Maria,marin@a.a,0123456789,Directoro,Equipe,equipe@a.a,0123456789,Equipe,oui,oui
         CSV
       end
 
       it do
         expect(result).to be_success
         team = Expert.teams.first
-        expect(team.users.count).to eq 2
+        expect(team.users.count).to eq 4
         expect(team.experts_subjects.count).to eq 2
         expect(team.institutions_subjects.pluck(:description)).to eq ['First IS', 'Second IS']
       end
@@ -143,6 +145,26 @@ describe CsvImport::UserImporter, CsvImport do
         invalid_experts = first_error[:value]
         expect(invalid_experts).not_to be_nil
         expect(invalid_experts.flat_map{ |e| e.errors.details }).to eq [{ :"experts_subjects.institution_subject" => [{ error: :blank }] }]
+      end
+    end
+
+    context 'merge the subjects of users in the same team' do
+      let(:csv) do
+        <<~CSV
+          Institution,Antenne,Prénom et nom,E-mail,Téléphone,Fonction,Nom de l’équipe,E-mail de l’équipe,Téléphone de l’équipe,Fonction de l’équipe,Sujet
+          The Institution,The Antenne,Marie,marie@a.a,0123456789,Superchef,Equipe,equipe@a.a,0123456789,Equipe,First IS
+          The Institution,The Antenne,Marco,marco@a.a,0123456789,Directeur,Equipe,equipe@a.a,0123456789,Equipe,Second IS
+          The Institution,The Antenne,Maria,maria@a.a,0123456789,Directora,Equipe,equipe@a.a,0123456789,Equipe,
+          The Institution,The Antenne,Maria,marin@a.a,0123456789,Directoro,Equipe,equipe@a.a,0123456789,Equipe,First IS
+        CSV
+      end
+
+      it do
+        expect(result).to be_success
+        team = Expert.teams.first
+        expect(team.users.count).to eq 4
+        expect(team.experts_subjects.count).to eq 2
+        expect(team.institutions_subjects.pluck(:description)).to eq ['First IS', 'Second IS']
       end
     end
   end


### PR DESCRIPTION
* réajout des colonnes de l’équipe à l’export (fixes #1327)
* correction de l’union des sujets des différents membres d’une équipe (#1327 aussi, et dû à #1311)
* corrections sur l'affichage d'erreurs à l’import
  * parfois, l’import échouait et on n’avait pas d’erreur affichées. c’était du au fait qu’on _re_ validait les objets pour afficher les erreurs, mais parfois, la re-validation ne donne pas les mêmes erreurs que la validation pendant l’import.
  * ajout d’un filet de sécurité à l’affichage des erreurs récursives 