### PR TITLE
Ne pas envoyer d'email aux comptes supprimes #1334

### DIFF
--- a/app/mailers/expert_mailer.rb
+++ b/app/mailers/expert_mailer.rb
@@ -17,7 +17,7 @@ class ExpertMailer < ApplicationMailer
     # Also send a reset link to the expert’s users that have never used their account.
     # In practice, this only happens to Experts that used to have no corresponding User and
     # for which we created User accounts automatically.
-    expert.users.filter(&:never_used_account?).each do |user|
+    expert.users.not_deleted.filter(&:never_used_account?).each do |user|
       user.send_reset_password_instructions
     end
   end

--- a/app/services/expert_reminder_service.rb
+++ b/app/services/expert_reminder_service.rb
@@ -3,7 +3,7 @@
 class ExpertReminderService
   class << self
     def send_reminders
-      Expert.with_active_matches.each do |expert|
+      Expert.not_deleted.with_active_matches.each do |expert|
         ExpertMailer.remind_involvement(expert).deliver_later
       end
     end

--- a/spec/mailers/expert_mailer_spec.rb
+++ b/spec/mailers/expert_mailer_spec.rb
@@ -62,7 +62,7 @@ describe ExpertMailer do
           count = 0
           allow_any_instance_of(User).to receive(:send_reset_password_instructions) do |user|
             expect(expert_members).to include user
-            count +=1
+            count += 1
           end
 
           mail
@@ -72,14 +72,14 @@ describe ExpertMailer do
 
       context 'expert with deleted user ' do
         let(:user1) { create :user, invitation_sent_at: nil, encrypted_password: '' }
-        let(:user2) { create :user, invitation_sent_at: nil, encrypted_password: '',  deleted_at: Time.zone.now}
+        let(:user2) { create :user, invitation_sent_at: nil, encrypted_password: '', deleted_at: Time.zone.now }
         let(:expert_members) { [user1, user2] }
 
         it do
           count = 0
           allow_any_instance_of(User).to receive(:send_reset_password_instructions) do |user|
             expect(user2).not_to eq(user)
-            count +=1
+            count += 1
           end
 
           mail

--- a/spec/mailers/expert_mailer_spec.rb
+++ b/spec/mailers/expert_mailer_spec.rb
@@ -54,15 +54,36 @@ describe ExpertMailer do
       end
 
       context 'expert with several users' do
-        let(:user1) { build :user, invitation_sent_at: nil, encrypted_password: '' }
-        let(:user2) { build :user, invitation_sent_at: nil, encrypted_password: '' }
+        let(:user1) { create :user, invitation_sent_at: nil, encrypted_password: '' }
+        let(:user2) { create :user, invitation_sent_at: nil, encrypted_password: '' }
         let(:expert_members) { [user1, user2] }
 
         it do
-          expect(user1).to receive(:send_reset_password_instructions).once
-          expect(user2).to receive(:send_reset_password_instructions).once
+          count = 0
+          allow_any_instance_of(User).to receive(:send_reset_password_instructions) do |user|
+            expect(expert_members).to include user
+            count +=1
+          end
 
           mail
+          expect(count).to eq(2)
+        end
+      end
+
+      context 'expert with deleted user ' do
+        let(:user1) { create :user, invitation_sent_at: nil, encrypted_password: '' }
+        let(:user2) { create :user, invitation_sent_at: nil, encrypted_password: '',  deleted_at: Time.zone.now}
+        let(:expert_members) { [user1, user2] }
+
+        it do
+          count = 0
+          allow_any_instance_of(User).to receive(:send_reset_password_instructions) do |user|
+            expect(user2).not_to eq(user)
+            count +=1
+          end
+
+          mail
+          expect(count).to eq(1)
         end
       end
     end

--- a/spec/mailers/expert_mailer_spec.rb
+++ b/spec/mailers/expert_mailer_spec.rb
@@ -54,8 +54,8 @@ describe ExpertMailer do
       end
 
       context 'expert with several users' do
-        let(:user1) { create :user, invitation_sent_at: nil, encrypted_password: '' }
-        let(:user2) { create :user, invitation_sent_at: nil, encrypted_password: '' }
+        let(:user1) { build :user, invitation_sent_at: nil, encrypted_password: '' }
+        let(:user2) { build :user, invitation_sent_at: nil, encrypted_password: '' }
         let(:expert_members) { [user1, user2] }
 
         it do
@@ -71,8 +71,8 @@ describe ExpertMailer do
       end
 
       context 'expert with deleted user ' do
-        let(:user1) { create :user, invitation_sent_at: nil, encrypted_password: '' }
-        let(:user2) { create :user, invitation_sent_at: nil, encrypted_password: '', deleted_at: Time.zone.now }
+        let(:user1) { build :user, invitation_sent_at: nil, encrypted_password: '' }
+        let(:user2) { build :user, invitation_sent_at: nil, encrypted_password: '', deleted_at: Time.zone.now }
         let(:expert_members) { [user1, user2] }
 
         it do


### PR DESCRIPTION
Cf 2e point de #1334 : met à jour les scopes pour les envois d'email pour ne rien envoyer aux utilisateurs soft-deleté