### PR TITLE
Remove some dynamic magic for User and Expert options in activeadmin

### DIFF
--- a/app/admin/user.rb
+++ b/app/admin/user.rb
@@ -56,17 +56,6 @@ ActiveAdmin.register User do
       item t('active_admin.user.impersonate', name: u.full_name), impersonate_engine.impersonate_user_path(u)
       item t('active_admin.person.normalize_values'), normalize_values_admin_user_path(u)
       item t('active_admin.user.do_invite'), invite_user_admin_user_path(u)
-
-      # Dynamically create a menu item to activate and deactivate each User::FLAGS
-      User::FLAGS.each do |flag|
-        [true, false].each do |value|
-          localized_flag = User.human_attribute_name(flag)
-          title = I18n.t(value, flag: localized_flag, scope: 'active_admin.flag.change')
-          if u.send(flag).to_b != value # Only add a menu item to change to the other value.
-            item title, polymorphic_path(["#{flag}_#{value}", :admin, u])
-          end
-        end
-      end
     end
   end
 
@@ -222,25 +211,17 @@ ActiveAdmin.register User do
     redirect_back fallback_location: collection_path, notice: I18n.t('active_admin.user.do_invite_done')
   end
 
-  # Dynamically create a member_action and a batch_action to activate and deactivate each User::FLAGS
-  User::FLAGS.each do |flag|
-    [true, false].each do |value|
-      localized_flag = User.human_attribute_name(flag)
-      title = I18n.t(value, flag: localized_flag, scope: 'active_admin.flag.change')
-      message = I18n.t(value, flag: localized_flag, scope: 'active_admin.flag.done')
+  form_options = {
+    action: [[I18n.t('active_admin.flag.action.add'), :add], [I18n.t('active_admin.flag.action.remove'), :remove]],
+      flag: User::FLAGS.map { |f| [User.human_attribute_name(f), f] }
+  }
+  batch_action I18n.t('active_admin.flag.add_remove'), form: form_options do |ids, inputs|
+    flag = inputs[:flag]
+    value = inputs[:action] == 'add'
+    User.where(id: ids).each { |u| u.update(flag => value) }
 
-      # member_action
-      member_action "#{flag}_#{value}" do
-        resource.update({ flag => value })
-        redirect_back fallback_location: collection_path, notice: message
-      end
-
-      # batch_action
-      batch_action title do |ids|
-        batch_action_collection.where(id: ids).update({ flag => value })
-        redirect_back fallback_location: collection_path, notice: message
-      end
-    end
+    message = I18n.t("active_admin.flag.done.#{inputs[:action]}", flag: User.human_attribute_name(flag))
+    redirect_to collection_path, notice: message
   end
 
   controller do

--- a/config/locales/models.fr.yml
+++ b/config/locales/models.fr.yml
@@ -4,12 +4,13 @@ fr:
     expert:
       modify_subjects: Modifier les domaines d’intervention
     flag:
-      change:
-        'false': Désactiver « %{flag} »
-        'true': Activer « %{flag} »
+      action:
+        add: Activer une option
+        remove: Supprimer une option
+      add_remove: Activer / désactiver des options sur
       done:
-        'false': "« %{flag} » désactivé"
-        'true': "« %{flag} » activé"
+        add: Option « %{flag} » activée
+        remove: Option « %{flag} » désactivée
     landings:
       home_sort_order_placeholder: Laisser vide pour ne pas afficher sur l’accueil.
     matches:


### PR DESCRIPTION
Change the way the flags are set and cleared in admin for Users and Experts.

Instead of dynamically building batch and item actions, just build one batch action with form_options. It’s not used very often, and it’s less fragile.

(Done in passing for #1348; this isn’t really related but I was there.)

Avant:
<img width="636" alt="Capture d’écran 2020-10-27 à 15 54 11" src="https://user-images.githubusercontent.com/139391/97319358-16536c80-186d-11eb-943c-b1303cea250a.png">

Après:
<img width="375" alt="Capture d’écran 2020-10-27 à 15 56 29" src="https://user-images.githubusercontent.com/139391/97319367-194e5d00-186d-11eb-8249-c5fc1c09297a.png">
