### PR TITLE
corrige le scope des besoins abandonnés 

### DIFF
--- a/app/models/need.rb
+++ b/app/models/need.rb
@@ -160,7 +160,8 @@ class Need < ApplicationRecord
 
   scope :reminder_abandoned, -> { left_outer_joins(:matches).where('matches.created_at < ?', REMINDER_ABANDONED_DELAY.ago) }
 
-  scope :abandoned, -> { where("needs.last_activity_at < ?", ABANDONED_DELAY.ago) }
+  # For Reminders, find Needs without taking care since ABANDONED_DELAY
+  scope :abandoned, -> { joins(:matches).where("matches.created_at < ?", ABANDONED_DELAY.ago) }
 
   scope :with_some_matches_in_status, -> (status) do # can be an array
     joins(:matches).where(matches: Match.unscoped.where(status: status)).distinct

--- a/config/locales/models.fr.yml
+++ b/config/locales/models.fr.yml
@@ -214,6 +214,8 @@ fr:
       need/statuses/short:
         diagnosis_not_complete: Analyse en cours
         done: Clôturé
+        done_no_help: Pas d’aide disponible
+        done_not_reachable: Non joignable
         not_for_me: Refusé
         quo: Pas de réponse
         sent_to_no_one: Envoyé à personne

--- a/spec/models/need_spec.rb
+++ b/spec/models/need_spec.rb
@@ -306,9 +306,9 @@ RSpec.describe Need, type: :model do
   end
 
   describe 'abandoned' do
-    let(:need) { create :need }
+    let(:need) { create :need_with_matches }
     let(:date1) { Time.zone.now - 2.months }
-    let(:old_need) { travel_to(date1) { create :need, last_activity_at: date1 } }
+    let(:old_need) { travel_to(date1) { create :need_with_matches } }
 
     it do
       expect(need).not_to be_abandoned


### PR DESCRIPTION
Corrige un bug sur le scope `abandoned` des besoins ça prenait les besoins sans activité depuis 15 jours, mais si on laisse un commentaire ça modifie cette date depuis que l'ona  ajouté le `touch: true`. Ce qu'on veut c'est les besoins sans prise en charge dans les 15 jours.

closes #1360 