### PR TITLE
Accélère la création d'analyses

### DIFF
--- a/app/admin/match.rb
+++ b/app/admin/match.rb
@@ -7,12 +7,13 @@ ActiveAdmin.register Match do
 
   ## Index
   #
-  includes :need, :diagnosis, :facility, :company, :related_matches,
+  includes :need, :facility, :company, :related_matches,
            :advisor, :advisor_antenne, :advisor_institution,
            :expert, :expert_antenne, :expert_institution,
            :subject, :theme,
            facility: :commune,
-           need: :subject
+           need: :subject,
+           diagnosis: :solicitation
 
   scope :all, default: true
   scope :with_deleted_expert

--- a/app/assets/javascripts/application/semantic-ui.js
+++ b/app/assets/javascripts/application/semantic-ui.js
@@ -4,5 +4,5 @@ addEventListener('turbolinks:load', function(event) {
   $('select.ui.selection.search.dropdown').dropdown({ fullTextSearch: 'exact', ignoreDiacritics: true });
   $('.ui.dropdown').not('.simple').dropdown();
   $('.tabular.menu .item').tab();
-  $('.ui.accordion').accordion();
+  $('.ui.accordion').accordion({exclusive: false});
 });

--- a/app/assets/stylesheets/application/diagnoses.sass
+++ b/app/assets/stylesheets/application/diagnoses.sass
@@ -68,3 +68,13 @@
 
 .ui.feed > .event.feedbacks-form
   margin-bottom: 1rem
+
+.ui.content.subjects.basic.segments
+  border-top: none
+
+.subject.actions
+  height: 2rem
+
+.ui.accordion.theme
+  i.dropdown.icon
+    float: right

--- a/app/assets/stylesheets/application/needs.sass
+++ b/app/assets/stylesheets/application/needs.sass
@@ -4,6 +4,12 @@
     color: rgba(0, 0, 0, 0.87)
   .solicitation-description
     margin: 2rem
+    .content
+      display: contents
+    .left
+      margin-right: 1rem
+    .right
+      margin-left: 1rem
 
   .expert-highlighted
     padding: 0 0.2em

--- a/app/assets/stylesheets/application/needs.sass
+++ b/app/assets/stylesheets/application/needs.sass
@@ -2,6 +2,8 @@
   margin-top: 6em
   .ui.header a
     color: rgba(0, 0, 0, 0.87)
+  .solicitation-description
+    margin: 2rem
 
   .expert-highlighted
     padding: 0 0.2em

--- a/app/controllers/diagnoses/steps_controller.rb
+++ b/app/controllers/diagnoses/steps_controller.rb
@@ -13,7 +13,12 @@ class Diagnoses::StepsController < ApplicationController
     diagnosis_params = params_for_needs
     diagnosis_params[:step] = :visit
     if @diagnosis.update(diagnosis_params)
-      redirect_to action: :visit
+      if @diagnosis.solicitation.present? && @diagnosis.visitee.present?
+        @diagnosis.update(step: :matches)
+        redirect_to action: :matches
+      else
+        redirect_to action: :visit
+      end
     else
       flash.alert = @diagnosis.errors.full_messages.to_sentence
       redirect_to action: :needs

--- a/app/models/concerns/diagnosis_creation.rb
+++ b/app/models/concerns/diagnosis_creation.rb
@@ -33,6 +33,7 @@ module DiagnosisCreation
       end
 
       params[:step] = :needs
+      params[:content] = get_solicitation_description(params)
       Diagnosis.create(params)
     end
   end
@@ -165,5 +166,13 @@ module DiagnosisCreation
 
       self
     end
+  end
+end
+
+def get_solicitation_description(params)
+  if params[:solicitation].present?
+    params[:solicitation].description
+  elsif params[:solicitation_id].present?
+    Solicitation.find(params[:solicitation_id])&.description
   end
 end

--- a/app/models/concerns/diagnosis_creation.rb
+++ b/app/models/concerns/diagnosis_creation.rb
@@ -41,7 +41,6 @@ module DiagnosisCreation
     # Some preconditions can be verified without actually trying to create the Diagnosis
     def may_prepare_diagnosis?
       self.preselected_subjects.present? &&
-        self.preselected_institutions.present? &&
         Facility.siret_is_valid(Facility.clean_siret(self.siret)) # TODO: unify the SIRET validation methods
     end
 
@@ -64,13 +63,13 @@ module DiagnosisCreation
         )
 
         # Steps 1, 2, 3: fill in with the solicitation data and the landing_option preselections
-        methods = [
-          :prepare_needs_from_solicitation,
-          :prepare_happened_on_from_solicitation,
-          :prepare_visitee_from_solicitation,
-          :prepare_matches_from_solicitation
-        ]
-        methods.each { |method| diagnosis.public_send(method) if diagnosis.errors.empty? }
+        diagnosis.prepare_needs_from_solicitation if diagnosis.errors.empty?
+        diagnosis.prepare_happened_on_from_solicitation if diagnosis.errors.empty?
+        diagnosis.prepare_visitee_from_solicitation if diagnosis.errors.empty?
+
+        if self.preselected_institutions.present?
+          diagnosis.prepare_matches_from_solicitation if diagnosis.errors.empty?
+        end
 
         # Rollback on error!
         if diagnosis.errors.present?

--- a/app/models/diagnosis.rb
+++ b/app/models/diagnosis.rb
@@ -70,6 +70,7 @@ class Diagnosis < ApplicationRecord
 
   # :needs
   has_many :subjects, through: :needs, inverse_of: :diagnoses
+  has_many :themes, through: :subjects, inverse_of: :diagnoses
   has_many :matches, through: :needs, inverse_of: :diagnosis
 
   # :matches

--- a/app/models/need.rb
+++ b/app/models/need.rb
@@ -55,6 +55,7 @@ class Need < ApplicationRecord
   # :diagnosis
   has_one :facility, through: :diagnosis, inverse_of: :needs
   has_one :company, through: :diagnosis, inverse_of: :needs
+  has_one :solicitation, through: :diagnosis, inverse_of: :needs
   has_one :advisor, through: :diagnosis, inverse_of: :sent_needs
 
   # :matches

--- a/app/models/solicitation.rb
+++ b/app/models/solicitation.rb
@@ -41,6 +41,7 @@ class Solicitation < ApplicationRecord
   has_many :diagnoses, inverse_of: :solicitation
   has_many :feedbacks, as: :feedbackable, dependent: :destroy
   has_many :matches, through: :diagnoses, inverse_of: :solicitation
+  has_many :needs, through: :diagnoses, inverse_of: :solicitation
   has_and_belongs_to_many :badges, -> { distinct }, after_add: :touch_after_badges_update, after_remove: :touch_after_badges_update
   belongs_to :institution, inverse_of: :solicitations, optional: true
 

--- a/app/models/theme.rb
+++ b/app/models/theme.rb
@@ -28,6 +28,7 @@ class Theme < ApplicationRecord
   #
   # :subjects
   has_many :needs, through: :subjects, inverse_of: :theme
+  has_many :diagnoses, through: :needs, inverse_of: :theme
   has_many :matches, through: :subjects, inverse_of: :theme
   has_many :institutions_subjects, through: :subjects, inverse_of: :theme
 

--- a/app/services/csv_export/match_exporter.rb
+++ b/app/services/csv_export/match_exporter.rb
@@ -14,7 +14,13 @@ module CsvExport
         advisor_institution: :advisor_institution,
         theme: :theme,
         subject: :subject,
-        content: -> { diagnosis.solicitation&.description || need.content },
+        content: -> do
+          if diagnosis.content.present? && need.content.present?
+            "#{diagnosis.content} / #{need.content}"
+          else
+            diagnosis.content.presence || need.content.presence
+          end
+        end,
         expert: :expert,
         expert_antenne: :expert_antenne,
         expert_institution: :expert_institution,

--- a/app/services/csv_export/match_exporter.rb
+++ b/app/services/csv_export/match_exporter.rb
@@ -14,7 +14,7 @@ module CsvExport
         advisor_institution: :advisor_institution,
         theme: :theme,
         subject: :subject,
-        content: -> { need.content },
+        content: -> { diagnosis.solicitation&.description || need.content },
         expert: :expert,
         expert_antenne: :expert_antenne,
         expert_institution: :expert_institution,

--- a/app/views/diagnoses/steps/_next_step.haml
+++ b/app/views/diagnoses/steps/_next_step.haml
@@ -1,0 +1,3 @@
+= diagnosis_form.button :submit, class: 'ui right floated button green right labeled icon' do
+  = t('next_step')
+  %i.arrow.right.icon

--- a/app/views/diagnoses/steps/needs.html.haml
+++ b/app/views/diagnoses/steps/needs.html.haml
@@ -2,6 +2,9 @@
 
 = render 'header', diagnosis: @diagnosis, current_page_step: 2
 
+- if @diagnosis.solicitation.present? && @diagnosis.facility.diagnoses.many?
+  = render 'diagnoses/related_diagnoses', diagnoses: @diagnosis.facility.diagnoses
+
 #needs-app
   = form_with model: @diagnosis,
     url: update_needs_diagnosis_path,

--- a/app/views/diagnoses/steps/needs.html.haml
+++ b/app/views/diagnoses/steps/needs.html.haml
@@ -21,22 +21,26 @@
     - @themes.each do |theme|
       - subjects = theme.subjects.for_interview
       - if subjects.present?
-        .ui.segments.shadow-less
-          .ui.segment.secondary
-            %h3.ui.header= theme
-          - all_needs = @diagnosis.needs
-          - subjects.each do |subject|
-            - need = all_needs.where(subject: subject).first_or_initialize
-            .ui.segment.checkbox.subject
-              = diagnosis_form.fields_for :needs, need do |need_form|
-                = need_form.check_box :_destroy, { checked: need.persisted? }, '0', '1'
-                = need_form.label :_destroy, subject
-                = need_form.text_area :content, placeholder: t('.need_content_placeholder'), rows: 2
-                = need_form.hidden_field :subject_id
+        - active_class = 'active' if @diagnosis.themes.include?(theme)
+        .ui.segments.shadow-less.accordion.theme
+          .ui.segment.secondary.title{ class: active_class }
+            %h3.ui.header
+              = theme
+              %i.dropdown.icon
+          .ui.content.subjects.basic.segments{ class: active_class }
+            - all_needs = @diagnosis.needs
+            - subjects.each do |subject|
+              - need = all_needs.where(subject: subject).first_or_initialize
+              .ui.checkbox.subject.segment
+                = diagnosis_form.fields_for :needs, need do |need_form|
+                  = need_form.check_box :_destroy, { checked: need.persisted? }, '0', '1'
+                  = need_form.label :_destroy, subject
+                  = need_form.text_area :content, placeholder: t('.need_content_placeholder'), rows: 2
+                  = need_form.hidden_field :subject_id
+            .ui.subject.actions
+              = render 'next_step', diagnosis_form: diagnosis_form
 
     .ui.actions
-      = diagnosis_form.button :submit, class: 'ui right floated button green right labeled icon' do
-        = t('next_step')
-        %i.arrow.right.icon
+      = render 'next_step', diagnosis_form: diagnosis_form
 
   .clear

--- a/app/views/diagnoses/steps/visit.html.haml
+++ b/app/views/diagnoses/steps/visit.html.haml
@@ -51,9 +51,7 @@
     %a.ui.left.floated.button.labeled.icon{ href: needs_diagnosis_path }
       = t('previous_step')
       %i.arrow.left.icon
-    = diagnosis_form.button :submit, class: 'ui right floated button green right labeled icon' do
-      = t('next_step')
-      %i.arrow.right.icon
+    = render 'next_step', diagnosis_form: diagnosis_form
 
   .clear
 

--- a/app/views/mailers/expert_mailer/notify_company_needs.html.haml
+++ b/app/views/mailers/expert_mailer/notify_company_needs.html.haml
@@ -10,9 +10,12 @@
 
 - needs.ordered_for_interview.each do |need|
   %h2.subject= need.subject
-  - if need.solicitation&.description.present? || need.content.present?
+  - if @diagnosis.content.present?
     %blockquote
-      %p= simple_format(auto_link(need.solicitation&.description || need.content))
+      %p= simple_format(auto_link(@diagnosis.content))
+  - if need.content.present?
+    %blockquote
+      %p= simple_format(auto_link(need.content))
 
 %p
   - if @solicitation.present? && @solicitation.landing&.partner_url.present?

--- a/app/views/mailers/expert_mailer/notify_company_needs.html.haml
+++ b/app/views/mailers/expert_mailer/notify_company_needs.html.haml
@@ -10,9 +10,9 @@
 
 - needs.ordered_for_interview.each do |need|
   %h2.subject= need.subject
-  - if need.content.present?
+  - if need.solicitation&.description.present? || need.content.present?
     %blockquote
-      %p= simple_format(auto_link(need.content))
+      %p= simple_format(auto_link(need.solicitation&.description || need.content))
 
 %p
   - if @solicitation.present? && @solicitation.landing&.partner_url.present?

--- a/app/views/needs/_need_header.haml
+++ b/app/views/needs/_need_header.haml
@@ -10,8 +10,13 @@
         .ui.basic.label.red
           = t('.need_archived')
 
-- if need.diagnosis.solicitation.present?
+- if need.diagnosis.content.present?
   .solicitation-description
-    %p= simple_format(auto_link(need.diagnosis.solicitation.description))
-    - if policy(need.diagnosis.solicitation).show?
+    - if need.solicitation.present?
+      %p= t('.company_message')
+    %i.quote.left.icon
+    = simple_format(auto_link(need.diagnosis.content), class: 'content')
+    %i.quote.right.icon
+
+    - if need.diagnosis.solicitation.present? && policy(need.diagnosis.solicitation).show?
       = link_to(t('.solicitation_link'), need.diagnosis.solicitation)

--- a/app/views/needs/_need_header.haml
+++ b/app/views/needs/_need_header.haml
@@ -9,3 +9,9 @@
       - else
         .ui.basic.label.red
           = t('.need_archived')
+
+- if need.diagnosis.solicitation.present?
+  .solicitation-description
+    %p= simple_format(auto_link(need.diagnosis.solicitation.description))
+    - if policy(need.diagnosis.solicitation).show?
+      = link_to(t('.solicitation_link'), need.diagnosis.solicitation)

--- a/app/views/needs/_visit_summary.haml
+++ b/app/views/needs/_visit_summary.haml
@@ -26,13 +26,3 @@
               = t('.advisor_has_diagnosed_n_needs', advisor: diagnosis.advisor, count: diagnosis.needs.count)
             - if diagnosis.content
               .extra.text= simple_format(auto_link(diagnosis.content))
-
-  - if diagnosis.solicitation.present?
-    .ui.horizontal.divider.sub.header
-      = t('.solicitation', id: diagnosis.solicitation.id)
-    .row
-      .column
-        = simple_format(auto_link(diagnosis.solicitation.description))
-        - if policy(diagnosis.solicitation).show?
-          = link_to(t('.solicitation_link'), diagnosis.solicitation)
-

--- a/app/views/needs/_visit_summary.haml
+++ b/app/views/needs/_visit_summary.haml
@@ -24,5 +24,3 @@
             .date= I18n.l(diagnosis.completed_at, format: :long)
             .summary
               = t('.advisor_has_diagnosed_n_needs', advisor: diagnosis.advisor, count: diagnosis.needs.count)
-            - if diagnosis.content
-              .extra.text= simple_format(auto_link(diagnosis.content))

--- a/config/locales/views.fr.yml
+++ b/config/locales/views.fr.yml
@@ -470,6 +470,7 @@ fr:
       title: Demandes reçues pour %{antenne}
     need_header:
       need_archived: Besoin archivé
+      solicitation_link: Lien vers la sollicitation
     needs_archived_tabs:
       done: Clôturées
       failed: Marquées en échec
@@ -493,8 +494,6 @@ fr:
         other: "%{advisor} a identifié %{count} besoins."
       person_advisor: Conseiller
       person_company_contact: Personne rencontrée
-      solicitation: Sollicitation %{id}
-      solicitation_link: Lien vers la sollicitation
       visit_made_on: Mise en relation faite le %{date}
   newsletters:
     create:

--- a/config/locales/views.fr.yml
+++ b/config/locales/views.fr.yml
@@ -469,6 +469,7 @@ fr:
       browse_archived_needs: Voir les demandes archivées
       title: Demandes reçues pour %{antenne}
     need_header:
+      company_message: 'Message de l''entreprise :'
       need_archived: Besoin archivé
       solicitation_link: Lien vers la sollicitation
     needs_archived_tabs:

--- a/spec/mailers/previews/expert_mailer_preview.rb
+++ b/spec/mailers/previews/expert_mailer_preview.rb
@@ -1,7 +1,15 @@
 class ExpertMailerPreview < ActionMailer::Preview
-  def notify_company_needs
+  def notify_company_needs_without_solicitation
+    diagnosis = Diagnosis.completed.where(solicitation: nil).joins(:experts).where(experts: { deleted_at: nil }).sample
+    expert = diagnosis.experts.not_deleted.sample
+    ExpertMailer.notify_company_needs(expert, diagnosis)
+  end
+
+  def notify_company_needs_with_solicitation
     expert = active_expert
-    ExpertMailer.notify_company_needs(expert, expert.received_diagnoses.sample)
+    diagnosis = expert.received_diagnoses.sample
+    diagnosis.solicitation = Solicitation.all.sample
+    ExpertMailer.notify_company_needs(expert, diagnosis)
   end
 
   def notify_company_needs_from_partner
@@ -31,6 +39,6 @@ class ExpertMailerPreview < ActionMailer::Preview
   private
 
   def active_expert
-    Expert.with_active_matches.sample
+    Expert.not_deleted.with_active_matches.sample
   end
 end


### PR DESCRIPTION
- Réduit tous les thèmes sur /analyses/:id/besoins pour ne laisser ouvert que celui qui a le sujet pré-sélectionné et ajoute un bouton "passer à la suite" sur chaque thème pour éviter d'avoir a scroller en bas du formulaire
- passe l'étape "visite" si une sollicitation est liée et si une `diagnosis.visitee` est présente
- dans l'export CSV des matches affiche la description de la sollicitation s'il y en a une
- affiche la description de la sollicitation en dessous du titre du besoin, juste au-dessus des commentaires
- affiche les analyses précédentes sur l'écran de choix des sujets si une entreprise a déjà fait l'objet d'analyses
- dans l'email aux experts afficher la description de la sollicitation s'il y a lieu

closes #1366
closes #1028