### PR TITLE
Fix Newsletter url

### DIFF
--- a/app/views/mailers/company_mailer/newsletter_subscription.html.haml
+++ b/app/views/mailers/company_mailer/newsletter_subscription.html.haml
@@ -6,7 +6,7 @@
 
 %p
   .button
-    %a{ href: "#{newsletters_url}", target: '_blank' }= t('.subscribe')
+    %a{ href: "#{new_newsletters_url}", target: '_blank' }= t('.subscribe')
 
 %p= t('mailers.nice_day')
 

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -65,7 +65,8 @@ Rails.application.routes.draw do
 
   resource :newsletters, only: %i[] do
     post :create
-    get :new, path: 'abonnement'
+    get :new, path: 'abonnement', as: :new
+    get :index, to: redirect('/newsletters/abonnement')
   end
 
   resources :solicitations, only: %i[index show], path: 'sollicitations' do


### PR DESCRIPTION
fixes #1388

* send the correct url in the new emails
* redirect the failing url to the correct url