### PR TITLE
Panier a rappeler

### DIFF
--- a/app/controllers/reminders/experts_controller.rb
+++ b/app/controllers/reminders/experts_controller.rb
@@ -16,7 +16,7 @@ module Reminders
     end
 
     def needs
-      retrieve_needs(:needs_quo)
+      retrieve_needs :needs_quo
       @needs = @needs.abandoned
     end
 

--- a/app/controllers/reminders/needs_controller.rb
+++ b/app/controllers/reminders/needs_controller.rb
@@ -6,8 +6,8 @@ module Reminders
       retrieve_needs :reminder_quo_not_taken
     end
 
-    def in_progress
-      retrieve_needs :reminder_in_progress
+    def to_recall
+      retrieve_needs :reminder_to_recall
       render :index
     end
 

--- a/app/controllers/reminders/reminders_controller.rb
+++ b/app/controllers/reminders/reminders_controller.rb
@@ -12,9 +12,9 @@ module Reminders
       @count_needs = Rails.cache.fetch(["reminders_need", Need.all]) do
         {
           reminder_quo_not_taken: Need.diagnosis_completed.reminder_quo_not_taken.size.keys.size,
-            reminder_in_progress: Need.diagnosis_completed.reminder_in_progress.size,
-            reminder_institutions: Need.diagnosis_completed.reminder_institutions.size,
-            abandoned_without_taking_care: Need.diagnosis_completed.abandoned_without_taking_care.size,
+          reminder_to_recall: Need.diagnosis_completed.reminder_to_recall.size,
+          reminder_institutions: Need.diagnosis_completed.reminder_institutions.size,
+          abandoned_without_taking_care: Need.diagnosis_completed.abandoned_without_taking_care.size,
           rejected: Need.diagnosis_completed.rejected.size
         }
       end

--- a/app/views/reminders/_menu.html.haml
+++ b/app/views/reminders/_menu.html.haml
@@ -1,5 +1,5 @@
 = active_link_to(t('reminders.needs.menu.reminder_quo_not_taken_html', label: colored_label(count_needs[:reminder_quo_not_taken])), reminders_needs_path, active: ['reminders/needs': :index], class: 'item')
-= active_link_to(t('reminders.needs.menu.reminder_in_progress_html', label: colored_label(count_needs[:reminder_in_progress])), in_progress_reminders_needs_path, active: ['reminders/needs': :in_progress], class: 'item')
+= active_link_to(t('reminders.needs.menu.reminder_to_recall_html', label: colored_label(count_needs[:reminder_to_recall])), to_recall_reminders_needs_path, active: ['reminders/needs': :to_recall], class: 'item')
 = active_link_to(t('reminders.needs.menu.reminder_institutions_html', label: colored_label(count_needs[:reminder_institutions])), institutions_reminders_needs_path, active: ['reminders/needs': :institutions], class: 'item')
 = active_link_to(t('reminders.needs.menu.abandoned_without_taking_care_html', label: colored_label(count_needs[:abandoned_without_taking_care])), abandoned_reminders_needs_path, active: ['reminders/needs': :abandoned], class: 'item')
 = active_link_to(t('reminders.needs.menu.rejected_html', label: colored_label(count_needs[:rejected])), rejected_reminders_needs_path, active: ['reminders/needs': :rejected], class: 'item')

--- a/config/locales/views.fr.yml
+++ b/config/locales/views.fr.yml
@@ -563,19 +563,17 @@ fr:
       header:
         abandoned_without_taking_care: Abandonnés
         rejected: Refusés
-        # reminder_in_progress: En cours
+        reminder_institutions: Institution à prévenir
         reminder_quo_not_taken: À relancer
         reminder_to_recall: À rappeler
-        reminder_institutions: Institution à prévenir
       index:
         title: Besoins %{status}
       menu:
         abandoned_without_taking_care_html: "%{label} Abandonnés <i>(J+30)</i>"
         rejected_html: "%{label} Refusés"
-        # reminder_in_progress_html: "%{label} Relancés"
+        reminder_institutions_html: "%{label} Prévenir l‘institution <i>(J+21)</i>"
         reminder_quo_not_taken_html: "%{label} À relancer <i>(J+7)</i>"
         reminder_to_recall_html: "%{label} À rappeler<i>(J+14)</i>"
-        reminder_institutions_html: "%{label} Prévenir l‘institution <i>(J+21)</i>"
   solicitations:
     header:
       canceled: annulées

--- a/config/locales/views.fr.yml
+++ b/config/locales/views.fr.yml
@@ -563,17 +563,19 @@ fr:
       header:
         abandoned_without_taking_care: Abandonnés
         rejected: Refusés
-        reminder_in_progress: En cours
-        reminder_institutions: Institution à prévenir
+        # reminder_in_progress: En cours
         reminder_quo_not_taken: À relancer
+        reminder_to_recall: À rappeler
+        reminder_institutions: Institution à prévenir
       index:
         title: Besoins %{status}
       menu:
         abandoned_without_taking_care_html: "%{label} Abandonnés <i>(J+30)</i>"
         rejected_html: "%{label} Refusés"
-        reminder_in_progress_html: "%{label} Relancés"
-        reminder_institutions_html: "%{label} Prévenir l‘institution <i>(J+21)</i>"
+        # reminder_in_progress_html: "%{label} Relancés"
         reminder_quo_not_taken_html: "%{label} À relancer <i>(J+7)</i>"
+        reminder_to_recall_html: "%{label} À rappeler<i>(J+14)</i>"
+        reminder_institutions_html: "%{label} Prévenir l‘institution <i>(J+21)</i>"
   solicitations:
     header:
       canceled: annulées

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -178,7 +178,7 @@ Rails.application.routes.draw do
     end
     resources :needs, path: 'besoins', only: %i[index] do
       collection do
-        get :in_progress, path: 'en_cours'
+        get :to_recall, path: 'a-rappeler'
         get :institutions, path: 'institutions_a_prevenir'
         get :abandoned, path: 'abandonnes'
         get :rejected, path: 'refuses'

--- a/spec/models/need_spec.rb
+++ b/spec/models/need_spec.rb
@@ -386,7 +386,7 @@ RSpec.describe Need, type: :model do
       # - besoin créé il y a 14 jours, avec 1 cloture « injoignable », et autres MER sans réponse             ok
     end
 
-    describe 'besoins prévenir l\'institution (J+21)' do
+    describe 'besoins prévenir l’institution (J+21)' do
       # - besoins restés sans réponse à plus 21 jours après les mises en relation ;
       # - besoins avec une mise en relation clôturée par « pas d’aide disponible » et « non joignable » ou refusés ET pour lesquels des experts n’ont toujours pas répondu à plus de 21 jours.
 

--- a/spec/models/need_spec.rb
+++ b/spec/models/need_spec.rb
@@ -311,7 +311,7 @@ RSpec.describe Need, type: :model do
           need4
         end
 
-        it 'displays needs in correct time_range' do
+        it 'retourne les besoins dans la bonne période' do
           expect(described_class.reminder_quo_not_taken).to eq [need2, need3]
         end
       end
@@ -324,7 +324,7 @@ RSpec.describe Need, type: :model do
 
         let(:date) { Time.zone.now.beginning_of_day - 7.days }
 
-        xit 'displays needs witout Reminder Action' do
+        xit 'retourne les besoins sans Reminder Action' do
           # expect(described_class.reminder_quo_not_taken).to eq [need2, need3]
         end
       end
@@ -338,7 +338,7 @@ RSpec.describe Need, type: :model do
 
         let(:date) { Time.zone.now.beginning_of_day - 7.days }
 
-        xit 'displays needs with certain relations' do
+        xit 'retourne les besoins avec certaines relations' do
           # expect(described_class.reminder_quo_not_taken).to eq [need2, need3]
         end
       end
@@ -368,7 +368,7 @@ RSpec.describe Need, type: :model do
           need4
         end
 
-        it 'displays needs in correct time_range' do
+        it 'retourne les besoins dans la bonne période' do
           expect(described_class.reminder_to_recall).to eq [need2, need3]
         end
       end
@@ -405,7 +405,7 @@ RSpec.describe Need, type: :model do
           need4
         end
 
-        it 'displays needs in correct time_range' do
+        it 'retourne les besoins dans la bonne période' do
           expect(described_class.reminder_institutions).to eq [need2, need3]
         end
       end

--- a/spec/models/need_spec.rb
+++ b/spec/models/need_spec.rb
@@ -285,10 +285,9 @@ RSpec.describe Need, type: :model do
     it { is_expected.to eq 'taking_care' }
   end
 
-    describe 'paniers relance' do
-
+  describe 'paniers relance' do
     describe 'besoins à relancer (J+7)' do
-      # - besoins restés sans réponse (=sans positionnement, personne a cliqué sur les boutons "je prends en charge" ou "je refuse") à plus 7 jours après les mises en relation ; 
+      # - besoins restés sans réponse (=sans positionnement, personne a cliqué sur les boutons "je prends en charge" ou "je refuse") à plus 7 jours après les mises en relation ;
       # - besoins avec une mise en relation clôturée par « pas d’aide disponible » et « non joignable » ou refusés ET pour lesquels des experts n’ont toujours pas répondu à plus de 7 jours.
 
       describe 'contraintes de délais' do
@@ -313,7 +312,7 @@ RSpec.describe Need, type: :model do
         end
 
         it 'displays needs in correct time_range' do
-          expect(Need.reminder_quo_not_taken).to eq [need2, need3]
+          expect(described_class.reminder_quo_not_taken).to eq [need2, need3]
         end
       end
 
@@ -326,7 +325,7 @@ RSpec.describe Need, type: :model do
         let(:date) { Time.zone.now.beginning_of_day - 7.days }
 
         xit 'displays needs witout Reminder Action' do
-          # expect(Need.reminder_quo_not_taken).to eq [need2, need3]
+          # expect(described_class.reminder_quo_not_taken).to eq [need2, need3]
         end
       end
 
@@ -340,20 +339,20 @@ RSpec.describe Need, type: :model do
         let(:date) { Time.zone.now.beginning_of_day - 7.days }
 
         xit 'displays needs with certain relations' do
-          # expect(Need.reminder_quo_not_taken).to eq [need2, need3]
+          # expect(described_class.reminder_quo_not_taken).to eq [need2, need3]
         end
       end
     end
 
     describe 'besoins à rappeler (J+14)' do
-      # - besoins restés sans réponse à plus 14 jours après les mises en relation ; 
+      # - besoins restés sans réponse à plus 14 jours après les mises en relation ;
       # - besoins avec une mise en relation clôturée par « pas d’aide disponible » et « non joignable » ou refusés ET pour lesquels des experts n’ont toujours pas répondu à plus de 14 jours.
 
       describe 'contraintes de délais' do
-      # - besoin créé il y a 13 jours, sans positionnement     ko
-      # - besoin créé il y a 14 jours, sans positionnement     ok
-      # - besoin créé il y a 20 jours, sans positionnement     ok
-      # - besoin créé il y a 21 jours, sans positionnement     ko
+        # - besoin créé il y a 13 jours, sans positionnement     ko
+        # - besoin créé il y a 14 jours, sans positionnement     ok
+        # - besoin créé il y a 20 jours, sans positionnement     ok
+        # - besoin créé il y a 21 jours, sans positionnement     ko
 
         let(:reference_date) { Time.zone.now.beginning_of_day }
 
@@ -370,7 +369,7 @@ RSpec.describe Need, type: :model do
         end
 
         it 'displays needs in correct time_range' do
-          expect(Need.reminder_to_recall).to eq [need2, need3]
+          expect(described_class.reminder_to_recall).to eq [need2, need3]
         end
       end
 
@@ -388,11 +387,10 @@ RSpec.describe Need, type: :model do
     end
 
     describe 'besoins prévenir l\'institution (J+21)' do
-      # - besoins restés sans réponse à plus 21 jours après les mises en relation ; 
-      # - besoins avec une mise en relation clôturée par « pas d’aide disponible » et « non joignable » ou refusés ET pour lesquels des experts n’ont toujours pas répondu à plus de 21 jours.
+      # - besoins restés sans réponse à plus 21 jours après les mises en relation ;
+      # - besoins avec une mise en relation clôturée par « pas d’aide disponible » et « non joignable » ou refusés ET pour lesquels des experts n’ont toujours pas répondu à plus de 21 jours.
 
       describe 'contraintes de délais' do
-
         let(:reference_date) { Time.zone.now.beginning_of_day }
 
         let(:need1) { travel_to(reference_date - 20.days) { create :need_with_matches } }
@@ -408,45 +406,44 @@ RSpec.describe Need, type: :model do
         end
 
         it 'displays needs in correct time_range' do
-          expect(Need.reminder_institutions).to eq [need2, need3]
+          expect(described_class.reminder_institutions).to eq [need2, need3]
         end
       end
-
     end
 
-    describe 'Besoins abandonnés (J+30)' do
-      # - besoins restés sans réponse de tous les experts à plus 30 jours après les mises en relation
-      # - besoins avec une mise en relation refusée ET pour lesquels des experts n’ont toujours pas répondu à plus de 30 jours. 
-      # - besoins refusés de tous les experts
+    # describe 'Besoins abandonnés (J+30)' do
+    #   # - besoins restés sans réponse de tous les experts à plus 30 jours après les mises en relation
+    #   # - besoins avec une mise en relation refusée ET pour lesquels des experts n’ont toujours pas répondu à plus de 30 jours.
+    #   # - besoins refusés de tous les experts
 
-      # DELAIS
-      # - besoin créé il y a 29 jours, sans prise en charge     ko
-      # - besoin créé il y a 30 jours, sans prise en charge     ok
-      # - besoin créé il y a 100 jours, sans prise en charge    ok
+    #   # DELAIS
+    #   # - besoin créé il y a 29 jours, sans prise en charge     ko
+    #   # - besoin créé il y a 30 jours, sans prise en charge     ok
+    #   # - besoin créé il y a 100 jours, sans prise en charge    ok
 
-      # REMINDER ACTIONS
-      # - besoin créé il y a 30 jours, sans prise en charge, pas marqué "traité J+30"   ok
-      # - besoin créé il y a 30 jours, sans prise en charge, marqué "traité J+30"       ko
-      # - besoin créé il y a 30 jours, avec prise en charge, pas marqué "traité J+30"   ko
-      # - besoin créé il y a 30 jours, avec prise en charge, marqué "traité J+30"       ko
+    #   # REMINDER ACTIONS
+    #   # - besoin créé il y a 30 jours, sans prise en charge, pas marqué "traité J+30"   ok
+    #   # - besoin créé il y a 30 jours, sans prise en charge, marqué "traité J+30"       ko
+    #   # - besoin créé il y a 30 jours, avec prise en charge, pas marqué "traité J+30"   ko
+    #   # - besoin créé il y a 30 jours, avec prise en charge, marqué "traité J+30"       ko
 
-      # STATUT
-      # - besoin créé il y a 14 jours, avec 1 positionnement « refusé », et autres MER sans réponse           ok
-      # - besoin créé il y a 14 jours, avec tous les positionnement « refusé »                                ok
-      # - besoin créé il y a 14 jours, avec 1 cloture « pas d’aide disponible », et autres MER sans réponse   ko
-      # - besoin créé il y a 14 jours, avec 1 cloture « injoignable », et autres MER sans réponse             ko
-    end
+    #   # STATUT
+    #   # - besoin créé il y a 14 jours, avec 1 positionnement « refusé », et autres MER sans réponse           ok
+    #   # - besoin créé il y a 14 jours, avec tous les positionnement « refusé »                                ok
+    #   # - besoin créé il y a 14 jours, avec 1 cloture « pas d’aide disponible », et autres MER sans réponse   ko
+    #   # - besoin créé il y a 14 jours, avec 1 cloture « injoignable », et autres MER sans réponse             ko
+    # end
 
-    describe 'Besoins pris en charge sans cloture' do
-      # - besoins pris en charge mais n’ayant aucune mise en relation de clôturée depuis + 7 jours de la prise en charge.
-      # DELAIS
-      # - besoin avec un positionnement « prise en charge  » il y a 6 jours    ko
-      # - besoin avec un positionnement « prise en charge  » il y a 7 jours    ok
+    # describe 'Besoins pris en charge sans cloture' do
+    #   # - besoins pris en charge mais n’ayant aucune mise en relation de clôturée depuis + 7 jours de la prise en charge.
+    #   # DELAIS
+    #   # - besoin avec un positionnement « prise en charge  » il y a 6 jours    ko
+    #   # - besoin avec un positionnement « prise en charge  » il y a 7 jours    ok
 
-      # STATUT
-      # - besoin avec un positionnement « prise en charge  » il y a 7 jours et une cloture                ko
-      # - besoin avec un positionnement « prise en charge  » il y a 7 jours et un autre il y a 2 jours    ok
-    end
+    #   # STATUT
+    #   # - besoin avec un positionnement « prise en charge  » il y a 7 jours et une cloture                ko
+    #   # - besoin avec un positionnement « prise en charge  » il y a 7 jours et un autre il y a 2 jours    ok
+    # end
 
     describe 'abandoned_without_taking_care' do
       let(:date1) { Time.zone.now.beginning_of_day }
@@ -495,6 +492,5 @@ RSpec.describe Need, type: :model do
         is_expected.to eq [mid_need]
       end
     end
-
   end
 end


### PR DESCRIPTION
- ajout du panier "A rappeler (J+14)
- ajustement des delais de relances des paniers contigus
- suppression du "panier" "Relancés"
- ajout d'une base de test pour les paniers relance, basée sur https://docs.google.com/document/d/1vNTpNEdgmacCoAp1yw_MMaTI5PgOEFGMvGI3t-xZrQQ/edit, à compléter une fois la jonction faite avec https://github.com/betagouv/place-des-entreprises/pull/1403
- suppression de tests caducs

closes #1380 