### PR TITLE
met à jour et test le scope no_help_provided

### DIFF
--- a/app/models/need.rb
+++ b/app/models/need.rb
@@ -181,7 +181,7 @@ class Need < ApplicationRecord
 
   scope :reminder, -> { left_outer_joins(:matches).where('matches.created_at BETWEEN ? AND ?', REMINDER_TO_RECALL_DELAY.ago, REMINDER_DELAY.ago) }
 
-  scope :in_reminder_to_recall_time_range, -> { left_outer_joins(:matches).where('matches.created_at BETWEEN ? AND ?',REMINDER_INSTITUTIONS_DELAY.ago, REMINDER_TO_RECALL_DELAY.ago) }
+  scope :in_reminder_to_recall_time_range, -> { left_outer_joins(:matches).where('matches.created_at BETWEEN ? AND ?', REMINDER_INSTITUTIONS_DELAY.ago, REMINDER_TO_RECALL_DELAY.ago) }
 
   scope :reminder_institutions_delay, -> { left_outer_joins(:matches).where('matches.created_at BETWEEN ? AND ?', REMINDER_ABANDONED_DELAY.ago, REMINDER_INSTITUTIONS_DELAY.ago) }
 
@@ -190,11 +190,13 @@ class Need < ApplicationRecord
   # For Reminders, find Needs without taking care since EXPERT_ABANDONED_DELAY
   scope :abandoned, -> { joins(:matches).where("matches.created_at < ?", EXPERT_ABANDONED_DELAY.ago) }
 
-  scope :with_some_matches_in_status, -> (status) do # can be an array
+  scope :with_some_matches_in_status, -> (status) do
+    # can be an array
     joins(:matches).where(matches: Match.unscoped.where(status: status)).distinct
   end
 
-  scope :with_matches_only_in_status, -> (status) do # can be an array
+  scope :with_matches_only_in_status, -> (status) do
+    # can be an array
     left_outer_joins(:matches).where.not(matches: Match.unscoped.where.not(status: status)).distinct
   end
 

--- a/app/models/need.rb
+++ b/app/models/need.rb
@@ -198,7 +198,15 @@ class Need < ApplicationRecord
     left_outer_joins(:matches).where.not(matches: Match.unscoped.where.not(status: status)).distinct
   end
 
-  scope :no_help_provided, -> { where(status: %w[quo not_for_me done_no_help done_not_reachable]) }
+  scope :no_help_provided, -> do
+    joins(:matches)
+      .where(status: %w[quo not_for_me])
+      .distinct
+      .or(
+        where(status: %w[done_no_help done_not_reachable])
+          .with_some_matches_in_status(:quo)
+      )
+  end
 
   scope :active, -> do
     archived(false)

--- a/spec/models/need_spec.rb
+++ b/spec/models/need_spec.rb
@@ -189,26 +189,40 @@ RSpec.describe Need, type: :model do
       it { is_expected.to match_array [need1, need2] }
     end
 
-    describe 'by_status_no_help' do
-      let(:match_taking_care) { create(:match, status: :taking_care) }
-      let(:match_done) { create(:match, status: :done) }
-      let(:match_quo) { create(:match, status: :quo) }
-      let(:match_done_no_help) { create(:match, status: :done_no_help) }
-      let(:match_done_not_reachable) { create(:match, status: :done_not_reachable) }
-      let(:match_not_for_me) { create(:match, status: :not_for_me) }
+    describe 'no_help_provided' do
+      # Base des scopes pour les relances il défini quand un besoin n'a pas reçu d'aide
+      # 1 - besoin sans positionnement ok
+      # 2 - besoin avec que des refus ok
+      # 3 - besoin avec un positionnement et un refus ko
+      # 4 - besoin avec un refus et un 'pas d'aide disponible' ko
+      # 5 - besoin avec un refus et un 'pas joignable' ko
+      # 6 - besoin sans positionnement et un 'pas d'aide disponible' ok
+      # 7 - besoin sans positionnement et un 'pas joignable' ok
+      # 8 - besoin avec le statut diagnosis_not_complete ko
+      # 9 - besoin avec tous les positionnements en 'pas joignable' ko
 
-      before do
-        match_taking_care
-        match_done
-        match_quo
-        match_done_no_help
-        match_done_not_reachable
-        match_not_for_me
-      end
+      let!(:need1) { create :need_with_matches }
+      let(:need2) { create :need }
+      let!(:need2_match) { create :match, status: :not_for_me, need: need2 }
+      let(:need3) { create :need }
+      let!(:need3_match1) { create :match, status: :taking_care, need: need3 }
+      let!(:need3_match2) { create :match, status: :not_for_me, need: need3 }
+      let(:need4) { create :need }
+      let!(:need4_match1) { create :match, status: :done_no_help, need: need4 }
+      let!(:need4_match2) { create :match, status: :not_for_me, need: need4 }
+      let(:need5) { create :need }
+      let!(:need5_match1) { create :match, status: :done_not_reachable, need: need5 }
+      let!(:need5_match2) { create :match, status: :not_for_me, need: need5 }
+      let!(:need6) { create :need_with_matches }
+      let!(:need6_match) { create :match, status: :done_no_help, need: need6 }
+      let!(:need7) { create :need_with_matches }
+      let!(:need7_match) { create :match, status: :done_not_reachable, need: need7 }
+      let!(:need8) { create :need }
+      let!(:need9) { create :need }
+      let!(:need9_match1) { create :match, status: :done_not_reachable, need: need9 }
+      let!(:need9_match2) { create :match, status: :done_not_reachable, need: need9 }
 
-      subject { described_class.no_help_provided.order(:id) }
-
-      it { is_expected.to eq [match_quo.need, match_done_no_help.need, match_done_not_reachable.need, match_not_for_me.need] }
+      it { expect(described_class.no_help_provided).to match_array [need1, need2, need6, need7] }
     end
 
     describe 'exclude_needs_with_reminders_action' do


### PR DESCRIPTION
Ce scope est censé définir si un besoin a reçu de l'aide ou pas pour les relances mais ils y a plusieurs cas de besoins qui passent à la trappe