### PR TITLE
Make sure Need#update_status works correctly after the matches are made

### DIFF
--- a/app/models/need.rb
+++ b/app/models/need.rb
@@ -218,6 +218,7 @@ class Need < ApplicationRecord
   end
 
   def update_status
+    self.matches.reload # Make sure the matches are fresh from DB; see #1421
     matches_status = matches.pluck(:status).map(&:to_sym)
 
     if !diagnosis.step_completed?

--- a/spec/controllers/diagnoses/steps_controller_spec.rb
+++ b/spec/controllers/diagnoses/steps_controller_spec.rb
@@ -113,6 +113,20 @@ RSpec.describe Diagnoses::StepsController, type: :controller do
       }
     end
 
+    describe 'statuses are correctly updated' do
+      let(:selected) { true }
+
+      it('updates matches, needs and diagnoses statuses') {
+        post :update_matches, params: params
+
+        diagnosis.reload
+        need.reload
+        expect(diagnosis.step).to eq 'completed'
+        expect(need.status).to eq 'quo'
+        expect(diagnosis.matches.pluck(:status)).to eq ['quo']
+      }
+    end
+
     describe 'matches must be selected' do
       context 'one match selected' do
         let(:selected) { true }


### PR DESCRIPTION
Fixes #1421

The `update(status:...)` actually failed, because of a validation error in matches. It was due to this validation in Match:

```
validates :expert, uniqueness: { scope: :need_id, allow_nil: true }
```
This code is called in a weird context: we’re actually updating diagnosis params from StepController#update_matches, and the matches `touch`es back the Need. It seems that Need.update tries to validate the in-memory matches objects, but fails because the same data is already in database, and it doesn’t know it’s actually the same record.

Anyway. Nothing that a .reload can’t fix. 🤷‍♀️