### PR TITLE
Import prod to staging

### DIFF
--- a/doc/02-development.md
+++ b/doc/02-development.md
@@ -63,6 +63,15 @@ You can import data in your local development database from remote staging datab
  - `rake import_dump:import` : drop local db and import
  - `rake import_dump:anonymize` : anonymize personal information fields
 
+## Staging data
+
+You can import production data in staging application, if you want to test features in almost real condition. You need to install the [Scalingo CLI](http://doc.scalingo.com/app/command-line-tool.html) first.
+
+- `rake import_prod_to_staging`:
+ - `rake import_dump:dump` : dump data from production db 
+ - `rake import_dump:import_to_staging` : import prod db in staging db
+
+You may encounter dependencies problems. If so, you may have to change `/lib/tasks/import_prod_to_staging.rake` in order to drop a few problematic tables in staging before restoring database.
 ---
 
 Next: [Deployment](03-deployment.md)

--- a/lib/tasks/import_prod_to_staging.rake
+++ b/lib/tasks/import_prod_to_staging.rake
@@ -1,0 +1,62 @@
+namespace :import_prod_to_staging do
+  EXPORT_FILENAME = 'tmp/export_prod.dump'
+
+  def setup_prod_tunnel
+    tunnel_command = 'scalingo -a reso-production db-tunnel SCALINGO_POSTGRESQL_URL'
+    @prod_tunnel_pid = fork{ exec tunnel_command }
+  end
+
+  def kill_prod_tunnel
+    Process.kill('QUIT', @prod_tunnel_pid)
+  end
+
+  def setup_staging_tunnel
+    tunnel_command = 'scalingo -a reso-staging db-tunnel SCALINGO_POSTGRESQL_URL'
+    @staging_tunnel_pid = fork{ exec tunnel_command }
+  end
+
+  def kill_staging_tunnel
+    Process.kill('QUIT', @staging_tunnel_pid)
+  end
+
+  task :dump_prod do
+    setup_prod_tunnel
+
+    sleep 2
+
+    env = `scalingo -a reso-production env`.lines
+    pg_url = env.find{ |i| i[/SCALINGO_POSTGRESQL_URL=/] }
+    pw = pg_url[/.*:(.*)@/,1]
+    username = 'reso_produc_4107'
+    dbname = 'reso_produc_4107'
+    sh "#{pg_url}"
+    db_url = "postgres://#{username}:#{pw}@127.0.0.1:10000/#{dbname}?sslmode=require"
+
+    sh "pg_dump --clean --if-exists --format c --dbname #{db_url} --file #{EXPORT_FILENAME}"
+    kill_prod_tunnel
+  end
+
+  task :import_to_staging do
+    setup_staging_tunnel
+
+    sleep 2
+
+    env = `scalingo -a reso-staging env`.lines
+    pg_url = env.find{ |i| i[/SCALINGO_POSTGRESQL_URL=/] }
+    pw = pg_url[/.*:(.*)@/,1]
+    username = 'reso_stagin_5607'
+    dbname = 'reso_stagin_5607'
+    db_url = "postgres://#{username}:#{pw}@127.0.0.1:10000/#{dbname}?sslmode=require"
+
+    # not working yet
+    # sh "echo \"DROP SCHEMA public CASCADE; CREATE SCHEMA public;\" | psql -d #{db_url}"
+    sh "pg_restore --clean --if-exists --no-owner --no-privileges --no-comments --dbname #{db_url} #{EXPORT_FILENAME}"
+
+    kill_staging_tunnel
+  end
+
+  task all: %i[dump_prod import_to_staging]
+end
+
+desc 'import production data in staging db'
+task import_prod_to_staging: %w[import_prod_to_staging:all db:seed]

--- a/lib/tasks/import_prod_to_staging.rake
+++ b/lib/tasks/import_prod_to_staging.rake
@@ -48,8 +48,8 @@ namespace :import_prod_to_staging do
     dbname = 'reso_stagin_5607'
     db_url = "postgres://#{username}:#{pw}@127.0.0.1:10000/#{dbname}?sslmode=require"
 
-    # not working yet
-    # sh "echo \"DROP SCHEMA public CASCADE; CREATE SCHEMA public;\" | psql -d #{db_url}"
+    # solution non pérenne mais on n'a pas mieux pour le moment
+    sh "echo \"DROP TABLE public.needs CASCADE;\" | psql -d #{db_url}"
     sh "pg_restore --clean --if-exists --no-owner --no-privileges --no-comments --dbname #{db_url} #{EXPORT_FILENAME}"
 
     kill_staging_tunnel

--- a/lib/tasks/import_prod_to_staging.rake
+++ b/lib/tasks/import_prod_to_staging.rake
@@ -1,5 +1,7 @@
 namespace :import_prod_to_staging do
-  EXPORT_FILENAME = 'tmp/export_prod.dump'
+  def export_filename
+    @export_filename ||= 'tmp/export_prod.dump'
+  end
 
   def setup_prod_tunnel
     tunnel_command = 'scalingo -a reso-production db-tunnel SCALINGO_POSTGRESQL_URL'
@@ -32,7 +34,7 @@ namespace :import_prod_to_staging do
     sh "#{pg_url}"
     db_url = "postgres://#{username}:#{pw}@127.0.0.1:10000/#{dbname}?sslmode=require"
 
-    sh "pg_dump --clean --if-exists --format c --dbname #{db_url} --file #{EXPORT_FILENAME}"
+    sh "pg_dump --clean --if-exists --format c --dbname #{db_url} --file #{export_filename}"
     kill_prod_tunnel
   end
 
@@ -50,7 +52,7 @@ namespace :import_prod_to_staging do
 
     # solution non pérenne mais on n'a pas mieux pour le moment
     sh "echo \"DROP TABLE public.needs CASCADE;\" | psql -d #{db_url}"
-    sh "pg_restore --clean --if-exists --no-owner --no-privileges --no-comments --dbname #{db_url} #{EXPORT_FILENAME}"
+    sh "pg_restore --clean --if-exists --no-owner --no-privileges --no-comments --dbname #{db_url} #{export_filename}"
 
     kill_staging_tunnel
   end


### PR DESCRIPTION
- tâche pour importer en staging la BDD de prod
- la première partie est très similaire à `import_dump.rake` mais pas tout à fait -> format restorable de l'import.
- il y a sûrement une refacto à faire entre les 2 tâches, mais comme cette histoire m'a déjà passablement épuisée j'ai pas eu le courage