### PR TITLE
excludes needs when there is at least one reminders action with category

### DIFF
--- a/app/models/need.rb
+++ b/app/models/need.rb
@@ -149,8 +149,8 @@ class Need < ApplicationRecord
   end
 
   scope :exclude_needs_with_reminders_action, -> (category) do
-    where.not(reminders_actions: { category: category })
-      .or(self.where(reminders_actions: { id: nil }))
+    where.not(reminders_actions: RemindersAction.unscoped.where(category: category))
+      .or(self.where(reminders_actions: { id: nil })).distinct
   end
 
   scope :abandoned_without_taking_care, -> do


### PR DESCRIPTION
Visiblement on avait oublié un cas de figure, par exemple dans le panier +21 jours si un besoin avec déjà été marqué dans un panier précédent il apparaissait quand même, même s'il était marqué +21. Du moment qu'un de ces `reminders_actions` avait une autre catégorie que celle du panier.