### PR TITLE
Simplification des scopes pour les paniers

### DIFF
--- a/app/controllers/reminders/base_controller.rb
+++ b/app/controllers/reminders/base_controller.rb
@@ -15,7 +15,7 @@ module Reminders
       @count_needs = Rails.cache.fetch(["reminders_need", Need.all, @territory]) do
         {
           reminders_to_poke: needs.diagnosis_completed.reminders_to_poke.size,
-          reminder_to_recall: needs.diagnosis_completed.reminder_to_recall.size,
+          reminders_to_recall: needs.diagnosis_completed.reminders_to_recall.size,
           reminder_institutions: needs.diagnosis_completed.reminder_institutions.size,
           abandoned_without_taking_care: needs.diagnosis_completed.abandoned_without_taking_care.size,
           rejected: needs.diagnosis_completed.rejected.size

--- a/app/controllers/reminders/base_controller.rb
+++ b/app/controllers/reminders/base_controller.rb
@@ -14,7 +14,7 @@ module Reminders
       needs = needs.by_territory(@territory) if @territory.present?
       @count_needs = Rails.cache.fetch(["reminders_need", Need.all, @territory]) do
         {
-          reminder_quo_not_taken: needs.diagnosis_completed.reminder_quo_not_taken.size,
+          reminders_to_poke: needs.diagnosis_completed.reminders_to_poke.size,
           reminder_to_recall: needs.diagnosis_completed.reminder_to_recall.size,
           reminder_institutions: needs.diagnosis_completed.reminder_institutions.size,
           abandoned_without_taking_care: needs.diagnosis_completed.abandoned_without_taking_care.size,

--- a/app/controllers/reminders/base_controller.rb
+++ b/app/controllers/reminders/base_controller.rb
@@ -17,7 +17,7 @@ module Reminders
           reminders_to_poke: needs.diagnosis_completed.reminders_to_poke.size,
           reminders_to_recall: needs.diagnosis_completed.reminders_to_recall.size,
           reminders_to_warn: needs.diagnosis_completed.reminders_to_warn.size,
-          abandoned_without_taking_care: needs.diagnosis_completed.abandoned_without_taking_care.size,
+          reminders_to_archive: needs.diagnosis_completed.reminders_to_archive.size,
           rejected: needs.diagnosis_completed.rejected.size
         }
       end

--- a/app/controllers/reminders/base_controller.rb
+++ b/app/controllers/reminders/base_controller.rb
@@ -1,5 +1,5 @@
 module Reminders
-  class RemindersController < ApplicationController
+  class BaseController < ApplicationController
     include TerritoryFiltrable
 
     before_action :authenticate_admin!

--- a/app/controllers/reminders/base_controller.rb
+++ b/app/controllers/reminders/base_controller.rb
@@ -16,7 +16,7 @@ module Reminders
         {
           reminders_to_poke: needs.diagnosis_completed.reminders_to_poke.size,
           reminders_to_recall: needs.diagnosis_completed.reminders_to_recall.size,
-          reminder_institutions: needs.diagnosis_completed.reminder_institutions.size,
+          reminders_to_warn: needs.diagnosis_completed.reminders_to_warn.size,
           abandoned_without_taking_care: needs.diagnosis_completed.abandoned_without_taking_care.size,
           rejected: needs.diagnosis_completed.rejected.size
         }

--- a/app/controllers/reminders/experts_controller.rb
+++ b/app/controllers/reminders/experts_controller.rb
@@ -1,5 +1,5 @@
 module Reminders
-  class ExpertsController < RemindersController
+  class ExpertsController < BaseController
     before_action :retrieve_expert, except: :index
     before_action :count_expert_needs, except: %i[index reminders_notes]
     before_action :find_territories, only: %i[index]

--- a/app/controllers/reminders/needs_controller.rb
+++ b/app/controllers/reminders/needs_controller.rb
@@ -1,5 +1,5 @@
 module Reminders
-  class NeedsController < RemindersController
+  class NeedsController < BaseController
     before_action :find_territories
     before_action :count_needs
 

--- a/app/controllers/reminders/needs_controller.rb
+++ b/app/controllers/reminders/needs_controller.rb
@@ -14,7 +14,7 @@ module Reminders
     end
 
     def to_recall
-      retrieve_needs :reminder_to_recall
+      retrieve_needs :reminders_to_recall
       @action_path = [:recall, :reminders_action]
       render :index
     end

--- a/app/controllers/reminders/needs_controller.rb
+++ b/app/controllers/reminders/needs_controller.rb
@@ -19,8 +19,8 @@ module Reminders
       render :index
     end
 
-    def institutions
-      retrieve_needs :reminder_institutions
+    def to_warn
+      retrieve_needs :reminders_to_warn
       @action_path = [:warn, :reminders_action]
       render :index
     end

--- a/app/controllers/reminders/needs_controller.rb
+++ b/app/controllers/reminders/needs_controller.rb
@@ -4,8 +4,13 @@ module Reminders
     before_action :count_needs
 
     def index
+      redirect_to action: :quo_not_taken
+    end
+
+    def quo_not_taken
       retrieve_needs :reminder_quo_not_taken
       @action_path = [:poke, :reminders_action]
+      render :index
     end
 
     def to_recall

--- a/app/controllers/reminders/needs_controller.rb
+++ b/app/controllers/reminders/needs_controller.rb
@@ -25,8 +25,8 @@ module Reminders
       render :index
     end
 
-    def abandoned
-      retrieve_needs :abandoned_without_taking_care
+    def to_archive
+      retrieve_needs :reminders_to_archive
       @action_path = [:archive, :need]
       render :index
     end

--- a/app/controllers/reminders/needs_controller.rb
+++ b/app/controllers/reminders/needs_controller.rb
@@ -4,11 +4,11 @@ module Reminders
     before_action :count_needs
 
     def index
-      redirect_to action: :quo_not_taken
+      redirect_to action: :to_poke
     end
 
-    def quo_not_taken
-      retrieve_needs :reminder_quo_not_taken
+    def to_poke
+      retrieve_needs :reminders_to_poke
       @action_path = [:poke, :reminders_action]
       render :index
     end

--- a/app/controllers/reminders_actions_controller.rb
+++ b/app/controllers/reminders_actions_controller.rb
@@ -15,7 +15,7 @@ class RemindersActionsController < ApplicationController
 
   def warn
     @need.reminders_actions.create(category: :warn)
-    redirect_to institutions_reminders_needs_path, notice: t('reminders_actions.processed_need', company: @need.company.name)
+    redirect_to to_warn_reminders_needs_path, notice: t('reminders_actions.processed_need', company: @need.company.name)
   end
 
   private

--- a/app/controllers/reminders_actions_controller.rb
+++ b/app/controllers/reminders_actions_controller.rb
@@ -10,7 +10,7 @@ class RemindersActionsController < ApplicationController
 
   def recall
     @need.reminders_actions.create(category: :recall)
-    redirect_back fallback_location: reminders_needs_path, notice: t('reminders_actions.processed_need', company: @need.company.name)
+    redirect_to to_recall_reminders_needs_path, notice: t('reminders_actions.processed_need', company: @need.company.name)
   end
 
   def warn

--- a/app/controllers/reminders_actions_controller.rb
+++ b/app/controllers/reminders_actions_controller.rb
@@ -5,7 +5,7 @@ class RemindersActionsController < ApplicationController
 
   def poke
     @need.reminders_actions.create(category: :poke)
-    redirect_to reminders_needs_path, notice: t('reminders_actions.processed_need', company: @need.company.name)
+    redirect_to to_poke_reminders_needs_path, notice: t('reminders_actions.processed_need', company: @need.company.name)
   end
 
   def recall

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -1,0 +1,7 @@
+module ApplicationHelper
+  def menu_link_with_count(title, count, url, options = {})
+    active_link_to(url, options.merge(class: 'item')) do
+      tag.div("#{count}", class: "ui label") + title
+    end
+  end
+end

--- a/app/helpers/badges_helper.rb
+++ b/app/helpers/badges_helper.rb
@@ -5,8 +5,4 @@ module BadgesHelper
     tag.div(badge.title, class: 'ui basic label badge',
                 style: "border: 1px solid #{badge.color}; color: #{badge.color}")
   end
-
-  def colored_label(content, color = '')
-    tag.div(content, class: "ui label #{color}")
-  end
 end

--- a/app/models/expert.rb
+++ b/app/models/expert.rb
@@ -237,12 +237,10 @@ class Expert < ApplicationRecord
   ## Reminders
   #
   def reminders_needs_to_call_back
-    query = self.received_needs
+    self.received_needs
       .status_quo
       .where.not(matches: received_matches.status_not_for_me)
       .archived(false)
-      .left_outer_joins(:reminders_actions)
-      .distinct
-    query.exclude_needs_with_reminders_action(:recall)
+      .without_action(:recall)
   end
 end

--- a/app/models/need.rb
+++ b/app/models/need.rb
@@ -91,7 +91,7 @@ class Need < ApplicationRecord
   ## Scopes
   #
   EXPERT_ABANDONED_DELAY = 14.days
-  REMINDER_DELAY = 7.days
+  REMINDERS_TO_POKE_DELAY = 7.days
   REMINDER_TO_RECALL_DELAY = 14.days
   REMINDER_INSTITUTIONS_DELAY = 21.days
   REMINDER_ABANDONED_DELAY = 30.days
@@ -124,7 +124,7 @@ class Need < ApplicationRecord
       .reminder
   end
 
-  scope :reminder_quo_not_taken, -> do
+  scope :reminders_to_poke, -> do
     query = no_help_provided
       .archived(false)
       .reminder
@@ -179,7 +179,7 @@ class Need < ApplicationRecord
       .having("MIN(matches.closed_at) BETWEEN ? AND ?", range.begin, range.end)
   end
 
-  scope :reminder, -> { left_outer_joins(:matches).where('matches.created_at BETWEEN ? AND ?', REMINDER_TO_RECALL_DELAY.ago, REMINDER_DELAY.ago) }
+  scope :reminder, -> { left_outer_joins(:matches).where('matches.created_at BETWEEN ? AND ?', REMINDER_TO_RECALL_DELAY.ago, REMINDERS_TO_POKE_DELAY.ago) }
 
   scope :in_reminder_to_recall_time_range, -> { left_outer_joins(:matches).where('matches.created_at BETWEEN ? AND ?', REMINDER_INSTITUTIONS_DELAY.ago, REMINDER_TO_RECALL_DELAY.ago) }
 

--- a/app/models/need.rb
+++ b/app/models/need.rb
@@ -92,7 +92,7 @@ class Need < ApplicationRecord
   #
   EXPERT_ABANDONED_DELAY = 14.days
   REMINDERS_TO_POKE_DELAY = 7.days
-  REMINDER_TO_RECALL_DELAY = 14.days
+  REMINDERS_TO_RECALL_DELAY = 14.days
   REMINDER_INSTITUTIONS_DELAY = 21.days
   REMINDER_ABANDONED_DELAY = 30.days
 
@@ -132,10 +132,10 @@ class Need < ApplicationRecord
     query.exclude_needs_with_reminders_action(:poke).distinct
   end
 
-  scope :reminder_to_recall, -> do
+  scope :reminders_to_recall, -> do
     query = no_help_provided
       .archived(false)
-      .in_reminder_to_recall_time_range
+      .in_reminders_to_recall_time_range
       .left_outer_joins(:reminders_actions)
     query.exclude_needs_with_reminders_action(:recall).distinct
   end
@@ -179,9 +179,9 @@ class Need < ApplicationRecord
       .having("MIN(matches.closed_at) BETWEEN ? AND ?", range.begin, range.end)
   end
 
-  scope :reminder, -> { left_outer_joins(:matches).where('matches.created_at BETWEEN ? AND ?', REMINDER_TO_RECALL_DELAY.ago, REMINDERS_TO_POKE_DELAY.ago) }
+  scope :reminder, -> { left_outer_joins(:matches).where('matches.created_at BETWEEN ? AND ?', REMINDERS_TO_RECALL_DELAY.ago, REMINDERS_TO_POKE_DELAY.ago) }
 
-  scope :in_reminder_to_recall_time_range, -> { left_outer_joins(:matches).where('matches.created_at BETWEEN ? AND ?', REMINDER_INSTITUTIONS_DELAY.ago, REMINDER_TO_RECALL_DELAY.ago) }
+  scope :in_reminders_to_recall_time_range, -> { left_outer_joins(:matches).where('matches.created_at BETWEEN ? AND ?', REMINDER_INSTITUTIONS_DELAY.ago, REMINDERS_TO_RECALL_DELAY.ago) }
 
   scope :reminder_institutions_delay, -> { left_outer_joins(:matches).where('matches.created_at BETWEEN ? AND ?', REMINDER_ABANDONED_DELAY.ago, REMINDER_INSTITUTIONS_DELAY.ago) }
 

--- a/app/models/need.rb
+++ b/app/models/need.rb
@@ -94,7 +94,7 @@ class Need < ApplicationRecord
   REMINDERS_TO_POKE_DELAY = 7.days
   REMINDERS_TO_RECALL_DELAY = 14.days
   REMINDERS_TO_WARN_DELAY = 21.days
-  REMINDER_ABANDONED_DELAY = 30.days
+  REMINDERS_TO_ARCHIVE_DELAY = 30.days
 
   scope :ordered_for_interview, -> do
     left_outer_joins(:subject)
@@ -141,7 +141,7 @@ class Need < ApplicationRecord
       .or(self.where(reminders_actions: { id: nil })).distinct
   end
 
-  scope :abandoned_without_taking_care, -> do
+  scope :reminders_to_archive, -> do
     with_matches_only_in_status([:quo, :not_for_me])
       .archived(false)
       .reminder_abandoned
@@ -171,9 +171,9 @@ class Need < ApplicationRecord
 
   scope :in_reminders_to_recall_time_range, -> { left_outer_joins(:matches).where('matches.created_at BETWEEN ? AND ?', REMINDERS_TO_WARN_DELAY.ago, REMINDERS_TO_RECALL_DELAY.ago) }
 
-  scope :reminders_to_warn_delay, -> { left_outer_joins(:matches).where('matches.created_at BETWEEN ? AND ?', REMINDER_ABANDONED_DELAY.ago, REMINDERS_TO_WARN_DELAY.ago) }
+  scope :reminders_to_warn_delay, -> { left_outer_joins(:matches).where('matches.created_at BETWEEN ? AND ?', REMINDERS_TO_ARCHIVE_DELAY.ago, REMINDERS_TO_WARN_DELAY.ago) }
 
-  scope :reminder_abandoned, -> { left_outer_joins(:matches).where('matches.created_at < ?', REMINDER_ABANDONED_DELAY.ago) }
+  scope :reminder_abandoned, -> { left_outer_joins(:matches).where('matches.created_at < ?', REMINDERS_TO_ARCHIVE_DELAY.ago) }
 
   # For Reminders, find Needs without taking care since EXPERT_ABANDONED_DELAY
   scope :abandoned, -> { joins(:matches).where("matches.created_at < ?", EXPERT_ABANDONED_DELAY.ago) }

--- a/app/models/need.rb
+++ b/app/models/need.rb
@@ -96,12 +96,6 @@ class Need < ApplicationRecord
   REMINDER_INSTITUTIONS_DELAY = 21.days
   REMINDER_ABANDONED_DELAY = 30.days
 
-  scope :made_in, -> (date_range) do
-    joins(:diagnosis)
-      .where(diagnoses: { happened_on: date_range })
-      .distinct
-  end
-
   scope :ordered_for_interview, -> do
     left_outer_joins(:subject)
       .merge(Subject.ordered_for_interview)
@@ -116,12 +110,6 @@ class Need < ApplicationRecord
     status_quo
       .archived(false)
       .abandoned
-  end
-
-  scope :reminders_to_process, -> do
-    no_help_provided
-      .archived(false)
-      .reminder
   end
 
   scope :reminders_to_poke, -> do

--- a/app/models/need.rb
+++ b/app/models/need.rb
@@ -93,7 +93,7 @@ class Need < ApplicationRecord
   EXPERT_ABANDONED_DELAY = 14.days
   REMINDERS_TO_POKE_DELAY = 7.days
   REMINDERS_TO_RECALL_DELAY = 14.days
-  REMINDER_INSTITUTIONS_DELAY = 21.days
+  REMINDERS_TO_WARN_DELAY = 21.days
   REMINDER_ABANDONED_DELAY = 30.days
 
   scope :ordered_for_interview, -> do
@@ -128,10 +128,10 @@ class Need < ApplicationRecord
     query.exclude_needs_with_reminders_action(:recall).distinct
   end
 
-  scope :reminder_institutions, -> do
+  scope :reminders_to_warn, -> do
     query = no_help_provided
       .archived(false)
-      .reminder_institutions_delay
+      .reminders_to_warn_delay
       .left_outer_joins(:reminders_actions)
     query.exclude_needs_with_reminders_action(:warn).distinct
   end
@@ -169,9 +169,9 @@ class Need < ApplicationRecord
 
   scope :reminder, -> { left_outer_joins(:matches).where('matches.created_at BETWEEN ? AND ?', REMINDERS_TO_RECALL_DELAY.ago, REMINDERS_TO_POKE_DELAY.ago) }
 
-  scope :in_reminders_to_recall_time_range, -> { left_outer_joins(:matches).where('matches.created_at BETWEEN ? AND ?', REMINDER_INSTITUTIONS_DELAY.ago, REMINDERS_TO_RECALL_DELAY.ago) }
+  scope :in_reminders_to_recall_time_range, -> { left_outer_joins(:matches).where('matches.created_at BETWEEN ? AND ?', REMINDERS_TO_WARN_DELAY.ago, REMINDERS_TO_RECALL_DELAY.ago) }
 
-  scope :reminder_institutions_delay, -> { left_outer_joins(:matches).where('matches.created_at BETWEEN ? AND ?', REMINDER_ABANDONED_DELAY.ago, REMINDER_INSTITUTIONS_DELAY.ago) }
+  scope :reminders_to_warn_delay, -> { left_outer_joins(:matches).where('matches.created_at BETWEEN ? AND ?', REMINDER_ABANDONED_DELAY.ago, REMINDERS_TO_WARN_DELAY.ago) }
 
   scope :reminder_abandoned, -> { left_outer_joins(:matches).where('matches.created_at < ?', REMINDER_ABANDONED_DELAY.ago) }
 

--- a/app/models/need.rb
+++ b/app/models/need.rb
@@ -109,32 +109,31 @@ class Need < ApplicationRecord
   end
 
   scope :reminders_to_poke, -> do
-    query = no_help_provided
+    no_help_provided
       .archived(false)
       .in_reminders_range(:poke)
-      .left_outer_joins(:reminders_actions)
-    query.exclude_needs_with_reminders_action(:poke).distinct
+      .without_action(:poke)
   end
 
   scope :reminders_to_recall, -> do
-    query = no_help_provided
+    no_help_provided
       .archived(false)
       .in_reminders_range(:recall)
-      .left_outer_joins(:reminders_actions)
-    query.exclude_needs_with_reminders_action(:recall).distinct
+      .without_action(:recall)
   end
 
   scope :reminders_to_warn, -> do
-    query = no_help_provided
+    no_help_provided
       .archived(false)
       .in_reminders_range(:warn)
-      .left_outer_joins(:reminders_actions)
-    query.exclude_needs_with_reminders_action(:warn).distinct
+      .without_action(:warn)
   end
 
-  scope :exclude_needs_with_reminders_action, -> (category) do
-    where.not(reminders_actions: RemindersAction.unscoped.where(category: category))
-      .or(self.where(reminders_actions: { id: nil })).distinct
+  scope :without_action, -> (category) do
+    subquery = Need.unscoped
+      .joins(:reminders_actions)
+      .where(reminders_actions: { category: category })
+    where.not(id: subquery)
   end
 
   scope :reminders_to_archive, -> do

--- a/app/views/application/_navbar.html.haml
+++ b/app/views/application/_navbar.html.haml
@@ -22,7 +22,7 @@
             = active_link_to badges_path, class: 'item' do
               %i.tags.icon
               = t('.badges')
-        = active_link_to reminders_needs_path, active: [['reminders/experts', 'reminders/needs'], [] ], class: 'item' do
+        = active_link_to reminders_path, class: 'item' do
           %i.ambulance.icon
           = t('reminders.index.title')
 

--- a/app/views/reminders/_menu.html.haml
+++ b/app/views/reminders/_menu.html.haml
@@ -1,5 +1,5 @@
 = menu_link_with_count(t('reminders.needs.menu.reminders_to_poke_html'), count_needs[:reminders_to_poke], to_poke_reminders_needs_path)
-= menu_link_with_count(t('reminders.needs.menu.reminder_to_recall_html'), count_needs[:reminder_to_recall], to_recall_reminders_needs_path)
+= menu_link_with_count(t('reminders.needs.menu.reminders_to_recall_html'), count_needs[:reminders_to_recall], to_recall_reminders_needs_path)
 = menu_link_with_count(t('reminders.needs.menu.reminder_institutions_html'), count_needs[:reminder_institutions], institutions_reminders_needs_path)
 = menu_link_with_count(t('reminders.needs.menu.abandoned_without_taking_care_html'), count_needs[:abandoned_without_taking_care], abandoned_reminders_needs_path)
 .ui.divider

--- a/app/views/reminders/_menu.html.haml
+++ b/app/views/reminders/_menu.html.haml
@@ -1,6 +1,6 @@
 = menu_link_with_count(t('reminders.needs.menu.reminders_to_poke_html'), count_needs[:reminders_to_poke], to_poke_reminders_needs_path)
 = menu_link_with_count(t('reminders.needs.menu.reminders_to_recall_html'), count_needs[:reminders_to_recall], to_recall_reminders_needs_path)
-= menu_link_with_count(t('reminders.needs.menu.reminder_institutions_html'), count_needs[:reminder_institutions], institutions_reminders_needs_path)
+= menu_link_with_count(t('reminders.needs.menu.reminders_to_warn_html'), count_needs[:reminders_to_warn], to_warn_reminders_needs_path)
 = menu_link_with_count(t('reminders.needs.menu.abandoned_without_taking_care_html'), count_needs[:abandoned_without_taking_care], abandoned_reminders_needs_path)
 .ui.divider
 = active_link_to Expert.model_name.human.pluralize, reminders_experts_path, { class: 'item' }

--- a/app/views/reminders/_menu.html.haml
+++ b/app/views/reminders/_menu.html.haml
@@ -1,4 +1,4 @@
-= menu_link_with_count(t('reminders.needs.menu.reminder_quo_not_taken_html'), count_needs[:reminder_quo_not_taken], quo_not_taken_reminders_needs_path)
+= menu_link_with_count(t('reminders.needs.menu.reminders_to_poke_html'), count_needs[:reminders_to_poke], to_poke_reminders_needs_path)
 = menu_link_with_count(t('reminders.needs.menu.reminder_to_recall_html'), count_needs[:reminder_to_recall], to_recall_reminders_needs_path)
 = menu_link_with_count(t('reminders.needs.menu.reminder_institutions_html'), count_needs[:reminder_institutions], institutions_reminders_needs_path)
 = menu_link_with_count(t('reminders.needs.menu.abandoned_without_taking_care_html'), count_needs[:abandoned_without_taking_care], abandoned_reminders_needs_path)

--- a/app/views/reminders/_menu.html.haml
+++ b/app/views/reminders/_menu.html.haml
@@ -1,4 +1,4 @@
-= menu_link_with_count(t('reminders.needs.menu.reminder_quo_not_taken_html'), count_needs[:reminder_quo_not_taken], reminders_needs_path, active: ['reminders/needs': :index])
+= menu_link_with_count(t('reminders.needs.menu.reminder_quo_not_taken_html'), count_needs[:reminder_quo_not_taken], quo_not_taken_reminders_needs_path)
 = menu_link_with_count(t('reminders.needs.menu.reminder_to_recall_html'), count_needs[:reminder_to_recall], to_recall_reminders_needs_path)
 = menu_link_with_count(t('reminders.needs.menu.reminder_institutions_html'), count_needs[:reminder_institutions], institutions_reminders_needs_path)
 = menu_link_with_count(t('reminders.needs.menu.abandoned_without_taking_care_html'), count_needs[:abandoned_without_taking_care], abandoned_reminders_needs_path)

--- a/app/views/reminders/_menu.html.haml
+++ b/app/views/reminders/_menu.html.haml
@@ -1,6 +1,6 @@
 = menu_link_with_count(t('reminders.needs.menu.reminders_to_poke_html'), count_needs[:reminders_to_poke], to_poke_reminders_needs_path)
 = menu_link_with_count(t('reminders.needs.menu.reminders_to_recall_html'), count_needs[:reminders_to_recall], to_recall_reminders_needs_path)
 = menu_link_with_count(t('reminders.needs.menu.reminders_to_warn_html'), count_needs[:reminders_to_warn], to_warn_reminders_needs_path)
-= menu_link_with_count(t('reminders.needs.menu.abandoned_without_taking_care_html'), count_needs[:abandoned_without_taking_care], abandoned_reminders_needs_path)
+= menu_link_with_count(t('reminders.needs.menu.reminders_to_archive_html'), count_needs[:reminders_to_archive], to_archive_reminders_needs_path)
 .ui.divider
 = active_link_to Expert.model_name.human.pluralize, reminders_experts_path, { class: 'item' }

--- a/app/views/reminders/_menu.html.haml
+++ b/app/views/reminders/_menu.html.haml
@@ -1,6 +1,6 @@
-= active_link_to(t('reminders.needs.menu.reminder_quo_not_taken_html', label: colored_label(count_needs[:reminder_quo_not_taken])), reminders_needs_path, active: ['reminders/needs': :index], class: 'item')
-= active_link_to(t('reminders.needs.menu.reminder_to_recall_html', label: colored_label(count_needs[:reminder_to_recall])), to_recall_reminders_needs_path, active: ['reminders/needs': :to_recall], class: 'item')
-= active_link_to(t('reminders.needs.menu.reminder_institutions_html', label: colored_label(count_needs[:reminder_institutions])), institutions_reminders_needs_path, active: ['reminders/needs': :institutions], class: 'item')
-= active_link_to(t('reminders.needs.menu.abandoned_without_taking_care_html', label: colored_label(count_needs[:abandoned_without_taking_care])), abandoned_reminders_needs_path, active: ['reminders/needs': :abandoned], class: 'item')
+= menu_link_with_count(t('reminders.needs.menu.reminder_quo_not_taken_html'), count_needs[:reminder_quo_not_taken], reminders_needs_path, active: ['reminders/needs': :index])
+= menu_link_with_count(t('reminders.needs.menu.reminder_to_recall_html'), count_needs[:reminder_to_recall], to_recall_reminders_needs_path)
+= menu_link_with_count(t('reminders.needs.menu.reminder_institutions_html'), count_needs[:reminder_institutions], institutions_reminders_needs_path)
+= menu_link_with_count(t('reminders.needs.menu.abandoned_without_taking_care_html'), count_needs[:abandoned_without_taking_care], abandoned_reminders_needs_path)
 .ui.divider
 = active_link_to Expert.model_name.human.pluralize, reminders_experts_path, { class: 'item' }

--- a/app/views/reminders/experts/_header.html.haml
+++ b/app/views/reminders/experts/_header.html.haml
@@ -5,7 +5,7 @@
     = expert
 
 .ui.breadcrumb
-  = link_to t('reminders.index.title'), reminders_needs_path, class: 'section'
+  = link_to t('reminders.index.title'), reminders_path, class: 'section'
   %i.right.chevron.icon.divider
   = link_to Expert.model_name.human.pluralize, reminders_experts_path, class: 'section'
   %i.right.chevron.icon.divider

--- a/app/views/reminders/experts/_menu.html.haml
+++ b/app/views/reminders/experts/_menu.html.haml
@@ -1,4 +1,4 @@
 = active_link_to(t('.summary'), reminders_expert_path(expert), active: ['reminders/experts': :show], class: 'item')
-= active_link_to(t('needs.index.needs_quo_html', label: colored_label(count_expert_needs[:reminders_needs_to_call_back])), needs_reminders_expert_path(expert), class: 'item')
-= active_link_to(t('needs.index.needs_taking_care_html', label: colored_label(count_expert_needs[:needs_taking_care])), needs_taking_care_reminders_expert_path(expert), class: 'item')
-= active_link_to(t('needs.index.needs_others_taking_care_html', label: colored_label(count_expert_needs[:needs_others_taking_care])), needs_taking_care_by_others_reminders_expert_path(expert), class: 'item')
+= menu_link_with_count(t('needs.index.needs_quo_html'), count_expert_needs[:reminders_needs_to_call_back], needs_reminders_expert_path(expert))
+= menu_link_with_count(t('needs.index.needs_taking_care_html'), count_expert_needs[:needs_taking_care], needs_taking_care_reminders_expert_path(expert))
+= menu_link_with_count(t('needs.index.needs_others_taking_care_html'), count_expert_needs[:needs_others_taking_care], needs_taking_care_by_others_reminders_expert_path(expert))

--- a/app/views/solicitations/_menu.html.haml
+++ b/app/views/solicitations/_menu.html.haml
@@ -1,4 +1,4 @@
-= active_link_to(t('.index_html', label: colored_label(count[:without_feedbacks])), solicitations_path, active: [solicitations: :index], class: 'item')
-= active_link_to(t('.in_progress_html', label: colored_label(count[:with_feedbacks])), in_progress_solicitations_path, class: 'item')
+= menu_link_with_count(t('.index_html'), count[:without_feedbacks], solicitations_path, active: [solicitations: :index])
+= menu_link_with_count(t('.in_progress_html'), count[:with_feedbacks], in_progress_solicitations_path)
 = active_link_to(t('.processed'), processed_solicitations_path, class: 'item')
 = active_link_to(t('.canceled'), canceled_solicitations_path, class: 'item')

--- a/config/locales/views.fr.yml
+++ b/config/locales/views.fr.yml
@@ -564,14 +564,14 @@ fr:
       title: Relances
     needs:
       header:
-        abandoned_without_taking_care: Abandonnés
+        reminders_to_archive: Abandonnés
         reminders_to_warn: Institution à prévenir
         reminders_to_poke: À relancer
         reminders_to_recall: À rappeler
       index:
         title: Besoins %{status}
       menu:
-        abandoned_without_taking_care_html: "Abandonnés <i>(J+30 et refusés)</i>"
+        reminders_to_archive_html: "Abandonnés <i>(J+30 et refusés)</i>"
         reminders_to_warn_html: "Prévenir l‘institution <i>(J+21)</i>"
         reminders_to_poke_html: "À relancer <i>(J+7)</i>"
         reminders_to_recall_html: "À rappeler<i>(J+14)</i>"

--- a/config/locales/views.fr.yml
+++ b/config/locales/views.fr.yml
@@ -460,9 +460,9 @@ fr:
       browse_archived_needs: Voir mes demandes archivées
       contact_us_mailto_text: Contactez-nous !
       needs_for_you: 'Ces entreprises ont besoin de vous :'
-      needs_others_taking_care_html: "Pris en charge par d’autres référents"
-      needs_quo_html: "À rappeler <i>(J+14)</i>"
-      needs_taking_care_html: "Pris en charge"
+      needs_others_taking_care_html: Pris en charge par d’autres référents
+      needs_quo_html: À rappeler <i>(J+14)</i>
+      needs_taking_care_html: Pris en charge
       no_needs: Il n’y a aucune demande.
       no_requests_html: "<p>Lorsqu’un chef d'entreprise déposera un besoin relevant de votre champ d’intervention, vous recevrez automatiquement un mail de notification à l’adresse %{email}.</p><p>Un problème ? Une question ? %{mailto_link}</p>"
       no_requests_many_emails_html: "<p>Lorsqu’un chef d’entreprise déposera un besoin relevant de votre champ d’intervention, vous recevrez automatiquement un mail de notification sur les adresses %{emails}.</p><p>Un problème ? Une question ? %{mailto_link}</p>"
@@ -565,16 +565,16 @@ fr:
     needs:
       header:
         reminders_to_archive: Abandonnés
-        reminders_to_warn: Institution à prévenir
         reminders_to_poke: À relancer
         reminders_to_recall: À rappeler
+        reminders_to_warn: Institution à prévenir
       index:
         title: Besoins %{status}
       menu:
-        reminders_to_archive_html: "Abandonnés <i>(J+30 et refusés)</i>"
-        reminders_to_warn_html: "Prévenir l‘institution <i>(J+21)</i>"
-        reminders_to_poke_html: "À relancer <i>(J+7)</i>"
-        reminders_to_recall_html: "À rappeler<i>(J+14)</i>"
+        reminders_to_archive_html: Abandonnés <i>(J+30 et refusés)</i>
+        reminders_to_poke_html: À relancer <i>(J+7)</i>
+        reminders_to_recall_html: À rappeler<i>(J+14)</i>
+        reminders_to_warn_html: Prévenir l‘institution <i>(J+21)</i>
   reminders_actions:
     archive: Archiver
     processed_need: Besoin de l‘entreprise %{company} traité
@@ -595,8 +595,8 @@ fr:
       title: Solicitations
     menu:
       canceled: Annulées
-      in_progress_html: "Relancées"
-      index_html: "À traiter"
+      in_progress_html: Relancées
+      index_html: À traiter
       processed: Traitées
     set_category_content:
       landings: Landings

--- a/config/locales/views.fr.yml
+++ b/config/locales/views.fr.yml
@@ -567,14 +567,14 @@ fr:
         abandoned_without_taking_care: Abandonnés
         reminder_institutions: Institution à prévenir
         reminders_to_poke: À relancer
-        reminder_to_recall: À rappeler
+        reminders_to_recall: À rappeler
       index:
         title: Besoins %{status}
       menu:
         abandoned_without_taking_care_html: "Abandonnés <i>(J+30 et refusés)</i>"
         reminder_institutions_html: "Prévenir l‘institution <i>(J+21)</i>"
         reminders_to_poke_html: "À relancer <i>(J+7)</i>"
-        reminder_to_recall_html: "À rappeler<i>(J+14)</i>"
+        reminders_to_recall_html: "À rappeler<i>(J+14)</i>"
   reminders_actions:
     archive: Archiver
     processed_need: Besoin de l‘entreprise %{company} traité

--- a/config/locales/views.fr.yml
+++ b/config/locales/views.fr.yml
@@ -566,14 +566,14 @@ fr:
       header:
         abandoned_without_taking_care: Abandonnés
         reminder_institutions: Institution à prévenir
-        reminder_quo_not_taken: À relancer
+        reminders_to_poke: À relancer
         reminder_to_recall: À rappeler
       index:
         title: Besoins %{status}
       menu:
         abandoned_without_taking_care_html: "Abandonnés <i>(J+30 et refusés)</i>"
         reminder_institutions_html: "Prévenir l‘institution <i>(J+21)</i>"
-        reminder_quo_not_taken_html: "À relancer <i>(J+7)</i>"
+        reminders_to_poke_html: "À relancer <i>(J+7)</i>"
         reminder_to_recall_html: "À rappeler<i>(J+14)</i>"
   reminders_actions:
     archive: Archiver

--- a/config/locales/views.fr.yml
+++ b/config/locales/views.fr.yml
@@ -460,9 +460,9 @@ fr:
       browse_archived_needs: Voir mes demandes archivées
       contact_us_mailto_text: Contactez-nous !
       needs_for_you: 'Ces entreprises ont besoin de vous :'
-      needs_others_taking_care_html: "%{label} Pris en charge par d’autres référents"
-      needs_quo_html: "%{label} À rappeler <i>(J+14)</i>"
-      needs_taking_care_html: "%{label} Pris en charge"
+      needs_others_taking_care_html: "Pris en charge par d’autres référents"
+      needs_quo_html: "À rappeler <i>(J+14)</i>"
+      needs_taking_care_html: "Pris en charge"
       no_needs: Il n’y a aucune demande.
       no_requests_html: "<p>Lorsqu’un chef d'entreprise déposera un besoin relevant de votre champ d’intervention, vous recevrez automatiquement un mail de notification à l’adresse %{email}.</p><p>Un problème ? Une question ? %{mailto_link}</p>"
       no_requests_many_emails_html: "<p>Lorsqu’un chef d’entreprise déposera un besoin relevant de votre champ d’intervention, vous recevrez automatiquement un mail de notification sur les adresses %{emails}.</p><p>Un problème ? Une question ? %{mailto_link}</p>"
@@ -571,10 +571,10 @@ fr:
       index:
         title: Besoins %{status}
       menu:
-        abandoned_without_taking_care_html: "%{label} Abandonnés <i>(J+30 et refusés)</i>"
-        reminder_institutions_html: "%{label} Prévenir l‘institution <i>(J+21)</i>"
-        reminder_quo_not_taken_html: "%{label} À relancer <i>(J+7)</i>"
-        reminder_to_recall_html: "%{label} À rappeler<i>(J+14)</i>"
+        abandoned_without_taking_care_html: "Abandonnés <i>(J+30 et refusés)</i>"
+        reminder_institutions_html: "Prévenir l‘institution <i>(J+21)</i>"
+        reminder_quo_not_taken_html: "À relancer <i>(J+7)</i>"
+        reminder_to_recall_html: "À rappeler<i>(J+14)</i>"
   reminders_actions:
     archive: Archiver
     processed_need: Besoin de l‘entreprise %{company} traité
@@ -595,8 +595,8 @@ fr:
       title: Solicitations
     menu:
       canceled: Annulées
-      in_progress_html: "%{label} Relancées"
-      index_html: "%{label} À traiter"
+      in_progress_html: "Relancées"
+      index_html: "À traiter"
       processed: Traitées
     set_category_content:
       landings: Landings

--- a/config/locales/views.fr.yml
+++ b/config/locales/views.fr.yml
@@ -565,14 +565,14 @@ fr:
     needs:
       header:
         abandoned_without_taking_care: Abandonnés
-        reminder_institutions: Institution à prévenir
+        reminders_to_warn: Institution à prévenir
         reminders_to_poke: À relancer
         reminders_to_recall: À rappeler
       index:
         title: Besoins %{status}
       menu:
         abandoned_without_taking_care_html: "Abandonnés <i>(J+30 et refusés)</i>"
-        reminder_institutions_html: "Prévenir l‘institution <i>(J+21)</i>"
+        reminders_to_warn_html: "Prévenir l‘institution <i>(J+21)</i>"
         reminders_to_poke_html: "À relancer <i>(J+7)</i>"
         reminders_to_recall_html: "À rappeler<i>(J+14)</i>"
   reminders_actions:

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -188,7 +188,7 @@ Rails.application.routes.draw do
     end
     resources :needs, path: 'besoins', only: %i[index] do
       collection do
-        get :quo_not_taken, path: 'a-relancer'
+        get :to_poke, path: 'a-relancer'
         get :to_recall, path: 'a-rappeler'
         get :institutions, path: 'institutions_a_prevenir'
         get :abandoned, path: 'abandonnes'

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -176,6 +176,8 @@ Rails.application.routes.draw do
   end
 
   namespace :reminders, path: 'relances' do
+    get '/', to: redirect('/relances/besoins')
+
     resources :experts, only: %i[index show], path: 'referents' do
       member do
         post :reminders_notes

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -190,7 +190,7 @@ Rails.application.routes.draw do
       collection do
         get :to_poke, path: 'a-relancer'
         get :to_recall, path: 'a-rappeler'
-        get :institutions, path: 'institutions_a_prevenir'
+        get :to_warn, path: 'institution-a-prevenir'
         get :abandoned, path: 'abandonnes'
       end
     end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -186,6 +186,7 @@ Rails.application.routes.draw do
     end
     resources :needs, path: 'besoins', only: %i[index] do
       collection do
+        get :quo_not_taken, path: 'a-relancer'
         get :to_recall, path: 'a-rappeler'
         get :institutions, path: 'institutions_a_prevenir'
         get :abandoned, path: 'abandonnes'

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -191,7 +191,7 @@ Rails.application.routes.draw do
         get :to_poke, path: 'a-relancer'
         get :to_recall, path: 'a-rappeler'
         get :to_warn, path: 'institution-a-prevenir'
-        get :abandoned, path: 'abandonnes'
+        get :to_archive, path: 'abandonnes'
       end
     end
   end

--- a/spec/models/need_spec.rb
+++ b/spec/models/need_spec.rb
@@ -525,7 +525,7 @@ RSpec.describe Need, type: :model do
         end
 
         it 'retourne les besoins dans la bonne période' do
-          expect(described_class.reminder_institutions).to match_array [need2, need3]
+          expect(described_class.reminders_to_warn).to match_array [need2, need3]
         end
       end
 
@@ -553,7 +553,7 @@ RSpec.describe Need, type: :model do
         let!(:reminders_action8) { create :reminders_action, category: :warn, need: need6 }
 
         it 'retourne les besoins sans Reminder Action' do
-          expect(described_class.reminder_institutions).to match_array [need1, need2]
+          expect(described_class.reminders_to_warn).to match_array [need1, need2]
         end
       end
     end

--- a/spec/models/need_spec.rb
+++ b/spec/models/need_spec.rb
@@ -575,7 +575,7 @@ RSpec.describe Need, type: :model do
         let!(:need3) { travel_to(reference_date - 100.days) { create :need_with_matches } }
 
         it 'retourne les besoins dans la bonne période' do
-          expect(described_class.abandoned_without_taking_care).to match_array [need2, need3]
+          expect(described_class.reminders_to_archive).to match_array [need2, need3]
         end
       end
 
@@ -596,7 +596,7 @@ RSpec.describe Need, type: :model do
         let!(:need4_match) { travel_to(thirty_days_ago) { create :match, need: need4, status: :taking_care } }
 
         it 'retourne les besoins non archivés' do
-          expect(described_class.abandoned_without_taking_care).to eq [need1]
+          expect(described_class.reminders_to_archive).to eq [need1]
         end
       end
 
@@ -626,7 +626,7 @@ RSpec.describe Need, type: :model do
         end
 
         it 'retourne les besoins avec certaines relations' do
-          expect(described_class.abandoned_without_taking_care).to match_array [need1, need4]
+          expect(described_class.reminders_to_archive).to match_array [need1, need4]
         end
       end
     end

--- a/spec/models/need_spec.rb
+++ b/spec/models/need_spec.rb
@@ -656,7 +656,7 @@ RSpec.describe Need, type: :model do
         old_need
       end
 
-      subject { described_class.reminder }
+      subject { described_class.in_reminders_range(:poke) }
 
       it 'expect to have needs between 10 and 30 days' do
         is_expected.to eq [mid_need]

--- a/spec/models/need_spec.rb
+++ b/spec/models/need_spec.rb
@@ -448,7 +448,7 @@ RSpec.describe Need, type: :model do
         end
 
         it 'retourne les besoins dans la bonne période' do
-          expect(described_class.reminder_to_recall).to match_array [need2, need3]
+          expect(described_class.reminders_to_recall).to match_array [need2, need3]
         end
       end
 
@@ -475,7 +475,7 @@ RSpec.describe Need, type: :model do
         let!(:reminders_action7) { create :reminders_action, category: :recall, need: need6 }
 
         it 'retourne les besoins sans Reminder Action' do
-          expect(described_class.reminder_to_recall).to match_array [need1, need2]
+          expect(described_class.reminders_to_recall).to match_array [need1, need2]
         end
       end
 
@@ -500,7 +500,7 @@ RSpec.describe Need, type: :model do
         end
 
         it 'retourne les besoins avec certains status' do
-          expect(described_class.reminder_to_recall).to match_array [need1, need2, need3]
+          expect(described_class.reminders_to_recall).to match_array [need1, need2, need3]
         end
       end
     end

--- a/spec/models/need_spec.rb
+++ b/spec/models/need_spec.rb
@@ -229,7 +229,7 @@ RSpec.describe Need, type: :model do
       it { expect(described_class.no_help_provided).to match_array [need1, need2, need6, need7] }
     end
 
-    describe 'exclude_needs_with_reminders_action' do
+    describe 'without_action' do
       # Exclue les besoins qui ont des reminders_action d'une catégorie en particulier
       # 1- besoin sans reminders_action
       # 2- besoin avec une action poke
@@ -253,17 +253,17 @@ RSpec.describe Need, type: :model do
       let!(:reminders_action6_2) { create :reminders_action, category: :recall, need: need6 }
 
       it 'expect to have needs without poke action' do
-        expect(described_class.left_outer_joins(:reminders_actions).exclude_needs_with_reminders_action(:poke))
+        expect(described_class.without_action(:poke))
           .to match_array [need1, need3, need5, need6]
       end
 
       it 'expect to have needs without recall action' do
-        expect(described_class.left_outer_joins(:reminders_actions).exclude_needs_with_reminders_action(:recall))
+        expect(described_class.without_action(:recall))
           .to match_array [need1, need2, need5]
       end
 
       it 'expect to have needs without warn action' do
-        expect(described_class.left_outer_joins(:reminders_actions).exclude_needs_with_reminders_action(:warn))
+        expect(described_class.without_action(:warn))
           .to match_array [need1, need2, need3, need4]
       end
     end

--- a/spec/models/need_spec.rb
+++ b/spec/models/need_spec.rb
@@ -359,7 +359,7 @@ RSpec.describe Need, type: :model do
         end
 
         it 'retourne les besoins dans la bonne période' do
-          expect(described_class.reminder_quo_not_taken).to match_array [need2, need3]
+          expect(described_class.reminders_to_poke).to match_array [need2, need3]
         end
       end
 
@@ -389,7 +389,7 @@ RSpec.describe Need, type: :model do
         end
 
         it 'retourne les besoins sans Reminder Action' do
-          expect(described_class.reminder_quo_not_taken).to eq [need1]
+          expect(described_class.reminders_to_poke).to eq [need1]
         end
       end
 
@@ -418,7 +418,7 @@ RSpec.describe Need, type: :model do
         end
 
         it 'retourne les besoins avec certaines relations' do
-          expect(described_class.reminder_quo_not_taken).to match_array [need1, need2, need3, need4]
+          expect(described_class.reminders_to_poke).to match_array [need1, need2, need3, need4]
         end
       end
     end


### PR DESCRIPTION
C’est un peu gros, mais ça se lit bien commit par commit. Il y a plusieurs points pour #1323 et #1367:

* tweaks de UI (en principe, ce sont les seuls changements visibles)
  * ajouts de redirections (de /relance vers /relances/besoins, principalement) et d’une route spécifique pour “to_poke” plutôt que d’utiliser :index.
* ajout d’un helper `menu_link_with_count`
* nettoyage des actions, des routes et des scopes pour coller aux noms des reminder_actions (poke, call, warn et archive)
* refactor des scopes et des délais par panier

Ça ne prend pas en compte toutes mes questions encore en cours sur need.status. À suivre :)