### PR TITLE
🧹 Fix the priority for done_no_help and done_not_reachable

### DIFF
--- a/app/models/need.rb
+++ b/app/models/need.rb
@@ -254,6 +254,10 @@ class Need < ApplicationRecord
     # at least one match done:
     elsif matches_status.include?(:done)
       result = :done
+    elsif matches_status.include?(:done_no_help)
+      result = :done_no_help
+    elsif matches_status.include?(:done_not_reachable)
+      result = :done_not_reachable
 
     # at least one match not closed
     elsif matches_status.include?(:taking_care)
@@ -261,11 +265,7 @@ class Need < ApplicationRecord
     elsif matches_status.include?(:quo)
       result = :quo
 
-    # all matches closed
-    elsif matches_status.include?(:done_no_help)
-      result = :done_no_help
-    elsif matches_status.include?(:done_not_reachable)
-      result = :done_not_reachable
+    # all matches rejected
     else
       result = :not_for_me
     end

--- a/spec/models/need_spec.rb
+++ b/spec/models/need_spec.rb
@@ -67,7 +67,6 @@ RSpec.describe Need, type: :model do
     context 'diagnosis complete' do
       rules = {
         %i[quo quo] => 'quo',
-        %i[quo done_not_reachable not_for_me] => 'quo',
         %i[quo not_for_me] => 'quo',
         %i[quo taking_care] => 'taking_care',
         %i[quo taking_care not_for_me] => 'taking_care',
@@ -75,8 +74,10 @@ RSpec.describe Need, type: :model do
         %i[quo taking_care not_for_me done] => 'done',
         %i[done done_no_help] => 'done',
         %i[done done_not_reachable done_no_help] => 'done',
+        %i[quo done_no_help] => 'done_no_help',
+        %i[taking_care done_no_help] => 'done_no_help',
         %i[done_not_reachable done_no_help] => 'done_no_help',
-        %i[done_not_reachable not_for_me] => 'done_not_reachable',
+        %i[quo done_not_reachable not_for_me] => 'done_not_reachable',
         %i[not_for_me not_for_me] => 'not_for_me',
       }
       rules.each do |matches_statuses, need_status|


### PR DESCRIPTION
Fixup for #1427. If at least one match is done_no_help or done_not_reachable, the status should reflect it.

⚠️ 🧹The rake task needs to be run in production after deployment.
```
rake update_needs_status
```