### PR TITLE
Remove old unused params

### DIFF
--- a/app/assets/stylesheets/application/needs.sass
+++ b/app/assets/stylesheets/application/needs.sass
@@ -11,10 +11,6 @@
     .right
       margin-left: 1rem
 
-  .expert-highlighted
-    padding: 0 0.2em
-    background: #ffe6c9
-
   .match-summary
     float: left
     .menu

--- a/app/controllers/needs_controller.rb
+++ b/app/controllers/needs_controller.rb
@@ -96,8 +96,6 @@ class NeedsController < ApplicationController
       # let diagnoses_controller (and steps_controller) handle incomplete diagnoses
       redirect_to @diagnosis and return
     end
-
-    @highlighted_experts = highlighted_experts
   end
 
   def additional_experts
@@ -143,14 +141,6 @@ class NeedsController < ApplicationController
   end
 
   private
-
-  def highlighted_experts
-    begin
-      [Expert.find(params.require(:highlighted_expert))]
-    rescue
-      []
-    end
-  end
 
   def retrieve_diagnosis
     Diagnosis.find(params.require(:id))

--- a/app/views/diagnoses/_diagnoses.haml
+++ b/app/views/diagnoses/_diagnoses.haml
@@ -1,2 +1,2 @@
 .ui.segments.shadow-less.selectable-list
-  = render partial: 'diagnoses/diagnosis', collection: diagnoses, locals: { highlighted_expert: local_assigns[:highlighted_expert] }, cached: true
+  = render partial: 'diagnoses/diagnosis', collection: diagnoses, cached: true

--- a/app/views/diagnoses/_diagnoses.haml
+++ b/app/views/diagnoses/_diagnoses.haml
@@ -1,3 +1,2 @@
 .ui.segments.shadow-less.selectable-list
-  = render partial: 'diagnoses/diagnosis', collection: diagnoses, locals: { needs_of_interest: local_assigns[:needs_of_interest],
-    highlighted_expert: local_assigns[:highlighted_expert] }, cached: true
+  = render partial: 'diagnoses/diagnosis', collection: diagnoses, locals: { highlighted_expert: local_assigns[:highlighted_expert] }, cached: true

--- a/app/views/diagnoses/_diagnosis.haml
+++ b/app/views/diagnoses/_diagnosis.haml
@@ -1,6 +1,6 @@
 - cache diagnosis do
   .ui.segment.selectable-item
-    - path = diagnosis.step_completed? ? need_path(diagnosis, highlighted_expert: local_assigns[:highlighted_expert]) : diagnosis_path(diagnosis)
+    - path = diagnosis.step_completed? ? need_path(diagnosis) : diagnosis_path(diagnosis)
     %a{ href: path }
       %h3.ui.header
         .sub.header= I18n.l(diagnosis.display_date, format: :long)

--- a/app/views/diagnoses/_diagnosis.haml
+++ b/app/views/diagnoses/_diagnosis.haml
@@ -11,11 +11,10 @@
         .sub.header= diagnosis.facility.commune_name
       - if diagnosis.step_completed?
         - diagnosis.needs.each do |need|
-          - if needs_of_interest.blank? || needs_of_interest.include?(need)
-            %h4.ui.header
-              = need.subject
-              .sub.header
-                = need.matches.human_count
-                - if need.abandoned?
-                  .ui.label.basic.orange= t('.last_activity_date', l: l(need.updated_at.to_date, format: :long))
+          %h4.ui.header
+            = need.subject
+            .sub.header
+              = need.matches.human_count
+              - if need.abandoned?
+                .ui.label.basic.orange= t('.last_activity_date', l: l(need.updated_at.to_date, format: :long))
       = render 'diagnoses/archive_action', diagnosis: diagnosis

--- a/app/views/diagnoses/index.haml
+++ b/app/views/diagnoses/index.haml
@@ -24,7 +24,6 @@
 = paginate @diagnoses
 
 .ui.segments.shadow-less.selectable-list
-  = render partial: 'diagnosis', collection: @diagnoses, locals: { needs_of_interest: local_assigns[:needs_of_interest],
-    highlighted_expert: local_assigns[:highlighted_expert] }, cached: true
+  = render partial: 'diagnosis', collection: @diagnoses, locals: { highlighted_expert: local_assigns[:highlighted_expert] }, cached: true
 
 = paginate @diagnoses

--- a/app/views/diagnoses/index.haml
+++ b/app/views/diagnoses/index.haml
@@ -24,6 +24,6 @@
 = paginate @diagnoses
 
 .ui.segments.shadow-less.selectable-list
-  = render partial: 'diagnosis', collection: @diagnoses, locals: { highlighted_expert: local_assigns[:highlighted_expert] }, cached: true
+  = render partial: 'diagnosis', collection: @diagnoses, cached: true
 
 = paginate @diagnoses

--- a/app/views/diagnoses/index_antenne.haml
+++ b/app/views/diagnoses/index_antenne.haml
@@ -17,6 +17,6 @@
 = paginate @diagnoses
 
 .ui.segments.shadow-less.selectable-list
-  = render partial: 'diagnosis', collection: @diagnoses, locals: { highlighted_expert: local_assigns[:highlighted_expert] }, cached: true
+  = render partial: 'diagnosis', collection: @diagnoses, cached: true
 
 = paginate @diagnoses

--- a/app/views/diagnoses/index_antenne.haml
+++ b/app/views/diagnoses/index_antenne.haml
@@ -17,7 +17,6 @@
 = paginate @diagnoses
 
 .ui.segments.shadow-less.selectable-list
-  = render partial: 'diagnosis', collection: @diagnoses, locals: { needs_of_interest: local_assigns[:needs_of_interest],
-    highlighted_expert: local_assigns[:highlighted_expert] }, cached: true
+  = render partial: 'diagnosis', collection: @diagnoses, locals: { highlighted_expert: local_assigns[:highlighted_expert] }, cached: true
 
 = paginate @diagnoses

--- a/app/views/feedbacks/_feedback.haml
+++ b/app/views/feedbacks/_feedback.haml
@@ -1,7 +1,5 @@
 :ruby
   for_me = policy(feedback).creator?
-  highlighted_experts = highlighted_experts || []
-  highlight = feedback.user.in? highlighted_experts
 
 .event{ id: "feedback-#{feedback.id}" }
   .label
@@ -9,7 +7,7 @@
       %i.comment.outline.icon{ class: ('blue' if for_me) }
   .content
     .summary
-      .user.popup-hover{ class: ('expert-highlighted' if highlight) }
+      .user.popup-hover
         = feedback.user.full_name
       .ui.popup= person_block(feedback.user)
       .date= I18n.l(feedback.created_at, format: :long)

--- a/app/views/feedbacks/create.js.haml
+++ b/app/views/feedbacks/create.js.haml
@@ -1,4 +1,4 @@
-- feedback_html = render 'feedbacks/feedback', feedback: @feedback, highlighted_experts: []
+- feedback_html = render 'feedbacks/feedback', feedback: @feedback
 document.getElementById('feedback-form-#{@feedback.feedbackable_id}').insertAdjacentHTML('beforebegin', "#{j feedback_html}");
 
 document.querySelector('#feedback-form-#{@feedback.feedbackable_id} .form').reset()

--- a/app/views/matches/_match.haml
+++ b/app/views/matches/_match.haml
@@ -1,5 +1,4 @@
 - for_me = match.in?(current_user.received_matches)
-- highlight = match.expert.in? highlighted_experts
 .event{ id: "match-#{match.id}" }
   .label
     %a{ href: "#match-#{match.id}", data: { turbolinks: 'false' } }
@@ -16,7 +15,7 @@
       - else
         = t('.match_with')
     .summary
-      .user.popup-hover{ class: ('expert-highlighted' if highlight) }
+      .user.popup-hover
         #{match.expert.full_name} - #{match.expert.antenne.name}
       .ui.popup= person_block(match.expert)
     - if match.need.not_archived?

--- a/app/views/matches/update.js.haml
+++ b/app/views/matches/update.js.haml
@@ -1,4 +1,4 @@
-- match_html = render @match, highlighted_experts: []
+- match_html = render @match
 document.getElementById('match-#{@match.id}').outerHTML = "#{j match_html}";
 
 - need_header_html = render 'needs/need_header', need: @match.need

--- a/app/views/needs/_need.haml
+++ b/app/views/needs/_need.haml
@@ -2,10 +2,10 @@
   = render 'need_header', need: need
 
   .ui.feed
-    = render 'need_content', need: need, highlighted_experts: highlighted_experts
-    = render need.feedbacks.order(:created_at), highlighted_experts: highlighted_experts
+    = render 'need_content'
+    = render need.feedbacks.order(:created_at)
     = render 'feedbacks/form', feedback: need.feedbacks.new(category: :need)
-    = render need.matches.order(:created_at), highlighted_experts: highlighted_experts
+    = render need.matches.order(:created_at)
     = render 'additional_experts', need: need
     - if current_user.is_admin?
       = render 'archive', need: need

--- a/app/views/needs/_need_content.haml
+++ b/app/views/needs/_need_content.haml
@@ -1,14 +1,13 @@
 - return if need.content.empty?
 
 - for_me = need.advisor == current_user
-- highlight = need.advisor.in? highlighted_experts
 .event{ id: "need_content-#{need.id}" }
   .label
     %a{ href: "#need_content-#{need.id}", data: { turbolinks: 'false' } }
       %i.comment.outline.icon{ class: ('blue' if for_me) }
   .content
     .summary
-      .user.popup-hover{ class: ('expert-highlighted' if highlight) }
+      .user.popup-hover
         = need.advisor.full_name
       .ui.popup= person_block(need.advisor)
       .date= I18n.l(need.diagnosis.completed_at, format: :long)

--- a/app/views/needs/_received_needs.haml
+++ b/app/views/needs/_received_needs.haml
@@ -2,6 +2,6 @@
 = paginate received_needs
 
 .ui.segments.shadow-less.selectable-list
-  = render partial: 'diagnoses/diagnosis', collection: diagnoses, locals: { highlighted_expert: local_assigns[:highlighted_expert] }, cached: true
+  = render partial: 'diagnoses/diagnosis', collection: diagnoses, cached: true
 
 = paginate received_needs

--- a/app/views/needs/_received_needs.haml
+++ b/app/views/needs/_received_needs.haml
@@ -2,7 +2,6 @@
 = paginate received_needs
 
 .ui.segments.shadow-less.selectable-list
-  = render partial: 'diagnoses/diagnosis', collection: diagnoses, locals: { needs_of_interest: received_needs,
-    highlighted_expert: local_assigns[:highlighted_expert] }, cached: true
+  = render partial: 'diagnoses/diagnosis', collection: diagnoses, locals: { highlighted_expert: local_assigns[:highlighted_expert] }, cached: true
 
 = paginate received_needs

--- a/app/views/needs/add_match.js.haml
+++ b/app/views/needs/add_match.js.haml
@@ -1,4 +1,4 @@
-- match_html = render @match, highlighted_experts: []
+- match_html = render @match
 document.getElementById('additional_experts-#{@need.id}').insertAdjacentHTML('beforebegin', "#{j match_html}");
 
 - html = render 'additional_experts', need: @need

--- a/app/views/needs/show.haml
+++ b/app/views/needs/show.haml
@@ -2,4 +2,4 @@
 
 = render 'visit_summary', diagnosis: @diagnosis
 
-= render @diagnosis.needs.ordered_for_interview, highlighted_experts: @highlighted_experts
+= render @diagnosis.needs.ordered_for_interview

--- a/app/views/reminders/_diagnosis.haml
+++ b/app/views/reminders/_diagnosis.haml
@@ -8,27 +8,26 @@
   .ui.segment.needs
     - if diagnosis.step_completed?
       - diagnosis.needs.each do |need|
-        - if needs_of_interest.blank? || needs_of_interest.include?(need)
-          %h3.ui.header
-            %span
-              = need.subject
-              .sub.header
-                = need.matches.human_count
-                - if need.abandoned?
-                  .ui.label.basic.orange= t('diagnoses.diagnosis.last_activity_date', l: l(need.updated_at.to_date, format: :long))
-            - if action.present?
-              = link_to t(action, scope: 'reminders.needs.scopes.mark_done'), polymorphic_path([action, :reminders_action], { id: need.id }),
-                method: :post, class: "ui button #{action == :archive ? 'red' : 'green'}"
+        %h3.ui.header
+          %span
+            = need.subject
+            .sub.header
+              = need.matches.human_count
+              - if need.abandoned?
+                .ui.label.basic.orange= t('diagnoses.diagnosis.last_activity_date', l: l(need.updated_at.to_date, format: :long))
+          - if action.present?
+            = link_to t(action, scope: 'reminders.needs.scopes.mark_done'), polymorphic_path([action, :reminders_action], { id: need.id }),
+              method: :post, class: "ui button #{action == :archive ? 'red' : 'green'}"
 
-          .ui.list
-            - need.matches.each do |match|
-              .item
-                ⁃ #{match.expert.antenne.to_s}
+        .ui.list
+          - need.matches.each do |match|
+            .item
+              ⁃ #{match.expert.antenne.to_s}
 
-          .ui.feed.feedbacks
-            = render partial: 'feedbacks/feedback', collection: need.reminder_feedbacks
-            = render 'feedbacks/form', feedback: need.reminder_feedbacks.new
+        .ui.feed.feedbacks
+          = render partial: 'feedbacks/feedback', collection: need.reminder_feedbacks
+          = render 'feedbacks/form', feedback: need.reminder_feedbacks.new
 
-          .item.show-feedbacks-form{ 'data-feedbackable': "#{need.id}" }
-            %button.mini.ui.button
-              = t('feedbacks.add')
+        .item.show-feedbacks-form{ 'data-feedbackable': "#{need.id}" }
+          %button.mini.ui.button
+            = t('feedbacks.add')

--- a/app/views/reminders/_needs.html.haml
+++ b/app/views/reminders/_needs.html.haml
@@ -3,6 +3,6 @@
 
 = paginate received_needs
 
-= render partial: 'reminders/diagnosis', collection: diagnoses, locals: { needs_of_interest: received_needs, action: action }, cached: true
+= render partial: 'reminders/diagnosis', collection: diagnoses, locals: { action: action }, cached: true
 
 = paginate received_needs


### PR DESCRIPTION
2ème partie de #1367. Sauf erreur, on a plus utilisé `highlighted_experts` et `needs_of_interest` depuis le redesign de la page /relances, voire déjà avant.

* [ ] ⚠️ merge #1469 first