### PR TITLE
Remove count false for CompaniesByEmployeesStats

### DIFF
--- a/app/services/stats/companies_by_employees_stats.rb
+++ b/app/services/stats/companies_by_employees_stats.rb
@@ -68,10 +68,6 @@ module Stats
       %w[#dddddd #9f3cca #F45A5B #e78112 #f3dd68 #2D908F #62e0d3]
     end
 
-    def count
-      false
-    end
-
     def format
       '{series.name} : <b>{point.percentage:.0f}%</b>'
     end


### PR DESCRIPTION
@LucienMLD 

Il y avait un problème d'affichage dans les mini-stats (j'en parle dans la revue de ta derniere PR stats, mais j'ai découvert que le bug était déjà présent avant ça.

![Screenshot from 2020-12-30 10-45-07](https://user-images.githubusercontent.com/2668217/103343394-41845300-4a8c-11eb-9a45-5677cf951c9c.png)

Pour le corriger, j'ai enlevé un bout de code, vérifié que les stats publiques continuent bien de s'afficher et que les tests pêtent pas. 
Je te laisse vérifier (j'ai aucune idée d'à quoi ce bout de code servait, donc j'espère pas avoir commis d'impair)