### PR TITLE
cache le filtre sollicitation pour les non admin (encore)

### DIFF
--- a/app/views/stats/_stats_params.haml
+++ b/app/views/stats/_stats_params.haml
@@ -7,7 +7,7 @@
         = select_tag(:territory,
           options_from_collection_for_select(Territory.regions.order(:name), :id, :name, stats.params.territory),
           options.dup)
-      - if current_user.present? && policy(Stats::All).team?
+      - if current_user.present? && current_user.is_admin?
         .form__group
           = label_tag(t('activerecord.models.institution.one'))
           = select_tag(:institution,


### PR DESCRIPTION
Manifestement il y avait des bugs d'utilisateurs qui voyaient le filtre institution. J'ai essayé de faire des tests de vues en essayant de passer le current_user pendant 1h sans succès. je me suis dit que `current_user.is_admin?` ça fonctionnera à tout les coups