### PR TITLE
Correction bug sib compant mailer

### DIFF
--- a/app/services/company_mailer_service.rb
+++ b/app/services/company_mailer_service.rb
@@ -20,10 +20,11 @@ class CompanyMailerService
       .min_closed_at(13.days.ago..12.days.ago)
       .not_newsletter_subscription_email_sent
     api_instance = SibApiV3Sdk::ContactsApi.new
+    list_contacts = api_instance.get_contacts_from_list(ENV['SENDINBLUE_NEWSLETTER_ID'].to_i)
+    list_emails = list_contacts.contacts.pluck(:email)
     diagnoses.each do |diagnosis|
       begin
-        contact = api_instance.get_contact_info(diagnosis.visitee.email)
-        CompanyMailer.newsletter_subscription(diagnosis).deliver_later unless contact.list_ids&.include?(ENV['SENDINBLUE_NEWSLETTER_ID'].to_i)
+        CompanyMailer.newsletter_subscription(diagnosis).deliver_later unless list_emails.include?(diagnosis.visitee.email)
         diagnosis.update(newsletter_subscription_email_sent: true)
       rescue SibApiV3Sdk::ApiError => e
         Raven.tags_context(email: diagnosis.visitee.email) do


### PR DESCRIPTION
Il y avait un soucis avec la méthode utilisée pour repérer si un contact était présent dans une liste de contacts sendinblue. 
Avec la nouvelle méthode ça devrait aller mieux
closes #1504 