### PR TITLE
Cleanup diagnosis creation

### DIFF
--- a/app/models/concerns/diagnosis_creation.rb
+++ b/app/models/concerns/diagnosis_creation.rb
@@ -169,12 +169,12 @@ module DiagnosisCreation
       self
     end
   end
-end
 
-def get_solicitation_description(params)
-  if params[:solicitation].present?
-    params[:solicitation].description
-  elsif params[:solicitation_id].present?
-    Solicitation.find(params[:solicitation_id])&.description
+  def self.get_solicitation_description(params)
+    if params[:solicitation].present?
+      params[:solicitation].description
+    elsif params[:solicitation_id].present?
+      Solicitation.find(params[:solicitation_id])&.description
+    end
   end
 end


### PR DESCRIPTION
* Move get_solicitation_description inside the module
* prepare matches without preselected institutions. The condition was added in #1375, I’m not exactly sure why; anyway, this is supposed to fail if no match is found. 🤷 