### PR TITLE
Fragment caching improvements

### DIFF
--- a/app/models/antenne.rb
+++ b/app/models/antenne.rb
@@ -14,6 +14,7 @@
 #  index_antennes_on_deleted_at               (deleted_at)
 #  index_antennes_on_institution_id           (institution_id)
 #  index_antennes_on_name_and_institution_id  (name,institution_id) UNIQUE
+#  index_antennes_on_updated_at               (updated_at)
 #
 # Foreign Keys
 #

--- a/app/models/institution.rb
+++ b/app/models/institution.rb
@@ -15,9 +15,10 @@
 # Indexes
 #
 #  index_institutions_on_code_region  (code_region)
-#  index_institutions_on_deleted_at   (deleted_at)
-#  index_institutions_on_name         (name) UNIQUE
-#  index_institutions_on_slug         (slug) UNIQUE
+#  index_institutions_on_deleted_at  (deleted_at)
+#  index_institutions_on_name        (name) UNIQUE
+#  index_institutions_on_slug        (slug) UNIQUE
+#  index_institutions_on_updated_at  (updated_at)
 #
 
 class Institution < ApplicationRecord

--- a/app/models/institution_subject.rb
+++ b/app/models/institution_subject.rb
@@ -13,6 +13,7 @@
 #
 #  index_institutions_subjects_on_institution_id  (institution_id)
 #  index_institutions_subjects_on_subject_id      (subject_id)
+#  index_institutions_subjects_on_updated_at      (updated_at)
 #  unique_institution_subject_in_institution      (subject_id,institution_id,description) UNIQUE
 #
 # Foreign Keys

--- a/app/models/theme.rb
+++ b/app/models/theme.rb
@@ -12,6 +12,7 @@
 #
 #  index_themes_on_interview_sort_order  (interview_sort_order)
 #  index_themes_on_label                 (label) UNIQUE
+#  index_themes_on_updated_at            (updated_at)
 #
 
 class Theme < ApplicationRecord

--- a/app/views/application/_navbar.html.haml
+++ b/app/views/application/_navbar.html.haml
@@ -7,8 +7,9 @@
         = active_link_to needs_path, class: 'item' do
           %i.inbox.icon
           = t('needs.index.title')
-          - if current_user.needs_quo.exists?
-            .ui.orange.empty.circular.horizontal.label
+          - cache([current_user, Need.all]) do
+            - if current_user.needs_quo.exists?
+              .ui.orange.empty.circular.horizontal.label
       - if policy(Diagnosis).index?
         = active_link_to diagnoses_path, class: 'item' do
           %i.tasks.icon

--- a/app/views/solicitations/index.html.haml
+++ b/app/views/solicitations/index.html.haml
@@ -27,9 +27,8 @@
 
 = paginate @solicitations
 
-- max_badge_updated_at = Badge.maximum(:updated_at)
 - if @solicitations.present?
-  = render(partial: 'solicitations/solicitation', collection: @solicitations, cached: -> (solicitation) { [solicitation, max_badge_updated_at] })
+  = render(partial: 'solicitations/solicitation', collection: @solicitations, cached: -> (solicitation) { [solicitation, Badge.all] })
 - elsif params[:query].present?
   .ui.divider.hidden
   = t('.no_result')

--- a/db/migrate/20210125130337_add_index_to_updated_at_for_cache_keys.rb
+++ b/db/migrate/20210125130337_add_index_to_updated_at_for_cache_keys.rb
@@ -1,0 +1,8 @@
+class AddIndexToUpdatedAtForCacheKeys < ActiveRecord::Migration[6.0]
+  def change
+    add_index :institutions, :updated_at
+    add_index :institutions_subjects, :updated_at
+    add_index :themes, :updated_at
+    add_index :antennes, :updated_at
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -2,15 +2,15 @@
 # of editing this file, please use the migrations feature of Active Record to
 # incrementally modify your database, and then regenerate this schema definition.
 #
-# This file is the source Rails uses to define your schema when running `rails
-# db:schema:load`. When creating a new database, `rails db:schema:load` tends to
+# This file is the source Rails uses to define your schema when running `bin/rails
+# db:schema:load`. When creating a new database, `bin/rails db:schema:load` tends to
 # be faster and is potentially less error prone than running all of your
 # migrations from scratch. Old migrations may fail to apply correctly if those
 # migrations use external dependencies or application code.
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2021_01_18_143631) do
+ActiveRecord::Schema.define(version: 2021_01_25_130337) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -55,6 +55,7 @@ ActiveRecord::Schema.define(version: 2021_01_18_143631) do
     t.index ["deleted_at"], name: "index_antennes_on_deleted_at"
     t.index ["institution_id"], name: "index_antennes_on_institution_id"
     t.index ["name", "institution_id"], name: "index_antennes_on_name_and_institution_id", unique: true
+    t.index ["updated_at"], name: "index_antennes_on_updated_at"
   end
 
   create_table "antennes_communes", id: false, force: :cascade do |t|
@@ -260,6 +261,7 @@ ActiveRecord::Schema.define(version: 2021_01_18_143631) do
     t.index ["deleted_at"], name: "index_institutions_on_deleted_at"
     t.index ["name"], name: "index_institutions_on_name", unique: true
     t.index ["slug"], name: "index_institutions_on_slug", unique: true
+    t.index ["updated_at"], name: "index_institutions_on_updated_at"
   end
 
   create_table "institutions_subjects", force: :cascade do |t|
@@ -271,6 +273,7 @@ ActiveRecord::Schema.define(version: 2021_01_18_143631) do
     t.index ["institution_id"], name: "index_institutions_subjects_on_institution_id"
     t.index ["subject_id", "institution_id", "description"], name: "unique_institution_subject_in_institution", unique: true
     t.index ["subject_id"], name: "index_institutions_subjects_on_subject_id"
+    t.index ["updated_at"], name: "index_institutions_subjects_on_updated_at"
   end
 
   create_table "landing_options", force: :cascade do |t|
@@ -432,6 +435,7 @@ ActiveRecord::Schema.define(version: 2021_01_18_143631) do
     t.integer "interview_sort_order"
     t.index ["interview_sort_order"], name: "index_themes_on_interview_sort_order"
     t.index ["label"], name: "index_themes_on_label", unique: true
+    t.index ["updated_at"], name: "index_themes_on_updated_at"
   end
 
   create_table "users", id: :serial, force: :cascade do |t|


### PR DESCRIPTION
A bunch of commits from a forgotten branch, done mostly while working on /annuaire.

* Add Indexes for “updated_at” attributes used for fragment caching: if we’re using `max(updated_at)` in sql queries, it better be indexed.
* Cleanup another use of fragment caching: there is no point in computing `Badge.maximum(:updated_at)` ourselves: rails caching knows to do it itself when we pass the Relation as a cache key.
* Also cache the need badge indicator in the navbar.