### PR TITLE
Fix Rails loading deprecations

### DIFF
--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -62,7 +62,7 @@ Rails.application.configure do
   config.assets.quiet = true
 
   # Raises error for missing translations
-  config.action_view.raise_on_missing_translations = false
+  config.i18n.raise_on_missing_translations = false
 
   # Use an evented file watcher to asynchronously detect changes in source code,
   # routes, locales, etc. This feature depends on the listen gem.

--- a/config/environments/test.rb
+++ b/config/environments/test.rb
@@ -43,7 +43,7 @@ Rails.application.configure do
   config.active_support.deprecation = :stderr
 
   # Raises error for missing translations
-  config.action_view.raise_on_missing_translations = true
+  config.i18n.raise_on_missing_translations = true
 
   # Let Faker load its :en text
   config.i18n.enforce_available_locales = false

--- a/config/initializers/core_extensions.rb
+++ b/config/initializers/core_extensions.rb
@@ -1,5 +1,7 @@
 # Note: human_count could be added as a class method of ApplicationRecord and could still be called on ActiveRecord::Relation
 # However, this would break the result cache (especially the count cache) in Relation.
-# Adding it in an extension isn’t ideal, as this breaks autoreload for human_count.rb, and Zeitwerk may complain.
-# However this is better than accidental n+1 queries.
-ActiveRecord::Relation.include RecordExtensions::HumanCount
+Rails.application.reloader.to_prepare do
+  # Adding the extension inside a to_prepare block is required for Zeitwerk autoloading to work properly.
+  # See https://guides.rubyonrails.org/autoloading_and_reloading_constants.html#autoloading-when-the-application-boots
+  ActiveRecord::Relation.include RecordExtensions::HumanCount
+end


### PR DESCRIPTION
* followup #1494: tweak the loading of HumanCount some more; this time following the docs and the warning message.
* use i18n.raise_on_missing_translation instead of action_view.raise_on_missing_translations; that’s Rails 6.1