### PR TITLE
Sanitize data on input

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -42,6 +42,7 @@ gem 'devise_invitable'
 gem 'user_impersonate2', require: 'user_impersonate'
 gem 'pundit'
 gem 'activerecord-postgres_enum'
+gem 'auto_strip_attributes'
 
 # Charts
 gem 'groupdate'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -99,9 +99,11 @@ GEM
       activesupport (>= 3.0.0, < 6.1)
       ruby2_keywords (>= 0.0.2, < 1.0)
     ast (2.4.1)
-    audited (4.9.0)
-      activerecord (>= 4.2, < 6.1)
-    autoprefixer-rails (10.0.2.0)
+    audited (4.10.0)
+      activerecord (>= 4.2, < 6.2)
+    auto_strip_attributes (2.6.0)
+      activerecord (>= 4.0)
+    autoprefixer-rails (10.2.0.0)
       execjs
     awesome_print (1.8.0)
     axe-matchers (2.6.1)
@@ -564,6 +566,7 @@ DEPENDENCIES
   activerecord-postgres_enum
   annotate
   audited
+  auto_strip_attributes
   awesome_print
   axe-matchers
   bootsnap

--- a/app/models/antenne.rb
+++ b/app/models/antenne.rb
@@ -37,8 +37,9 @@ class Antenne < ApplicationRecord
   # Same as :advisors, but excluding deleted users; this makes it possible to preload not_deleted users in views.
   has_many :not_deleted_advisors, -> { not_deleted }, class_name: 'User', inverse_of: :antenne
 
-  ## Validations
+  ## Hooks and Validations
   #
+  auto_strip_attributes :name
   validates :name, presence: true, uniqueness: { scope: :institution_id }
   validates :institution, presence: true
 

--- a/app/models/concerns/person_concern.rb
+++ b/app/models/concerns/person_concern.rb
@@ -2,10 +2,14 @@ module PersonConcern
   extend ActiveSupport::Concern
 
   included do
+    ## Validation
+    #
     validates :full_name, :role, presence: true
     validates :email, format: { with: Devise.email_regexp }, allow_blank: true
   end
 
+  ## Display helpers
+  #
   def to_s
     full_name
   end
@@ -29,7 +33,7 @@ module PersonConcern
   end
 
   def normalize_name
-    self.full_name = self.full_name.squish.titleize
+    self.full_name = titleize_if_all_same_case(self.full_name.squish)
   end
 
   def normalize_email
@@ -45,6 +49,18 @@ module PersonConcern
   end
 
   def normalize_role
-    self.role = self.role.squish.titleize
+    self.role = titleize_if_all_same_case(self.role.squish)
+  end
+
+  private
+
+  def titleize_if_all_same_case(str)
+    # Titleize if the input is all lowercase or all uppercase,
+    # leave it intact otherwise.
+    if str.in? [str.downcase, str.upcase]
+      str.titleize
+    else
+      str
+    end
   end
 end

--- a/app/models/concerns/person_concern.rb
+++ b/app/models/concerns/person_concern.rb
@@ -9,7 +9,7 @@ module PersonConcern
 
     ## Data sanitization
     #
-    before_validation :normalize_values
+    before_validation :normalize_values, on: :create
   end
 
   ## Display helpers
@@ -45,7 +45,7 @@ module PersonConcern
   def normalize_name
     return unless self.full_name
 
-    self.full_name = titleize_if_all_same_case(self.full_name.squish)
+    self.full_name = self.full_name.squish.titleize
   end
 
   def normalize_email
@@ -67,18 +67,6 @@ module PersonConcern
   def normalize_role
     return unless self.role
 
-    self.role = titleize_if_all_same_case(self.role.squish)
-  end
-
-  private
-
-  def titleize_if_all_same_case(str)
-    # Titleize if the input is all lowercase or all uppercase,
-    # leave it intact otherwise.
-    if str.in? [str.downcase, str.upcase]
-      str.titleize
-    else
-      str
-    end
+    self.role = self.role.squish.titleize
   end
 end

--- a/app/models/concerns/person_concern.rb
+++ b/app/models/concerns/person_concern.rb
@@ -6,6 +6,10 @@ module PersonConcern
     #
     validates :full_name, :role, presence: true
     validates :email, format: { with: Devise.email_regexp }, allow_blank: true
+
+    ## Data sanitization
+    #
+    before_validation :normalize_values
   end
 
   ## Display helpers
@@ -24,23 +28,35 @@ module PersonConcern
     end
   end
 
-  def normalize_values!
+  ## Data sanitization
+  #
+  def normalize_values
     normalize_name
-    normalize_phone_number
     normalize_email
+    normalize_phone_number
     normalize_role
+  end
+
+  def normalize_values!
+    normalize_values
     save!
   end
 
   def normalize_name
+    return unless self.full_name
+
     self.full_name = titleize_if_all_same_case(self.full_name.squish)
   end
 
   def normalize_email
+    return unless self.email
+
     self.email = self.email.strip.downcase
   end
 
   def normalize_phone_number
+    return unless self.phone_number
+
     number = self.phone_number.gsub(/[^0-9]/,'')
     if number.length == 10
       number = number.gsub(/(.{2})(?=.)/, '\1 \2')
@@ -49,6 +65,8 @@ module PersonConcern
   end
 
   def normalize_role
+    return unless self.role
+
     self.role = titleize_if_all_same_case(self.role.squish)
   end
 

--- a/app/models/institution.rb
+++ b/app/models/institution.rb
@@ -31,8 +31,9 @@ class Institution < ApplicationRecord
   has_many :landings, inverse_of: :institution
   has_many :solicitations, inverse_of: :institution
 
-  ## Validations
+  ## Hooks and Validations
   #
+  auto_strip_attributes :name
   validates :name, :slug, presence: true, uniqueness: true
   before_validation :compute_slug
 

--- a/spec/features/users/invitations_controller_spec.rb
+++ b/spec/features/users/invitations_controller_spec.rb
@@ -25,7 +25,7 @@ describe 'invitations', type: :feature do
       expect(last_user).to be_created_by_invite
       expect(last_user.email).to eq 'marie.dupont@exemple.fr'
       expect(last_user.full_name).to eq 'Marie Dupont'
-      expect(last_user.phone_number).to eq '0123456789'
+      expect(last_user.phone_number).to eq '01 23 45 67 89'
       expect(last_user.role).to eq 'Conseillère'
       expect(last_user.antenne).to eq antenne
     end

--- a/spec/services/csv_export/user_exporter_spec.rb
+++ b/spec/services/csv_export/user_exporter_spec.rb
@@ -11,7 +11,7 @@ describe CsvExport::UserExporter, CsvExport do
     it do
       csv = <<~CSV
         Institution,Antenne,Prénom et nom,E-mail,Téléphone,Fonction
-        Test Institution,Test Antenne,User 1,user@user.com,0123456789,User Role
+        Test Institution,Test Antenne,User 1,user@user.com,01 23 45 67 89,User Role
       CSV
       is_expected.to eq csv
     end
@@ -25,7 +25,7 @@ describe CsvExport::UserExporter, CsvExport do
     it do
       csv = <<~CSV
         Institution,Antenne,Prénom et nom,E-mail,Téléphone,Fonction,Nom de l’équipe,E-mail de l’équipe,Téléphone de l’équipe,Fonction de l’équipe
-        Test Institution,Test Antenne,User 1,user@user.com,0123456789,User Role,Team 1,team@team.com,0987654321,Team Role
+        Test Institution,Test Antenne,User 1,user@user.com,01 23 45 67 89,User Role,Team 1,team@team.com,09 87 65 43 21,Team Role
       CSV
       is_expected.to eq csv
     end
@@ -45,7 +45,7 @@ describe CsvExport::UserExporter, CsvExport do
     it do
       csv = <<~CSV
         Institution,Antenne,Prénom et nom,E-mail,Téléphone,Fonction,Test Subject
-        Test Institution,Test Antenne,User 1,user@user.com,0123456789,User Role,Intervention criteria
+        Test Institution,Test Antenne,User 1,user@user.com,01 23 45 67 89,User Role,Intervention criteria
       CSV
       is_expected.to eq csv
     end


### PR DESCRIPTION
Une autre branche, que vous pourriez trouver intéressante (ou non). Les tests échouent, et c’est normal: le comportement de `normalize_name` a changé, et les données sont normalisées automatiquement à la création.

Je pense que c’est pertinent; ça devrait éviter une partie des erreurs à l’import.