### PR TITLE
Explicitly specify the Delayed::Job backend for the ActiveAdmin page

### DIFF
--- a/app/admin/delayed_job.rb
+++ b/app/admin/delayed_job.rb
@@ -1,4 +1,6 @@
-ActiveAdmin.register Delayed::Job, as: 'Jobs' do
+require 'delayed/backend/active_record'
+
+ActiveAdmin.register Delayed::Backend::ActiveRecord::Job, as: 'Jobs' do
   menu priority: 2
   actions :index, :show, :destroy
 


### PR DESCRIPTION
This is a bit unfortunate. Starting in Rails 6.1, this crashes at lauch in production:
```
/Users/nicolas/Documents/place-des-entreprises/app/admin/delayed_job.rb:3:in `<main>': uninitialized constant Delayed::Job (NameError)
```

It seems that the Delayed::Job symbol is actually created dynamically when the backend for the ActiveJob is set; if the ActiveAdmin page is executed first, the Delayed::Job symbol doesn’t exist.
The workaround is to specify explicitly the actual backend class; it should be _the same thing_.

I’m not exactly sure why this started to fail now.