### PR TITLE
WIP: Split the needs inbox in two

### DIFF
--- a/app/controllers/needs_controller.rb
+++ b/app/controllers/needs_controller.rb
@@ -37,6 +37,10 @@ class NeedsController < ApplicationController
     retrieve_needs(current_user, :not_for_me)
   end
 
+  def others_taking_care
+    retrieve_needs(current_user, :others_taking_care)
+  end
+
   def archived
     retrieve_needs(current_user, :archived)
   end
@@ -57,6 +61,10 @@ class NeedsController < ApplicationController
     retrieve_needs(current_user.antenne, :not_for_me)
   end
 
+  def antenne_others_taking_care
+    retrieve_needs(current_user.antenne, :others_taking_care)
+  end
+
   def antenne_archived
     retrieve_needs(current_user.antenne, :archived)
   end
@@ -64,7 +72,7 @@ class NeedsController < ApplicationController
   private
 
   def collection_names
-    %i[quo taking_care done not_for_me archived]
+    %i[quo taking_care done not_for_me others_taking_care archived]
   end
 
   # Common render method for collection actions

--- a/app/models/concerns/involvement_concern.rb
+++ b/app/models/concerns/involvement_concern.rb
@@ -2,9 +2,21 @@ module InvolvementConcern
   extend ActiveSupport::Concern
 
   def needs_quo
-    received_needs
+    query = received_needs
       .where(matches: received_matches.status_quo)
       .archived(false)
+
+    # Taken by no one, or taken by someone else but not old yet
+    query.status_quo
+         .or(query.where.not(id: Need.in_reminders_range(:archive)))
+  end
+
+  def needs_others_taking_care
+    query = received_needs
+      .where(matches: received_matches.status_quo)
+      .archived(false)
+
+    query.not_status_quo.in_reminders_range(:archive)
   end
 
   def needs_taking_care
@@ -28,13 +40,5 @@ module InvolvementConcern
   def needs_archived
     received_needs
       .archived(true)
-  end
-
-  def needs_others_taking_care
-    received_needs
-      .status_taking_care
-      .where(matches: received_matches.status_quo)
-      .archived(false)
-      .distinct
   end
 end

--- a/config/locales/views.fr.yml
+++ b/config/locales/views.fr.yml
@@ -424,6 +424,7 @@ fr:
       archived: Expirées
       done: Clôturées
       not_for_me: Refusées
+      others_taking_care: Prises par d’autres
       quo: Boite de réception
       taking_care: Prises en charge
     empty_placeholder:

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -159,12 +159,14 @@ Rails.application.routes.draw do
       get :taking_care, path: 'prises_en_charge'
       get :done, path: 'cloturees'
       get :not_for_me, path: 'refusees'
+      get :others_taking_care, path: 'pris_en_charges_par_dautres'
       get :archived, path: 'expirees'
 
       get :antenne_quo, path: 'antenne/boite_de_reception'
       get :antenne_taking_care, path: 'antenne/prises_en_charge'
       get :antenne_done, path: 'antenne/cloturees'
       get :antenne_not_for_me, path: 'antenne/refusees'
+      get :antenne_others_taking_care, path: 'pris_en_charges_par_dautres'
       get :antenne_archived, path: 'antenne/expirees'
     end
     member do


### PR DESCRIPTION
En gros, on divise la boite de réception en deux.
Avant:
* tous les besoins reçus sur lesquels on n’est pas positionnés, et qui ne sont pas archivés

Après: ces mêmes besoins, mais séparés en deux:
* les “frais”: ceux sur lesquels personne ne s’est positionné, ou bien qui sont encore récents
* les “vieux”: ceux sur lesquels quelqu’un s’est déjà positionné, et qui ne sont plus récents.

TODO: 
* [ ] renommer les scopes, needs_quo et needs_taking_care ne sont pas de très bonnes descriptions
* [ ] retrouver l’issue qui mentionnait ça. 😁 

Avant: 
<img width="282" alt="image" src="https://user-images.githubusercontent.com/139391/105968654-a3ce7480-6087-11eb-8dec-2e528d43d917.png">
Après:
<img width="270" alt="image" src="https://user-images.githubusercontent.com/139391/105968651-a29d4780-6087-11eb-88a7-05a963a11a75.png">
