### PR TITLE
Fix reminders counts

### DIFF
--- a/app/models/need.rb
+++ b/app/models/need.rb
@@ -106,16 +106,19 @@ class Need < ApplicationRecord
 
   scope :reminders_to, -> (action) do
     if action == :archive
-      query1 = archived(false)
+      query1 = diagnosis_completed
+        .archived(false)
         .in_reminders_range(action)
         .with_matches_only_in_status([:quo, :not_for_me])
 
-      query2 = archived(false)
+      query2 = diagnosis_completed
+        .archived(false)
         .status_not_for_me
 
       query1.or(query2)
     else # :poke, :recall and :warn
-      archived(false)
+      diagnosis_completed
+        .archived(false)
         .in_reminders_range(action)
         .reminding_may_help
         .without_action(action)

--- a/app/views/reminders/_diagnosis.haml
+++ b/app/views/reminders/_diagnosis.haml
@@ -7,7 +7,7 @@
           .sub.header= I18n.l(diagnosis.display_date, format: :long)
   .ui.segment.needs
     - if diagnosis.step_completed?
-      - diagnosis.needs.each do |need|
+      - diagnosis.needs.reminders_to(action).each do |need|
         %h3.ui.header
           %span
             = need.subject

--- a/app/views/reminders/experts/_expert_contents.haml
+++ b/app/views/reminders/experts/_expert_contents.haml
@@ -35,12 +35,12 @@
             = abandoned_count
             .detail{ title: t('.received_needs_abandoned_quo_not_taken_tooltip') }
               = t('.received_needs_abandoned_quo_not_taken')
-          - abandoned_count = expert.needs_taking_care.abandoned.count
+          - abandoned_count = expert.needs_taking_care.diagnosis_completed.size
           = link_to needs_taking_care_reminders_expert_path(expert), class: "ui label #{abandoned_count > 0 ? 'yellow' : 'basic'}" do
             = abandoned_count
             .detail{ title: t('.received_needs_abandoned_taking_care_tooltip') }
               = t('.received_needs_abandoned_taking_care')
-          - abandoned_count = expert.needs_others_taking_care.abandoned.count
+          - abandoned_count = expert.needs_others_taking_care.diagnosis_completed.size
           = link_to needs_taking_care_by_others_reminders_expert_path(expert), class: "ui label #{abandoned_count > 0 ? 'yellow' : 'basic'}" do
             = abandoned_count
             .detail{ title: t('.received_needs_abandoned_others_taking_care_tooltip') }

--- a/spec/views/reminders/needs/index.html.haml_spec.rb
+++ b/spec/views/reminders/needs/index.html.haml_spec.rb
@@ -1,0 +1,30 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe 'reminders/needs/index.html.haml', type: :view do
+  describe "archive" do
+    let!(:action) { :archive }
+    let!(:current_date) { Time.zone.now.beginning_of_day }
+    let(:thirty_days_ago) { current_date - 30.days }
+    let!(:diagnosis_in_progress) { create :diagnosis }
+    let!(:diagnosis_mixte) { create :diagnosis_completed }
+    let!(:need00) { travel_to(thirty_days_ago) { create :need, diagnosis: diagnosis_in_progress } }
+    let!(:need01) { travel_to(thirty_days_ago) { create :need_with_matches, diagnosis:  diagnosis_mixte } }
+    let!(:need02) { travel_to(thirty_days_ago) { create :need_with_matches, diagnosis:  diagnosis_mixte, archived_at: current_date } }
+
+    let!(:needs_to_archive) { Need.reminders_to(action).includes(:subject).page(1) }
+
+    it "displays coherent needs counts" do
+      assign(:action, action)
+      assign(:needs, needs_to_archive)
+      assign(:collections_counts, %i[poke recall warn archive].index_with { |name| Need.reminders_to(name).size })
+      assign(:territories, Territory.regions.order(:name))
+
+      render
+
+      expect(rendered).to have_content("Région")
+      assert_select "a", { count: 1, text: "Archiver" }
+    end
+  end
+end


### PR DESCRIPTION
Correction des erreurs d'affichage et de décompte des relances, avec test basique

Tests à compléter : les tests de views ne prennent pas le `layout` ni les `content_for`, donc ici les chiffres afffichés dans la colonne du menu ne sont pas testés. Pas pris le temps de creuser comment les tester en même temps.
