### PR TITLE
Use fragment caching for the annuaire

### DIFF
--- a/app/models/antenne.rb
+++ b/app/models/antenne.rb
@@ -28,7 +28,7 @@ class Antenne < ApplicationRecord
   include ManyCommunes
   include InvolvementConcern
 
-  belongs_to :institution, inverse_of: :antennes
+  belongs_to :institution, inverse_of: :antennes, touch: true
 
   has_many :experts, inverse_of: :antenne
   has_many :advisors, class_name: 'User', inverse_of: :antenne

--- a/app/models/institution_subject.rb
+++ b/app/models/institution_subject.rb
@@ -24,7 +24,7 @@
 class InstitutionSubject < ApplicationRecord
   ## Associations
   #
-  belongs_to :institution, inverse_of: :institutions_subjects
+  belongs_to :institution, inverse_of: :institutions_subjects, touch: true
   belongs_to :subject, inverse_of: :institutions_subjects
   has_many :experts_subjects, dependent: :destroy
 

--- a/app/models/subject.rb
+++ b/app/models/subject.rb
@@ -32,7 +32,7 @@ class Subject < ApplicationRecord
 
   ## Associations
   #
-  belongs_to :theme, inverse_of: :subjects
+  belongs_to :theme, inverse_of: :subjects, touch: true
 
   has_many :needs, inverse_of: :subject
   has_many :institutions_subjects, inverse_of: :subject

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -59,7 +59,7 @@ class User < ApplicationRecord
 
   ## Associations
   #
-  belongs_to :antenne, inverse_of: :advisors
+  belongs_to :antenne, inverse_of: :advisors, touch: true
   has_and_belongs_to_many :experts, inverse_of: :users
   has_many :sent_diagnoses, class_name: 'Diagnosis', foreign_key: 'advisor_id', inverse_of: :advisor
   has_many :searches, inverse_of: :user

--- a/app/views/annuaire/advisors/index.html.haml
+++ b/app/views/annuaire/advisors/index.html.haml
@@ -4,4 +4,5 @@
 
 = render 'import_buttons' unless application_fullscreen
 
-= render 'table', institutions_subjects: @institutions_subjects, advisors: @advisors, antenne: @antenne
+- cache([@institutions_subjects, @advisors, Theme.all]) do
+  = render 'table', institutions_subjects: @institutions_subjects, advisors: @advisors, antenne: @antenne

--- a/app/views/annuaire/antennes/index.html.haml
+++ b/app/views/annuaire/antennes/index.html.haml
@@ -4,4 +4,5 @@
 
 = render 'import_buttons'
 
-= render 'table', antennes: @antennes
+- cache(@antennes) do
+  = render 'table', antennes: @antennes

--- a/app/views/annuaire/institutions/index.html.haml
+++ b/app/views/annuaire/institutions/index.html.haml
@@ -2,4 +2,5 @@
 - meta title: title
 %h1.ui.header= title
 
-= render 'table', institutions: @institutions
+- cache([@institutions, Theme.all]) do
+  = render 'table', institutions: @institutions

--- a/app/views/annuaire/subjects/index.html.haml
+++ b/app/views/annuaire/subjects/index.html.haml
@@ -2,5 +2,6 @@
 - content_for :header, render('header', institution: @institution)
 - content_for :menu, render('menu', institution: @institution)
 
-= render 'table', institutions_subjects: @institutions_subjects
+- cache([@institutions_subjects, Theme.all]) do
+  = render 'table', institutions_subjects: @institutions_subjects
 


### PR DESCRIPTION
🚄🚄🚄
* Use fragment caching for the annuaire: the trick is to add `touch:true` to relations so that the cache gets invalidated. <- :warning: this is where bugs may lie.