### PR TITLE
change la clé du cache pour les analyses dans les relances

### DIFF
--- a/app/views/reminders/_diagnosis.haml
+++ b/app/views/reminders/_diagnosis.haml
@@ -1,33 +1,34 @@
-.ui.segments.shadow-less.diagnosis{ 'id': diagnosis.id }
-  = link_to diagnosis do
-    .ui.segment.secondary
-      .ui.header.grid.aligned
-        .eight.wide.column
-          %h2= diagnosis.company.name
-          .sub.header= I18n.l(diagnosis.display_date, format: :long)
-  .ui.segment.needs
-    - if diagnosis.step_completed?
-      - diagnosis.needs.reminders_to(action).each do |need|
-        %h3.ui.header
-          %span
-            = need.subject
-            .sub.header
-              = need.matches.human_count
-              - if need.abandoned?
-                .ui.label.basic.orange= t('diagnoses.diagnosis.last_activity_date', l: l(need.updated_at.to_date, format: :long))
-          - if action.present?
-            = link_to t(action, scope: 'reminders.needs.scopes.mark_done'), polymorphic_path([action, :reminders_action], { id: need.id }),
-              method: :post, class: "ui button #{action == :archive ? 'red' : 'green'}"
+- cache [diagnosis, action] do
+  .ui.segments.shadow-less.diagnosis{ 'id': diagnosis.id }
+    = link_to diagnosis do
+      .ui.segment.secondary
+        .ui.header.grid.aligned
+          .eight.wide.column
+            %h2= diagnosis.company.name
+            .sub.header= I18n.l(diagnosis.display_date, format: :long)
+    .ui.segment.needs
+      - if diagnosis.step_completed?
+        - diagnosis.needs.reminders_to(action).each do |need|
+          %h3.ui.header
+            %span
+              = need.subject
+              .sub.header
+                = need.matches.human_count
+                - if need.abandoned?
+                  .ui.label.basic.orange= t('diagnoses.diagnosis.last_activity_date', l: l(need.updated_at.to_date, format: :long))
+            - if action.present?
+              = link_to t(action, scope: 'reminders.needs.scopes.mark_done'), polymorphic_path([action, :reminders_action], { id: need.id }),
+                method: :post, class: "ui button #{action == :archive ? 'red' : 'green'}"
 
-        .ui.list
-          - need.matches.each do |match|
-            .item
-              ⁃ #{match.expert.antenne.to_s}
+          .ui.list
+            - need.matches.each do |match|
+              .item
+                ⁃ #{match.expert.antenne.to_s}
 
-        .ui.feed.feedbacks
-          = render partial: 'feedbacks/feedback', collection: need.reminder_feedbacks
-          = render 'feedbacks/form', feedback: need.reminder_feedbacks.new
+          .ui.feed.feedbacks
+            = render partial: 'feedbacks/feedback', collection: need.reminder_feedbacks
+            = render 'feedbacks/form', feedback: need.reminder_feedbacks.new
 
-        .item.show-feedbacks-form{ 'data-feedbackable': "#{need.id}" }
-          %button.mini.ui.button
-            = t('feedbacks.add')
+          .item.show-feedbacks-form{ 'data-feedbackable': "#{need.id}" }
+            %button.mini.ui.button
+              = t('feedbacks.add')

--- a/app/views/reminders/_needs.html.haml
+++ b/app/views/reminders/_needs.html.haml
@@ -1,8 +1,7 @@
 - diagnoses = Diagnosis.completed.where(needs: received_needs).distinct.order(happened_on: :desc)
 
-
 = paginate received_needs
 
-= render partial: 'reminders/diagnosis', collection: diagnoses, locals: { action: action }, cached: true
+= render partial: 'reminders/diagnosis', collection: diagnoses, locals: { action: action }
 
 = paginate received_needs


### PR DESCRIPTION
Je n'ai pas réussi à reproduire le problème en local mais je pense que si un besoin est dans le panier "à rappeler" qu’aucune action n'ai faite et qu'il passe dans le panier suivant au bout d'un certain temps. Le Diagnosis reste inchangé car il n'a pas été mis à jour, en rajoutant l'action du panier courant dans la clé du cache ça peut résoudre le problème. Avec un peu de chance ça va résoudre le problème des Diagnosis dont les boutons n'apparaissaient pas tout le temps.

closes #1562 