### PR TITLE
Mise à jour de sentry

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -65,7 +65,9 @@ gem 'recipient_interceptor'
 gem 'ip_anonymizer'
 
 # Notifiers
-gem 'sentry-raven'
+gem "sentry-ruby"
+gem "sentry-rails"
+gem "sentry-delayed_job"
 
 # Helper gems
 gem 'browser'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -478,8 +478,18 @@ GEM
       childprocess (>= 0.5, < 4.0)
       rubyzip (>= 1.2.2)
     semantic_range (2.3.0)
-    sentry-raven (3.1.1)
+    sentry-delayed_job (4.2.1)
+      sentry-ruby-core (~> 4.2.0)
+    sentry-rails (4.2.2)
+      rails (>= 5.0)
+      sentry-ruby-core (~> 4.2.0)
+    sentry-ruby (4.2.2)
+      concurrent-ruby (~> 1.0, >= 1.0.2)
       faraday (>= 1.0)
+      sentry-ruby-core (= 4.2.2)
+    sentry-ruby-core (4.2.2)
+      concurrent-ruby
+      faraday
     sexp_processor (4.15.1)
     shoulda-matchers (4.4.1)
       activesupport (>= 4.2.0)
@@ -630,7 +640,9 @@ DEPENDENCIES
   rubocop-rspec
   sassc-rails
   selenium-webdriver
-  sentry-raven
+  sentry-delayed_job
+  sentry-rails
+  sentry-ruby
   shoulda-matchers
   sib-api-v3-sdk (~> 7.2)
   spring

--- a/app/controllers/newsletters_controller.rb
+++ b/app/controllers/newsletters_controller.rb
@@ -15,7 +15,7 @@ class NewslettersController < PagesController
       api_instance.create_contact(SibApiV3Sdk::CreateContact.new(contact_params))
       flash[:success] = t('.success_newsletter')
     rescue SibApiV3Sdk::ApiError => e
-      Raven.capture_exception(e)
+      Sentry.capture_exception(e)
       flash[:warning] = t('.error_newsletter_subscription')
     end
 

--- a/app/controllers/shared_controller.rb
+++ b/app/controllers/shared_controller.rb
@@ -38,7 +38,7 @@ class SharedController < ActionController::Base
     Sentry.configure_scope do |scope|
       scope.set_user(id: current_user&.id)
       scope.set_extras(
-        params: params.to_unsafe_h, 
+        params: params.to_unsafe_h,
         url: request.url
       )
     end

--- a/app/services/company_mailer_service.rb
+++ b/app/services/company_mailer_service.rb
@@ -27,8 +27,9 @@ class CompanyMailerService
         CompanyMailer.newsletter_subscription(diagnosis).deliver_later unless list_emails.include?(diagnosis.visitee.email)
         diagnosis.update(newsletter_subscription_email_sent: true)
       rescue SibApiV3Sdk::ApiError => e
-        Raven.tags_context(email: diagnosis.visitee.email) do
-          Raven.capture_exception(e)
+        Sentry.with_scope do |scope|
+          scope.set_tags(email: diagnosis.visitee.email)
+          Sentry.capture_exception(e)
         end
       end
     end

--- a/config/initializers/sentry.rb
+++ b/config/initializers/sentry.rb
@@ -1,5 +1,6 @@
-Raven.configure do |config|
-  # SENTRY_DSN is used to set the DSN https://docs.sentry.io/clients/ruby/
-  config.sanitize_fields = Rails.application.config.filter_parameters.map(&:to_s)
-  config.silence_ready = true
+Sentry.init do |config|
+  config.dsn = ENV['SENTRY_DSN']
+  config.breadcrumbs_logger = [:active_support_logger]
+  config.traces_sample_rate = 0.5
+  config.send_default_pii = false
 end


### PR DESCRIPTION
- passage à sentry standard suite à l'incendie des serveurs de https://sentry.data.gouv.fr
- on en profite pour mettre à jour la gem sentry

close #1595