### PR TITLE
Fix bug js remove() avec ie11

### DIFF
--- a/app/front/javascripts/pages/siret_autocomplete.js
+++ b/app/front/javascripts/pages/siret_autocomplete.js
@@ -94,7 +94,9 @@ import accessibleAutocomplete from 'accessible-autocomplete';
 
   async function fetchEtablissements(query) {
     let params = `query=${query}&non_diffusables=false`; // pour ne pas afficher publiquement les SIRET non diffusibles
-    let response = await fetch(`/rech-etablissement?${params}`);
+    let response = await fetch(`/rech-etablissement?${params}`, {
+      credentials: "same-origin",
+    });
     let data = await response.json();
     return data;
   }

--- a/app/views/feedbacks/create.js.haml
+++ b/app/views/feedbacks/create.js.haml
@@ -1,5 +1,5 @@
 var noComment = document.getElementById('no-comment')
-if (noComment != null) { noComment.remove() }
+if (noComment != null) { noComment.parentNode.removeChild(noComment) }
 
 - feedback_html = render 'feedbacks/feedback', feedback: @feedback
 document.getElementById('display-feedbacks-#{@feedback.feedbackable_id}').insertAdjacentHTML('beforeend', "#{j feedback_html}");
@@ -10,5 +10,5 @@ document.querySelector('.feedback-form-#{@feedback.feedbackable_id}').reset()
 var form = document.getElementsByClassName('from_alert_box');
 if (form.length > 0) {
 form[0].insertAdjacentHTML('beforebegin', "#{j I18n.t('feedbacks.form.thank_you_html').html_safe}");
-form[0].remove();
+form[0].parentNode.removeChild(form[0]);
 }

--- a/app/views/feedbacks/destroy.js.haml
+++ b/app/views/feedbacks/destroy.js.haml
@@ -1,2 +1,2 @@
 element = document.getElementById('feedback-#{@feedback_id}');
-if (element != null) { element.remove() }
+if (element != null) { element.parentNode.removeChild(element) }


### PR DESCRIPTION
closes #1668 
et essaye aussi de traiter `Failed to execute 'fetch' on 'Window': Request cannot be constructed from a URL that includes credentials: /rech-etablissement?query=34063900400068&non_diffusables=false` (https://sentry.io/organizations/place-des-entreprises/issues/2307965094/?project=5671428&query=is%3Aunresolved)