### PR TITLE
Sur la page d'un besoin affiche les experts supprimés uniquement aux admins

### DIFF
--- a/app/policies/expert_policy.rb
+++ b/app/policies/expert_policy.rb
@@ -10,4 +10,8 @@ class ExpertPolicy < ApplicationPolicy
   def update?
     edit?
   end
+
+  def show_deleted_experts?
+    admin?
+  end
 end

--- a/app/views/matches/_match.haml
+++ b/app/views/matches/_match.haml
@@ -1,22 +1,23 @@
-.fr-grid-row.row-match{ id: "row-match-#{match.id}" }
-  .fr-col-sm-1.fr-col-1.col-icon
-    = expert_status_icon(match.status)
-  .fr-col-sm-8.fr-col-11
-    %p
-      %b.blue.js-simple-tooltip{ "data-simpletooltip-content-id" => "tooltip-case-#{match.id}" }
-        #{match.expert.full_name}
-      = " - " + match.expert.antenne.name
-    .hidden{ id: "tooltip-case-#{match.id}" }
-      = person_block(match.expert)
+- if !match.expert.deleted? || (match.expert.deleted? && policy(match.expert).show_deleted_experts?)
+  .fr-grid-row.row-match{ id: "row-match-#{match.id}" }
+    .fr-col-sm-1.fr-col-1.col-icon
+      = expert_status_icon(match.status)
+    .fr-col-sm-8.fr-col-11
+      %p
+        %b.blue.js-simple-tooltip{ "data-simpletooltip-content-id" => "tooltip-case-#{match.id}" }
+          #{match.expert.full_name}
+        = " - " + match.expert.antenne.name
+      .hidden{ id: "tooltip-case-#{match.id}" }
+        = person_block(match.expert)
 
-  .fr-col-sm-2.fr-col.col-label
-    = status_label(match)
+    .fr-col-sm-2.fr-col.col-label
+      = status_label(match)
 
-  .fr-col-sm-1.fr-col.modify-match
-    - if policy(match).mark_as_done? && match.status_taking_care?
-      %section.fr-accordion
-        %h3.fr-accordion__title
-          %button.fr-accordion__btn{ "aria-controls" => "fr-accordion-#{match.id}", "aria-expanded" => "false" }
-            .ri-edit-box-line
-        .fr-collapse{ id: "fr-accordion-#{match.id}" }
-          = admin_match_actions_buttons match
+    .fr-col-sm-1.fr-col.modify-match
+      - if policy(match).mark_as_done? && match.status_taking_care?
+        %section.fr-accordion
+          %h3.fr-accordion__title
+            %button.fr-accordion__btn{ "aria-controls" => "fr-accordion-#{match.id}", "aria-expanded" => "false" }
+              .ri-edit-box-line
+          .fr-collapse{ id: "fr-accordion-#{match.id}" }
+            = admin_match_actions_buttons match

--- a/spec/policies/expert_policy_spec.rb
+++ b/spec/policies/expert_policy_spec.rb
@@ -45,4 +45,18 @@ RSpec.describe ExpertPolicy, type: :policy do
       it { is_expected.not_to permit(user, expert) }
     end
   end
+
+  permissions :show_deleted_experts? do
+    context "grants access if user is an admin" do
+      let(:user) { create :user, is_admin: true }
+
+      it { is_expected.to permit(user, expert) }
+    end
+
+    context "denies access if user is another user" do
+      let(:user) { create :user }
+
+      it { is_expected.not_to permit(user, expert) }
+    end
+  end
 end


### PR DESCRIPTION
<img width="971" alt="Capture d’écran 2021-04-27 à 14 02 59" src="https://user-images.githubusercontent.com/22002486/116238283-75813380-a761-11eb-986e-52994ea7b31a.png">
