### PR TITLE
Ajouter l'icone "ambulance" lorsque  les experts ont été ajoutés + de 30 secondes après les 1eres MER (au lieu de 5min)

### DIFF
--- a/app/models/match.rb
+++ b/app/models/match.rb
@@ -158,7 +158,7 @@ class Match < ApplicationRecord
 
   def additional_match?
     delay_after_first_match = (created_at - need.initial_matches_at)
-    delay_after_first_match > 5.minutes
+    delay_after_first_match > 30.seconds
   end
 
   def expert_subject


### PR DESCRIPTION
close #1730 

@LucienMLD il y avait une raison précise au délai de 5 minutes pour les `additional_match` ? j'ai réduit le délais de 5 min à 30 secondes ; tu diras s'il faut être vigilant là-dessus