### PR TITLE
prevent rails-ujs is already been loaded

### DIFF
--- a/app/views/about/mentions_d_information.fr.html.erb
+++ b/app/views/about/mentions_d_information.fr.html.erb
@@ -206,6 +206,12 @@
         <td headers="data3">Stocke les préférences des visiteurs et personnalise les annonces sur les sites web de Google en fonction des recherches et des interactions récentes</td>
         <td headers="data4">6 mois</td>
       </tr>
+      <tr>
+        <td headers="data1">Google DoubleClick (remarketing)</td>
+        <td headers="data2">IDE</td>
+        <td headers="data3">Stocke les préférences des visiteurs et personnalise les annonces sur les sites web n’appartenant pas à Google en fonction des recherches et des interactions récentes</td>
+        <td headers="data4">6 mois</td>
+      </tr>
       </tbody>
     </table>
     <p>À tout moment, vous pouvez refuser l’utilisation des cookies et désactiver le dépôt sur votre ordinateur en utilisant la fonction dédiée de votre navigateur (fonction disponible notamment sur Microsoft Internet Explorer 11, Edge, Google Chrome, Mozilla Firefox, Apple Safari et Opera).</p>

--- a/app/views/shared/_matomo.html.erb
+++ b/app/views/shared/_matomo.html.erb
@@ -1,4 +1,4 @@
-<%= javascript_tag nonce: true do -%>
+<%= javascript_tag 'data-turbolinks-eval': false, nonce: true do -%>
   var _paq = _paq || [];
   // Configure Matomo analytics
   _paq.push(['trackPageView']);

--- a/app/views/shared/_tarteaucitron.html.erb
+++ b/app/views/shared/_tarteaucitron.html.erb
@@ -25,8 +25,35 @@
   "groupServices": false
   });
 
-  tarteaucitron.user.adwordsremarketingId = 'AW-798054765';
-  (tarteaucitron.job = tarteaucitron.job || []).push('googleadwordsremarketing');
+  tarteaucitron.services.google_ads = {
+  "key": "google_ads",
+  "type": "ads",
+  "name": "Google Ads (remarketing)",
+  "uri": "https://policies.google.com/privacy",
+  "needConsent": true,
+  "cookies": ['__Secure-3PSIDCC', '__Secure-3PSID', '__Secure-3PAPISID', 'NID'],
+  "js": function () {
+    "use strict";
+    window.dataLayer = window.dataLayer || [];
+    tarteaucitron.addScript('https://www.googletagmanager.com/gtag/js?id=' + tarteaucitron.user.gtagAw, '', function () {
+      window.gtag = function gtag(){dataLayer.push(arguments);}
+      gtag('js', new Date());
+
+      if (tarteaucitron.user.gtagCrossdomain) {
+        gtag('config',tarteaucitron.user.gtagAw,{ 'anonymize_ip': true },{linker: {domains: tarteaucitron.user.gtagCrossdomain,}});
+      } else {
+        gtag('config', tarteaucitron.user.gtagAw, { 'anonymize_ip': true });
+      }
+
+      if (typeof tarteaucitron.user.gtagMore === 'function') {
+        tarteaucitron.user.gtagMore();
+      }
+      });
+    }
+  };
+
+  tarteaucitron.user.gtagAw = 'AW-415474841';
+  (tarteaucitron.job = tarteaucitron.job || []).push('google_ads');
 
   // Ouvre la boite gestion des cookies au clic sur le lien
   document.addEventListener("DOMContentLoaded", function() {

--- a/app/views/solicitations/_solicitations_tags_js.html.erb
+++ b/app/views/solicitations/_solicitations_tags_js.html.erb
@@ -1,5 +1,5 @@
 <%= content_for :head do %>
-  <%= javascript_tag nonce: true do -%>
+  <%= javascript_tag nonce: true, 'data-turbolinks-eval': false do -%>
     $(document).ready(function() {
       $('select.ui.selection.search.dropdown.badges').dropdown({
         fullTextSearch: 'exact',

--- a/config/initializers/content_security_policy.rb
+++ b/config/initializers/content_security_policy.rb
@@ -4,14 +4,17 @@
 # For further information see the following documentation
 # https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Content-Security-Policy
 
+# https://developers.google.com/tag-manager/web/csp Pour les CSP Google
+
 Rails.application.config.content_security_policy do |p|
   p.default_src :self
   p.base_uri    :self
   p.font_src    :self, :data, 'https://fonts.gstatic.com'
-  p.img_src     :self, :data, 'https://voxusagers.numerique.gouv.fr', 'https://stats.data.gouv.fr', 'https://www.google.com', 'https://www.google.fr'
+  p.img_src     :self, :data, 'https://voxusagers.numerique.gouv.fr', 'https://stats.data.gouv.fr', 'https://www.google.com', 'https://www.google.fr', 'https://googleads.g.doubleclick.net'
   p.object_src  :none
   p.style_src   :self, :unsafe_inline, 'https://fonts.googleapis.com'
-  p.script_src  :self, 'https://browser.sentry-cdn.com', 'sentry.io', 'https://stats.data.gouv.fr', 'https://cdn.jsdelivr.net', 'https://www.googleadservices.com'
+  p.script_src  :self, 'https://browser.sentry-cdn.com', 'sentry.io', 'https://stats.data.gouv.fr', 'https://cdn.jsdelivr.net', 'https://www.googletagmanager.com', 'https://www.googleadservices.com', 'https://googleads.g.doubleclick.net', 'https://www.google.com'
+  p.frame_src   :self, 'stats.data.gouv.fr', 'https://bid.g.doubleclick.net'
 
   if Rails.env.development?
     p.connect_src :self, 'localhost:3035', 'ws://localhost:3035'


### PR DESCRIPTION
j'ai des doutes que ça règle toutes les erreurs mais j'ai trouvé cette parade sur pas mal de posts qui en parlent, c'est à ajouter sur les scripts qui ne sont pas chargé dans le head d'une page

https://sentry.io/organizations/betagouv-f7/issues/2384890408/?environment=production&project=5747178&query=is%3Aunresolved+ujs&statsPeriod=14d