### PR TITLE
ajoute la description du besoin sur une fiche besoin

### DIFF
--- a/app/helpers/needs_helper.rb
+++ b/app/helpers/needs_helper.rb
@@ -1,0 +1,13 @@
+
+module NeedsHelper
+  def need_general_context(need)
+    context = ""
+    if need.diagnosis.content.present? || need.solicitation&.description.present?
+      context << simple_format(need.diagnosis.content.presence || need.solicitation&.description, class: 'content')
+    end
+    if need.content.present?
+      context << simple_format(need.content, class: 'content')
+    end
+    context
+  end
+end

--- a/app/helpers/needs_helper.rb
+++ b/app/helpers/needs_helper.rb
@@ -1,4 +1,3 @@
-
 module NeedsHelper
   def need_general_context(need)
     context = ""
@@ -8,6 +7,6 @@ module NeedsHelper
     if need.content.present?
       context << simple_format(need.content, class: 'content')
     end
-    context
+    raw context
   end
 end

--- a/app/views/needs/show.haml
+++ b/app/views/needs/show.haml
@@ -10,7 +10,10 @@
         %h1.fr-h2= @need.subject
         %p
           %time.date{ datetime: @need.display_time } Le #{I18n.l(@need.display_time, format: :sentence)}
-        = simple_format(auto_link(@need.diagnosis.content.presence || @need.solicitation&.description), class: 'content')
+        - if @need.diagnosis.content.present? || @need.solicitation&.description.present?
+          = simple_format(@need.diagnosis.content.presence || @need.solicitation&.description, class: 'content')
+        - if @need.content.present?
+          = simple_format(@need.content, class: 'content')
 
     .fr-col-md-4.order-minus-one.bp-sm
       .fr-grid-row.fr-grid-row--gutter.fr-grid-row--middle.fr-mb-2w

--- a/app/views/needs/show.haml
+++ b/app/views/needs/show.haml
@@ -10,10 +10,7 @@
         %h1.fr-h2= @need.subject
         %p
           %time.date{ datetime: @need.display_time } Le #{I18n.l(@need.display_time, format: :sentence)}
-        - if @need.diagnosis.content.present? || @need.solicitation&.description.present?
-          = simple_format(@need.diagnosis.content.presence || @need.solicitation&.description, class: 'content')
-        - if @need.content.present?
-          = simple_format(@need.content, class: 'content')
+        = need_general_context(@need)
 
     .fr-col-md-4.order-minus-one.bp-sm
       .fr-grid-row.fr-grid-row--gutter.fr-grid-row--middle.fr-mb-2w


### PR DESCRIPTION
closes #1794 
le texte en haut de la sélection des besoins était bien pris en compte sur la fiche
<img width="535" alt="Capture d’écran 2021-06-08 à 17 43 58" src="https://user-images.githubusercontent.com/22002486/121216401-2579ae80-c881-11eb-8a81-31d53f818140.png">

mais pas celui en dessous d'un sujet
<img width="403" alt="Capture d’écran 2021-06-08 à 17 44 04" src="https://user-images.githubusercontent.com/22002486/121216490-39bdab80-c881-11eb-97b8-7172688b2a09.png">

