### PR TITLE
Petites corrections annuaire

### DIFF
--- a/app/controllers/annuaire/advisors_controller.rb
+++ b/app/controllers/annuaire/advisors_controller.rb
@@ -4,7 +4,6 @@ module  Annuaire
       @antenne = @institution.antennes.find_by(id: params[:antenne_id]) # may be nil
 
       @advisors = (@antenne || @institution).advisors
-        .not_deleted
         .relevant_for_skills
         .joins(:antenne)
         .order('antennes.name', 'team_name', 'users.full_name')

--- a/app/models/expert.rb
+++ b/app/models/expert.rb
@@ -108,6 +108,8 @@ class Expert < ApplicationRecord
       .where(users: { id: User.unscoped.single_expert })
   end
 
+  scope :with_users, -> { joins(:users) }
+
   scope :without_users, -> do
     # Experts without members can’t connect to the app.
     # This is not a normal state, but can happen during referencing
@@ -192,7 +194,7 @@ class Expert < ApplicationRecord
   ## Team stuff
   def personal_skillset?
     users.size == 1 &&
-      users.first.email == self.email
+      users.first.email.casecmp(self.email).zero?
   end
 
   def without_users?

--- a/app/views/annuaire/advisors/_table.html.haml
+++ b/app/views/annuaire/advisors/_table.html.haml
@@ -19,12 +19,12 @@
         - grouped_subjects.each_value do |subjects|
           - subjects.each do |subject, institutions_subjects|
             - institutions_subjects.each do |institution_subject|
-              - experts = institution_subject.not_deleted_experts
+              - experts = institution_subject.not_deleted_experts.with_users
               - if local_assigns[:antenne]
                 - experts &= antenne.experts
               - count = experts.size
               - anomalie = (count == 0 || (local_assigns[:antenne] && count > 1))
-              %th.right.aligned{ title: t('.experts_on_subject', count: count), class: ('red' if anomalie) }
+              %th.right.aligned{ title: t('.experts_on_subject', count: count, subject: institution_subject.description), class: ('red' if anomalie) }
                 = count
                 - if anomalie
                   %i.red.ri-error-warning-fill

--- a/config/locales/views.fr.yml
+++ b/config/locales/views.fr.yml
@@ -31,7 +31,7 @@ fr:
     advisors:
       table:
         edit_expert: Modifier %{expert_name} - %{antenne}
-        experts_on_subject: "%{count} référents sur ce sujet"
+        experts_on_subject: "%{count} référents sur le sujet %{subject}"
     base:
       import_errors:
         import_failed: Échec de l’import


### PR DESCRIPTION
- décalage de décompte `advisors` / `experts`
- comparaison d'email sans `downcase`
- affichage des sujets d'institution au survol du décompte