### PR TITLE
suppression des anciens sujet

### DIFF
--- a/app/admin/subject.rb
+++ b/app/admin/subject.rb
@@ -2,7 +2,7 @@
 
 ActiveAdmin.register Subject do
   menu parent: :themes, priority: 1
-  actions :all, except: :destroy
+  actions :all
 
   ##
   #

--- a/app/models/subject.rb
+++ b/app/models/subject.rb
@@ -62,6 +62,7 @@ class Subject < ApplicationRecord
   #
   scope :ordered_for_interview, -> do
     left_outer_joins(:theme)
+      .not_archived
       .merge(Theme.ordered_for_interview)
       .order(:interview_sort_order, :id)
   end

--- a/lib/tasks/delete_old_subjects.rake
+++ b/lib/tasks/delete_old_subjects.rake
@@ -1,0 +1,28 @@
+task update_old_subjects_needs: :environment do
+  # One-shot task for #1883.
+
+  puts 'Updating old subjects needs'
+
+  Subject.transaction do
+    subjects_count = 0
+    needs_count = 0
+    default_subject = Subject.find(59)
+    subjects = Subject.is_archived.joins(:theme).joins(:needs).where(themes: { id: 11 }).group(:id).having('COUNT(needs.id) < 15')
+    subjects.each do |subject|
+      subject.needs.each do |need|
+        need.subject = default_subject
+        if Need.where(subject: default_subject, diagnoses: need.diagnosis).any?
+          new_diagnosis = need.diagnosis.dup
+          new_diagnosis.step = :not_started
+          new_diagnosis.needs = []
+          new_diagnosis.save
+          need.diagnosis = new_diagnosis
+        end
+        need.save(validate: false)
+        needs_count += 1
+      end
+      subjects_count += 1
+    end
+    puts "…updated #{subjects_count} subjects and  #{needs_count} needs"
+  end
+end


### PR DESCRIPTION
Ajout d'une tache rake pour mettre a jour le sujet des besoins qui ont des sujets obsolètes avec le sujet actuel "Autre besoin non référencé" et permettre de supprimer les sujets sans besoins directement en admin.

closes #1883 