### PR TITLE
Masque les autres antennes à l'import d'utilisateurs

### DIFF
--- a/app/controllers/annuaire/advisors_controller.rb
+++ b/app/controllers/annuaire/advisors_controller.rb
@@ -30,6 +30,7 @@ module  Annuaire
       @result = User.import_csv(params.require(:file), institution: @institution)
       if @result.success?
         flash[:table_highlighted_ids] = @result.objects.map(&:id)
+        flash[:highlighted_antennes_ids] = Antenne.where(advisors: @result.objects).ids
         redirect_to action: :index
       else
         render :import

--- a/app/front/stylesheets/components/table.sass
+++ b/app/front/stylesheets/components/table.sass
@@ -33,6 +33,9 @@
   th.red, td.red
       background: $red-lighter
       color: $red
+  th.orange, td.orange
+      background: $orange-lighter
+      color: $orange
   th, td.td-header
     position: sticky
     top: 0

--- a/app/views/annuaire/advisors/_table.html.haml
+++ b/app/views/annuaire/advisors/_table.html.haml
@@ -33,7 +33,9 @@
       -# `advisors` contains multiple rows for the same users, for each of their team. (See User.relevant_for_skills)
         We’ll group by Antenne and by Expert team, and span the first two columns as needed.
       - grouped_advisors = advisors.group_by(&:antenne).transform_values{ |users| users.group_by(&:relevant_expert) }
+      - highlighted_antennes_ids = flash[:highlighted_antennes_ids]
       - grouped_advisors.each do |antenne, teams|
+        - next if highlighted_antennes_ids.present? && flash[:highlighted_antennes_ids].exclude?(antenne.id)
         - teams.each_with_index do |key_and_value, index_in_antenne|
           - advisors = key_and_value.last
           - advisors.each_with_index do |user, index_in_team|

--- a/app/views/annuaire/advisors/_table.html.haml
+++ b/app/views/annuaire/advisors/_table.html.haml
@@ -23,11 +23,14 @@
               - if local_assigns[:antenne]
                 - experts &= antenne.experts
               - count = experts.size
-              - anomalie = (count == 0 || (local_assigns[:antenne] && count > 1))
-              %th.right.aligned{ title: t('.experts_on_subject', count: count, subject: institution_subject.description), class: ('red' if anomalie) }
+              - anomalie_less = count == 0
+              - anomalie_more = local_assigns[:antenne] && count > 1
+              %th.right.aligned{ title: t('.experts_on_subject', count: count, subject: institution_subject.description), class: (('red' if anomalie_less) || ('orange' if anomalie_more)) }
                 = count
-                - if anomalie
-                  %i.red.ri-error-warning-fill
+                - if anomalie_less
+                  %span.red.ri-error-warning-fill
+                - if anomalie_more
+                  %span.orange.ri-error-warning-fill
 
     %tbody
       -# `advisors` contains multiple rows for the same users, for each of their team. (See User.relevant_for_skills)


### PR DESCRIPTION
Plutôt que de réduire la taille des lignes j'ai masqué les antennes ou on n’importait pas d'utilisateurs
Change aussi la couleur quand il y a plusieurs utilisateurs sur un sujet en orange

closes #1886 
closes #1889