### PR TITLE
Réparation envoi des relances d'invitation

### DIFF
--- a/app/mailers/user_mailer.rb
+++ b/app/mailers/user_mailer.rb
@@ -36,6 +36,7 @@ class UserMailer < ApplicationMailer
   def remind_invitation(user)
     @user = user
     @institution = user.institution
+    # /!\ ce n'est pas le bon token, il faudrait `raw_token`, non enregistré en BDD
     @token = @user.invitation_token
 
     mail(to: @user.email, subject: t('mailers.user_mailer.remind_invitation.subject', institution_name: @institution.name))

--- a/app/mailers/user_mailer.rb
+++ b/app/mailers/user_mailer.rb
@@ -36,8 +36,11 @@ class UserMailer < ApplicationMailer
   def remind_invitation(user)
     @user = user
     @institution = user.institution
-    # /!\ ce n'est pas le bon token, il faudrait `raw_token`, non enregistré en BDD
-    @token = @user.invitation_token
+    # Hack : pour utiliser dans le lien d'invitation `raw_token`, non enregistré en BDD, on régénère le token
+    # https://github.com/scambra/devise_invitable/blob/f76994e1bea603e81c1ebc19422d589253371f9b/lib/devise_invitable/models.rb#L276
+    @user.send(:generate_invitation_token!)
+
+    @token = @user.raw_invitation_token
 
     mail(to: @user.email, subject: t('mailers.user_mailer.remind_invitation.subject', institution_name: @institution.name))
   end

--- a/app/models/clockwork.rb
+++ b/app/models/clockwork.rb
@@ -24,4 +24,7 @@ module Clockwork
   every(1.day, 'auto_archive_old_matches', at: ('2:41')) do
     `rake auto_archive_old_matches`
   end
+  every(1.day, 'send_reminder_invitation', at: ('7:03')) do
+    User.send_reminder_invitation
+  end
 end

--- a/app/models/clockwork.rb
+++ b/app/models/clockwork.rb
@@ -24,7 +24,4 @@ module Clockwork
   every(1.day, 'auto_archive_old_matches', at: ('2:41')) do
     `rake auto_archive_old_matches`
   end
-  every(1.day, 'send_reminder_invitation', at: ('7:03')) do
-    User.send_reminder_invitation
-  end
 end

--- a/spec/system/users/invitations_controller_spec.rb
+++ b/spec/system/users/invitations_controller_spec.rb
@@ -82,7 +82,7 @@ describe 'invitations', type: :system, js: true do
       visit accept_user_invitation_path(invitation_token: user.raw_invitation_token)
     end
 
-    it 'display error message and not validates invitation' do
+    it 'doesnt display error message' do
       user.reload
       expect(page.html).not_to include I18n.t('devise.invitations.invitation_token_invalid')
     end

--- a/spec/system/users/invitations_controller_spec.rb
+++ b/spec/system/users/invitations_controller_spec.rb
@@ -70,4 +70,21 @@ describe 'invitations', type: :system, js: true do
       expect(page.html).to include I18n.t('devise.invitations.invitation_token_invalid')
     end
   end
+
+  describe 're-invite user' do
+    let(:user) { create :user, full_name: "Hubertine Auclert", created_at: 3.months.ago, invitation_accepted_at: nil }
+
+    before do
+      create_home_landing
+      travel_to(3.weeks.ago) { user.invite! }
+      travel_back
+      user.invite!
+      visit accept_user_invitation_path(invitation_token: user.raw_invitation_token)
+    end
+
+    it 'display error message and not validates invitation' do
+      user.reload
+      expect(page.html).not_to include I18n.t('devise.invitations.invitation_token_invalid')
+    end
+  end
 end


### PR DESCRIPTION
close #1935 

Pistes de vraies résolutions pour le mail `remind_invitation` :
- simplement réinviter 
- trouver un moyen d'avoir un template spécifique en passant des paramètres
- créer un nouveau token lors de l'envoi du rappel, enregistrer la verison chiffrée en BDD, utiliser `raw_token` dans l'invitation