### PR TITLE
retire le message du dernier commit connue sur Main dans la tache push_to_production

### DIFF
--- a/lib/tasks/push_to_production.rake
+++ b/lib/tasks/push_to_production.rake
@@ -18,7 +18,7 @@ task :push_to_production do
   def retrieve_merge_commits_messages(last_commit)
     separator = '--------'
     messages = `git log --merges --pretty=%B#{separator} #{last_commit}..main`
-    messages.split(separator)
+    messages.split(separator)[0...-2]
   end
 
   def format_commit_messages(messages)


### PR DESCRIPTION
A chaque fois dans le message que l'on copie/colle on avait un commit qui était déjà en prod