### PR TITLE
Correction need status

### DIFF
--- a/app/models/diagnosis.rb
+++ b/app/models/diagnosis.rb
@@ -87,6 +87,10 @@ class Diagnosis < ApplicationRecord
   has_many :expert_institutions, through: :experts, source: :institution, inverse_of: :received_diagnoses
   has_many :contacted_users, through: :experts, source: :users, inverse_of: :received_diagnoses
 
+  ## Callbacks
+  #
+  after_update :update_needs, if: :step_completed?
+
   ## Scopes
   #
   scope :from_solicitation, -> { where.not(solicitation: nil) }
@@ -151,6 +155,10 @@ class Diagnosis < ApplicationRecord
   end
 
   private
+
+  def update_needs
+    needs.each{ |n| n.update_status }
+  end
 
   def step_visit_has_needs
     if step_visit?

--- a/app/models/need.rb
+++ b/app/models/need.rb
@@ -60,6 +60,10 @@ class Need < ApplicationRecord
 
   accepts_nested_attributes_for :matches, allow_destroy: true
 
+  ## Callbacks
+  #
+  after_touch :update_status
+
   ## Through Associations
   #
   # :diagnosis

--- a/app/models/need.rb
+++ b/app/models/need.rb
@@ -60,10 +60,6 @@ class Need < ApplicationRecord
 
   accepts_nested_attributes_for :matches, allow_destroy: true
 
-  ## Callbacks
-  #
-  after_touch :update_status
-
   ## Through Associations
   #
   # :diagnosis

--- a/spec/models/need_spec.rb
+++ b/spec/models/need_spec.rb
@@ -38,13 +38,29 @@ RSpec.describe Need, type: :model do
   end
 
   describe 'update_status' do
-    let(:need) { create :need_with_matches }
+    context 'after match changes' do
+      let(:need) { create :need_with_matches }
 
-    before { need.matches.first.update(status: :taking_care) }
+      before { need.matches.first.update(status: :taking_care) }
 
-    subject { need.reload.status }
+      subject { need.reload.status }
 
-    it { is_expected.to eq 'taking_care' }
+      it { is_expected.to eq 'taking_care' }
+    end
+
+    context 'after diagnosis changes' do
+      let(:need) { create :need }
+
+      before do
+        need.matches << create(:match)
+      end
+
+      it 'changes need status' do
+        expect(need.status).to eq('diagnosis_not_complete')
+        need.diagnosis.update(step: :completed)
+        expect(need.reload.status).to eq('quo')
+      end
+    end
   end
 
   describe 'status' do


### PR DESCRIPTION
close #2134 

Correction rapide en attendant de faire mieux les choses. Pistes :
- soit un service de mise à jour du diagnostic (qui gérerait pas mal du code de `steps_controller` et permettrait de tester de façon isolée la mise à jour des steps),
- soit une machine à état