### PR TITLE
Quick fix managers

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -131,5 +131,5 @@ group :development do
   gem 'rubocop-faker', require: false
   gem 'rubocop-i18n', require: false
   gem 'brakeman', require: false
-  gem "rails-erd", git: 'https://github.com/andrew-newell/rails-erd' # Compatibility for Rails 6.1, until https://github.com/voormedia/rails-erd/pull/365 is merged.
+  gem "rails-erd"
 end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,13 +1,3 @@
-GIT
-  remote: https://github.com/andrew-newell/rails-erd
-  revision: 9e174b3ef3e0588cdb628904b579f4fc5b354930
-  specs:
-    rails-erd (1.6.0)
-      activerecord (>= 4.2)
-      activesupport (>= 4.2)
-      choice (~> 0.2.0)
-      ruby-graphviz (~> 1.2)
-
 GEM
   remote: https://rubygems.org/
   specs:
@@ -414,6 +404,11 @@ GEM
     rails-dom-testing (2.0.3)
       activesupport (>= 4.2.0)
       nokogiri (>= 1.6)
+    rails-erd (1.6.1)
+      activerecord (>= 4.2)
+      activesupport (>= 4.2)
+      choice (~> 0.2.0)
+      ruby-graphviz (~> 1.2)
     rails-html-sanitizer (1.4.2)
       loofah (~> 2.3)
     rails-i18n (7.0.1)
@@ -672,7 +667,7 @@ DEPENDENCIES
   rack-attack
   rails
   rails-controller-testing
-  rails-erd!
+  rails-erd
   rails-i18n
   rails_autolink
   rails_real_favicon

--- a/app/admin/antenne.rb
+++ b/app/admin/antenne.rb
@@ -39,7 +39,13 @@ ActiveAdmin.register Antenne do
       div admin_link_to(a, :received_matches, blank_if_empty: true)
     end
     column(:manager) do |a|
-      div admin_link_to(a, :managers, list: true)
+      if a.managers.any?
+        div admin_link_to(a, :managers, list: true)
+      else
+        div a.manager_full_name
+        div a.manager_email
+        div a.manager_phone
+      end
     end
   end
 
@@ -88,7 +94,13 @@ ActiveAdmin.register Antenne do
         div admin_link_to(a, :received_matches)
       end
       row(:manager) do |a|
-        div admin_link_to(a, :managers, list: true)
+        if a.managers.any?
+          div admin_link_to(a, :managers, list: true)
+        else
+          div a.manager_full_name
+          div a.manager_email
+          div a.manager_phone
+        end
       end
       row(I18n.t('active_admin.territory.communes_list')) do |a|
         div displays_insee_codes(a.communes)

--- a/app/views/annuaire/antennes/_table.html.haml
+++ b/app/views/annuaire/antennes/_table.html.haml
@@ -29,3 +29,11 @@
                 %li= manager.full_name
                 %li= mail_to manager.email, manager.email, target: :blank
                 %li= link_to(manager.phone_number, "tel:#{manager.phone_number}")
+            - if antenne.managers.empty?
+              %ul
+                - if antenne.manager_full_name.present?
+                  %li= antenne.manager_full_name
+                - if antenne.manager_email.present?
+                  %li= mail_to antenne.manager_email, antenne.manager_email, target: :blank
+                - if antenne.manager_phone.present?
+                  %li= link_to(antenne.manager_phone, "tel:#{antenne.manager_phone}")


### PR DESCRIPTION
En lien avec #2195 et #2201 : la modélisation des managers n'est, en fait, pas stable -> des managers d'une antenne peuvent appartenir à une autre antenne. En attendant de clarifier le fonctionnement, on affiche de nouveau les anciens champs.

PR définitive en cours : #2212 