### PR TITLE
Amélioration de la gestion des slugs

### DIFF
--- a/app/models/concerns/with_slug.rb
+++ b/app/models/concerns/with_slug.rb
@@ -1,0 +1,23 @@
+module WithSlug
+  extend ActiveSupport::Concern
+
+  included do
+    validates :slug, presence: true, uniqueness: true
+    before_validation :compute_slug
+  end
+
+  def compute_slug
+    if slug_field.present? && slug.blank?
+      self.slug = slug_field
+    end
+    format_slug
+  end
+
+  def slug_field
+    title
+  end
+
+  def format_slug
+    self.slug = slug.dasherize.parameterize if slug.present?
+  end
+end

--- a/app/models/institution.rb
+++ b/app/models/institution.rb
@@ -24,6 +24,7 @@
 
 class Institution < ApplicationRecord
   include SoftDeletable
+  include WithSlug
 
   ## Associations
   #
@@ -38,8 +39,7 @@ class Institution < ApplicationRecord
   ## Hooks and Validations
   #
   auto_strip_attributes :name
-  validates :name, :slug, presence: true, uniqueness: true
-  before_validation :compute_slug
+  validates :name, presence: true, uniqueness: true
 
   ## Through Associations
   #
@@ -116,10 +116,8 @@ class Institution < ApplicationRecord
     name
   end
 
-  def compute_slug
-    if name.present?
-      self.slug = name.parameterize.underscore
-    end
+  def slug_field
+    name
   end
 
   def retrieve_antennes(region_id)

--- a/app/models/landing.rb
+++ b/app/models/landing.rb
@@ -32,6 +32,8 @@
 #
 
 class Landing < ApplicationRecord
+  include WithSlug
+
   enum layout: {
     multiple_steps: 1,
     single_page: 2
@@ -55,12 +57,10 @@ class Landing < ApplicationRecord
   has_many :solicitations, inverse_of: :landing
   accepts_nested_attributes_for :landing_joint_themes, allow_destroy: true
 
-  before_validation :compute_slug
   before_save :set_emphasis
 
   ## Validation
   #
-  validates :slug, presence: true, uniqueness: true
   validates :partner_url, presence: true, if: :iframe?
 
   ## Scopes
@@ -104,12 +104,6 @@ class Landing < ApplicationRecord
   def set_emphasis
     if emphasis
       Landing.where.not(id: id).update_all(emphasis: false)
-    end
-  end
-
-  def compute_slug
-    if title.present? && slug.blank?
-      self.slug = title.dasherize.parameterize
     end
   end
 end

--- a/app/models/landing_subject.rb
+++ b/app/models/landing_subject.rb
@@ -33,18 +33,14 @@
 #  fk_rails_...  (subject_id => subjects.id)
 #
 class LandingSubject < ApplicationRecord
+  include WithSlug
+
   ## Associations
   #
   belongs_to :subject, inverse_of: :landing_subjects
   belongs_to :landing_theme, inverse_of: :landing_subjects
   has_many :solicitations, inverse_of: :landing_subject, dependent: :restrict_with_exception
   has_and_belongs_to_many :logos, -> { order(:name) }, inverse_of: :landing_subjects
-
-  before_validation :compute_slug
-
-  ## Validation
-  #
-  validates :slug, presence: true, uniqueness: true
 
   ## Scopes
   #
@@ -77,11 +73,5 @@ class LandingSubject < ApplicationRecord
       .filter{ |_, value| value }
       .keys
       .map{ |flag| flag.to_s.delete_prefix('requires_').to_sym }
-  end
-
-  def compute_slug
-    if title.present? && slug.blank?
-      self.slug = title.dasherize.parameterize
-    end
   end
 end

--- a/app/models/landing_theme.rb
+++ b/app/models/landing_theme.rb
@@ -17,6 +17,8 @@
 #  index_landing_themes_on_slug  (slug) UNIQUE
 #
 class LandingTheme < ApplicationRecord
+  include WithSlug
+
   ## Associations
   #
   has_many :landing_joint_themes, -> { order(:position) }, inverse_of: :landing_theme, dependent: :destroy
@@ -26,25 +28,11 @@ class LandingTheme < ApplicationRecord
 
   accepts_nested_attributes_for :landing_subjects, allow_destroy: true
 
-  before_validation :compute_slug
-
-  ## Validation
-  #
-  validates :slug, presence: true, uniqueness: true
-
   def to_s
     title
   end
 
   def to_param
     slug
-  end
-
-  private
-
-  def compute_slug
-    if title.present? && slug.blank?
-      self.slug = title.dasherize.parameterize
-    end
   end
 end

--- a/spec/models/institution_spec.rb
+++ b/spec/models/institution_spec.rb
@@ -37,14 +37,14 @@ RSpec.describe Institution, type: :model do
     context 'manual call' do
       before { institution.compute_slug }
 
-      it { expect(institution.slug).to eq 'my_institution' }
+      it { expect(institution.slug).to eq 'my-institution' }
     end
 
     context 'before_validation hook' do
       before { institution.save }
 
       it do
-        expect(institution.slug).to eq 'my_institution'
+        expect(institution.slug).to eq 'my-institution'
         expect(institution).to be_valid
       end
     end


### PR DESCRIPTION
close #2221 

Seul changement notable : les slugs des Institutions, dont les "_" sont remplacés par des "-". J'ai l'impression que la seule justification à des slugs avec underscore était pour l'affichage des logos, mais comme on a changé le système, le remplacement pose pas de pb de ce côté-là.

Tu penses peut-être à un cas que ni moi ni les tests n'avons en tête, @LucienMLD  ?