### PR TITLE
disable autocomplete for siret

### DIFF
--- a/app/views/landings/landing_subjects/_new_solicitation_form.html.haml
+++ b/app/views/landings/landing_subjects/_new_solicitation_form.html.haml
@@ -11,18 +11,19 @@
         - if field == :siret
           // Duplication pour respecter l'accessibilité (id unique, field avec label...)
           = label_tag "solicitation_siret_autocomplete", t(".attributes.label.find_my_facility")
-          %span= t(".attributes.help.siret_html")
-          %div{ 'data-controller': "pages-siret-autocomplete" }
-            %div{ data: { 'pages-siret-autocomplete-target': "field", name: "solicitation[siret]", 'assistive-hint': t(".attributes.help.siret_assistive_hint"), 'landing-theme': solicitation.landing_theme.slug } }
+          -#
+            %span= t(".attributes.help.siret_html")
+            %div{ 'data-controller': "pages-siret-autocomplete" }
+             %div{ data: { 'pages-siret-autocomplete-target': "field", name: "solicitation[siret]", 'assistive-hint': t(".attributes.help.siret_assistive_hint"), 'landing-theme': solicitation.landing_theme.slug } }
             = f.hidden_field :code_region, data: { 'pages-siret-autocomplete-target': 'codeRegionField', 'deployed-regions': Territory.deployed_codes_regions }
-
             .notification.warning.autocomplete-warning{ data: { 'pages-siret-autocomplete-target': 'indifusibleBlock' } }
               = t(".attributes.help.indiffusible_siret_html")
-
             .notification.warning.autocomplete-warning{ data: { 'pages-siret-autocomplete-target': 'undeployedRegionBlock' } }
               = image_tag('info-alert-orange.png', alt: '')
               = t(".attributes.help.not_in_deployed_region_html")
               = link_to t('.clic_newsletter'), '#newsletter'
+          = f.text_field field, required: true, placeholder: '12345678900013', minlength: '14', maxlength: '14'
+          %span= t('.no_creation')
         - else
           = f.label field
           - if help.present?

--- a/config/locales/views.fr.yml
+++ b/config/locales/views.fr.yml
@@ -318,7 +318,7 @@ fr:
             siret_assistive_hint: Lorsque les résultats de l’auto-complétion sont disponibles, utilisez les flèches haut et bas pour les examiner et Entrée pour sélectionner une option. Les utilisateurs d’appareils tactiles peuvent sélectionner une option par en glissant et tapotant l'écran.
             siret_html: Recherche possible par SIREN
           label:
-            find_my_facility: Trouver votre numéro SIRET
+            find_my_facility: Votre numéro SIRET
           placeholder:
             description: Décrivez votre demande.
             email: marie.dupont@exemple.fr
@@ -335,6 +335,7 @@ fr:
         clic_newsletter: Je m'abonne.
         description: Description de votre demande
         legal_notice_html: "<p>Le Ministère du Travail (DGEFP) traite vos données personnelles dans le cadre d’une mission d’intérêt de service public. Place des Entreprises est un service de l’État qui vise à mettre en relation les TPE & PME avec les bons conseillers publics et ainsi de mobiliser les accompagnements publics existants (aides financières, conseils, accompagnements…) de manière adaptée. Pour mieux vous accompagner, vos données sont transmises aux partenaires publics et parapublics.</p><p>Pour exercer vos droits ou pour toute question relative au traitement de vos données à caractère personnel dans le cadre de ce dispositif, vous pouvez contacter l’équipe Place de Entreprises par voie électronique %{mailto_link} ou par courrier postal, à l’adresse suivante : Ministères Sociaux – DGEFP – FIMOD MISI RGPD 14 avenue Duquesne, 75007, Paris.</p><p>Pour en savoir plus, consultez les %{informations}.</p>"
+        no_creation: Le service n’accompagne pas à la création d’entreprise, ce numéro est nécessaire.
         submit_in_progress: Envoi en cours...
       new_solicitation_thank_you:
         iframe_message_html: "<p>Votre demande a bien été transmise à Place des Entreprises, le service public de mise en relation pour les TPE & PME. </p> <p>Un conseiller va vous appeler dans les <b>5 jours</b> ouvrés (en moyenne).</p> <p>Merci pour votre confiance !</p>"


### PR DESCRIPTION
Bloque le champ siret à 14 caractères et désactive l'autocomplete en attendant de le faire fonctionner avec 14 chiffres

close #2270