### PR TITLE
prevent undefined input for enum

### DIFF
--- a/app/admin/solicitation.rb
+++ b/app/admin/solicitation.rb
@@ -171,7 +171,7 @@ ActiveAdmin.register Solicitation do
   form do |f|
     f.inputs do
       f.input :description, as: :text
-      f.input :status, collection: Solicitation.human_attribute_values(:status).invert.to_a
+      f.input :status, as: :select, collection: Solicitation.human_attribute_values(:status).invert.to_a
       f.input :siret
       f.input :full_name
       f.input :phone_number


### PR DESCRIPTION
Normalement on ne va pas sur la page d'édition d'une sollicitation, mais au cas où, c'est mieux que d'avoir une erreur 500