### PR TITLE
améliore l'affichage des mentions d'informations dans une iframe

### DIFF
--- a/app/controllers/about_controller.rb
+++ b/app/controllers/about_controller.rb
@@ -1,4 +1,6 @@
 class AboutController < PagesController
+  include IframePrefix
+
   def cgu; end
 
   def mentions_d_information; end

--- a/app/helpers/breadcrumbs_helper.rb
+++ b/app/helpers/breadcrumbs_helper.rb
@@ -14,6 +14,13 @@ module BreadcrumbsHelper
     html
   end
 
+  # Use for "Mentions d'information" inside iframe
+  def breadcrumbs_iframe_home(landing, title)
+    html = home_link(landing, params)
+    html << title
+    html
+  end
+
   # Breadcrumbs used for other pages
   # Ex : "Déposer une demande › Comment ça marche ?"
   def breadcrumbs_page(title)

--- a/app/views/about/mentions_d_information.fr.html.erb
+++ b/app/views/about/mentions_d_information.fr.html.erb
@@ -6,7 +6,7 @@
   </div>
 </section>
 
-<%= render 'pages/breadcrumbs', title: t('.title') %>
+<%= render 'pages/breadcrumbs', title: t('.title'), landing: @landing.presence %>
 
 <section class="section section-grey">
   <div class="container container-medium">

--- a/app/views/landings/landing_subjects/_new_solicitation_form.html.haml
+++ b/app/views/landings/landing_subjects/_new_solicitation_form.html.haml
@@ -50,4 +50,4 @@
   .legal-notice
     = t('.legal_notice_html',
       mailto_link: mail_to('dpo@placedesentreprises.beta.gouv.fr', 'dpo@placedesentreprises.beta.gouv.fr', target: :_blank),
-      informations: link_to('mentions d’information', mentions_d_information_url))
+      informations: link_to('mentions d’information', mentions_d_information_url(landing_slug: solicitation.landing.slug)))

--- a/app/views/landings/landings/_pde_partnership_mention.html.haml
+++ b/app/views/landings/landings/_pde_partnership_mention.html.haml
@@ -1,5 +1,5 @@
 %section.section.section-grey.section-pde-partnership-mention
   .container.text-center
-    = link_to canonical_base_url, class: 'iframe-pde-logo', title: t('application.navbar.root_path_title') do
+    .iframe-pde-logo
       = image_tag 'logo-PDE.svg', alt: t('logos.pde')
     %p= t('application.pde_partnership_mention')

--- a/app/views/layouts/pages.html.haml
+++ b/app/views/layouts/pages.html.haml
@@ -19,7 +19,7 @@
     - if in_iframe?
       %meta{ name: 'robots', content: 'noindex' }
       = render 'shared/iframe_resizer'
-      - if defined? @landing
+      - if defined?(@landing) && @landing.present?
         %style= @landing.custom_css
 
     = render 'favicon'

--- a/app/views/pages/_breadcrumbs.html.haml
+++ b/app/views/pages/_breadcrumbs.html.haml
@@ -3,7 +3,7 @@
     - if defined? landing_theme
       - landing_subject ||= nil
       = raw breadcrumbs_landing(landing, landing_theme, landing_subject)
-    - elsif defined? landing
+    - elsif defined?(landing) && landing.present?
       = raw breadcrumbs_iframe_home(landing, title)
     - else
       = breadcrumbs_page(title)

--- a/app/views/pages/_breadcrumbs.html.haml
+++ b/app/views/pages/_breadcrumbs.html.haml
@@ -3,5 +3,7 @@
     - if defined? landing_theme
       - landing_subject ||= nil
       = raw breadcrumbs_landing(landing, landing_theme, landing_subject)
+    - elsif defined? landing
+      = raw breadcrumbs_iframe_home(landing, title)
     - else
       = breadcrumbs_page(title)


### PR DESCRIPTION
Enlève le lien sur le logo en bas de page si on active l'affichage du partenariat.
Enlève `X-Frame-Options` sur la page des mentions d'information quand on vient d'une iframe + retrait de la navbar et amélioration du fil d'ariane

closes #2353 