### PR TITLE
Créé personal_skillsets à la MAJ si besoin

### DIFF
--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -276,8 +276,13 @@ class User < ApplicationRecord
     self.experts.create!(self.attributes_shared_with_personal_skills)
   end
 
+  # Bizarrement, qq utilisateurs sont créés sans personal_skillsets (investigation en cours)
   def synchronize_personal_skillsets
-    self.personal_skillsets.update_all(self.attributes_shared_with_personal_skills)
+    if personal_skillsets.present?
+      self.personal_skillsets.update_all(self.attributes_shared_with_personal_skills)
+    else
+      self.experts.create!(self.attributes_shared_with_personal_skills)
+    end
   end
 
   ## Rights

--- a/app/services/csv_import/user_importer.rb
+++ b/app/services/csv_import/user_importer.rb
@@ -37,6 +37,16 @@ module CsvImport
     end
 
     def postprocess(user, attributes)
+      # Debug user sans personal skillsets
+      if user.personal_skillsets.empty?
+        Sentry.with_scope do |scope|
+          scope.set_tags({
+            user: user,
+            antenne: user.antenne
+          })
+          Sentry.capture_message("import user sans personal_skillset")
+        end
+      end
       team = import_team(user, attributes)
       expert = team || user.personal_skillsets.first
       if expert.present?

--- a/app/services/csv_import/user_importer.rb
+++ b/app/services/csv_import/user_importer.rb
@@ -40,10 +40,7 @@ module CsvImport
       # Debug user sans personal skillsets
       if user.personal_skillsets.empty?
         Sentry.with_scope do |scope|
-          scope.set_tags({
-            user: user,
-            antenne: user.antenne
-          })
+          scope.set_tags({ user_id: user.id })
           Sentry.capture_message("import user sans personal_skillset")
         end
       end

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -257,18 +257,36 @@ RSpec.describe User, type: :model do
   end
 
   describe '#synchronize_personal_skillsets' do
-    let(:user) { create :user, email: 'user@email.com', full_name: 'Bob', experts: [personal_skillset, team] }
-    let(:personal_skillset) { create :expert, email: 'user@email.com', full_name: 'Bob', users: [] }
-    let(:team) { create :expert, email: 'team@email.com', full_name: 'Team' }
+    context 'user with skillsets' do
+      let(:user) { create :user, email: 'user@email.com', full_name: 'Bob', experts: [personal_skillset, team] }
+      let(:personal_skillset) { create :expert, email: 'user@email.com', full_name: 'Bob', users: [] }
+      let(:team) { create :expert, email: 'team@email.com', full_name: 'Team' }
 
-    before do
-      user.update(full_name: 'Robert')
+      before do
+        user.update(full_name: 'Robert')
+      end
+
+      it 'automatically synchronizes the info in the personal skillsets' do
+        expect(user.reload.full_name).to eq 'Robert'
+        expect(personal_skillset.reload.full_name).to eq 'Robert'
+        expect(team.reload.full_name).not_to eq 'Robert'
+      end
     end
 
-    it 'automatically synchronizes the info in the personal skillsets' do
-      expect(user.reload.full_name).to eq 'Robert'
-      expect(personal_skillset.reload.full_name).to eq 'Robert'
-      expect(team.reload.full_name).not_to eq 'Robert'
+    context 'user without skillsets' do
+      let(:user) { create :user, email: 'user@email.com', full_name: 'Bob', experts: [team] }
+      let(:team) { create :expert, email: 'team@email.com', full_name: 'Team' }
+
+      before do
+        user.update(full_name: 'Robert')
+      end
+
+      it 'automatically synchronizes the info in the personal skillsets' do
+        expect(user.reload.full_name).to eq 'Robert'
+        expect(user.personal_skillsets).not_to be_empty
+        expect(user.personal_skillsets.first.full_name).to eq 'Robert'
+        expect(team.reload.full_name).not_to eq 'Robert'
+      end
     end
   end
 


### PR DESCRIPTION
Des utilisateurs sont créés sans expert `personal_skillsets`, ce qui téhoriquement ne devrait pas être possible. 

Les callback `  after_create :create_personal_skillset_if_needed` et `after_update :synchronize_personal_skillsets` semble ne pas bien fonctionner, ou bien ne pas toujours être appelés. Situation difficile à débuguer ; dans l'immédiat je modifie `synchronize_personal_skillsets` pour créer cet expert s'il est manquant.