### PR TITLE
fix une erreur sur la page des mentions d'informations

### DIFF
--- a/app/views/landings/landing_subjects/_new_solicitation_form.html.haml
+++ b/app/views/landings/landing_subjects/_new_solicitation_form.html.haml
@@ -48,6 +48,7 @@
   .form__group
     = f.submit t('.button.title'), class: 'button large', data: { disable_with: t('.submit_in_progress') }
   .legal-notice
+    - mentions_link = in_iframe? ? mentions_d_information_url(landing_slug: solicitation.landing.slug) : mentions_d_information_url
     = t('.legal_notice_html',
       mailto_link: mail_to('dpo@placedesentreprises.beta.gouv.fr', 'dpo@placedesentreprises.beta.gouv.fr', target: :_blank),
-      informations: link_to('mentions d’information', mentions_d_information_url(landing_slug: solicitation.landing.slug)))
+      informations: link_to('mentions d’information', mentions_link))


### PR DESCRIPTION
c'est quand on cliquait sur ce lien dans une landing normal

<img width="426" alt="Capture d’écran 2022-04-07 à 11 01 26" src="https://user-images.githubusercontent.com/22002486/162162563-7745e979-134a-4435-8739-5b2dd6a3fcfb.png">

closes #2399 