### PR TITLE
récupère les événements Matomo dans les iframes (normalement)

### DIFF
--- a/app/views/shared/_matomo.html.erb
+++ b/app/views/shared/_matomo.html.erb
@@ -3,6 +3,7 @@
   // Configure Matomo analytics
   _paq.push(['trackPageView']);
   _paq.push(['enableLinkTracking']);
+  _paq.push(['setCookieSameSite', 'None']);
 
   // Load script from Matomo
   (function() {


### PR DESCRIPTION
https://fr.matomo.org/faq/how-to/how-do-i-track-a-website-within-an-iframe/

https://developer.matomo.org/api-reference/tracking-javascript

closes #2404