### PR TITLE
Jeudi debug

### DIFF
--- a/app/controllers/concerns/iframe_prefix.rb
+++ b/app/controllers/concerns/iframe_prefix.rb
@@ -17,15 +17,9 @@ module IframePrefix
       @landing = Landing.not_archived.find_by(slug: landing_slug)
       redirect_to root_path, status: :moved_permanently if @landing.nil?
     end
-    # Controller Solicitation#new & create
-    landing_id = params[:landing_id] || params.dig(:solicitation, :landing_id)
-    if landing_id.present?
-      @landing = Landing.not_archived.find(landing_id)
-      redirect_to root_path, status: :moved_permanently if @landing.nil?
-    end
-    landing_subject_id = params[:landing_subject_id] || params.dig(:solicitation, :landing_subject_id)
-    if landing_subject_id.present?
-      @landing_subject = LandingSubject.not_archived.find(landing_subject_id)
+    landing_subject_slug = params[:landing_subject_slug]
+    if landing_subject_slug.present?
+      @landing_subject = LandingSubject.not_archived.find_by(slug: landing_subject_slug)
       redirect_to root_path, status: :moved_permanently if @landing_subject.nil?
     end
     # Controller Solicitation#other_methods

--- a/app/controllers/landings/landings_controller.rb
+++ b/app/controllers/landings/landings_controller.rb
@@ -23,7 +23,7 @@ class Landings::LandingsController < Landings::BaseController
       redirect_to landing_theme_path(@landing, landing_theme)
     elsif @landing.form_iframe?
       landing_subject = @landing.landing_subjects.not_archived.first
-      redirect_to new_solicitation_path(landing_id: @landing.id, landing_subject_id: landing_subject.id)
+      redirect_to new_solicitation_path(@landing.slug, landing_subject.slug)
     else
       render :show
     end

--- a/app/helpers/solicitation_helper.rb
+++ b/app/helpers/solicitation_helper.rb
@@ -54,7 +54,7 @@ module SolicitationHelper
       subject = landing_subject.subject
       title_components[t('attributes.subject')] = subject
       title = "#{t('attributes.subject')} : #{subject}"
-      path = new_solicitation_path(landing_id: solicitation.landing.id, landing_subject_id: solicitation.landing_subject.id, siret: params[:siret].presence, anchor: 'section-breadcrumbs')
+      path = new_solicitation_path(solicitation.landing.slug, solicitation.landing_subject.slug, siret: params[:siret].presence, anchor: 'section-breadcrumbs')
       link_to landing_subject.title, path, class: classes, title: title
     end
   end

--- a/app/views/landings/landing_subjects/_card.html.haml
+++ b/app/views/landings/landing_subjects/_card.html.haml
@@ -1,6 +1,6 @@
 .card.block-link
   .card__content
-    - path = new_solicitation_path(landing_id: landing.id, landing_subject_id: landing_subject.id, siret: params[:siret].presence, anchor: 'section-breadcrumbs')
+    - path = new_solicitation_path(landing.slug, landing_subject.slug, siret: params[:siret].presence, anchor: 'section-breadcrumbs')
     %h3= link_to landing_subject.title.html_safe, path, class: 'click-on-landing-subject'
     - if landing_subject.description?
       %p= sanitize landing_subject.description.html_safe

--- a/app/views/sitemap/sitemap.xml.builder
+++ b/app/views/sitemap/sitemap.xml.builder
@@ -18,7 +18,7 @@ xml.urlset xmlns: "http://www.sitemaps.org/schemas/sitemap/0.9" do
 
       landing_theme.landing_subjects.each do |landing_subject|
         xml.url do
-          xml.loc landing_subject_url(landing, landing_subject)
+          xml.loc new_solicitation_path(landing.slug, landing_subject.slug)
           xml.lastmod landing_subject.updated_at.iso8601
           xml.changefreq 'weekly'
         end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -230,7 +230,7 @@ Rails.application.routes.draw do
     end
   end
 
-  resources :solicitations, only: %i[create new], param: :uuid, path: 'votre-demande', path_names: { new: 'nouvelle-demande' } do
+  resources :solicitations, only: %i[create], param: :uuid, path: 'votre-demande', path_names: { new: 'nouvelle-demande' } do
     member do
       get :step_contact, path: 'contact'
       patch :update_step_contact
@@ -241,6 +241,7 @@ Rails.application.routes.draw do
       get :form_complete, path: 'merci'
     end
   end
+  get 'aide-entreprise/:landing_slug/demande/:landing_subject_slug', to: 'solicitations#new', as: :new_solicitation
 
   resource :newsletters, only: %i[] do
     post :create

--- a/spec/a11y/a11y_spec.rb
+++ b/spec/a11y/a11y_spec.rb
@@ -35,7 +35,7 @@ describe 'a11y', type: :feature, js: true do
   describe '/aide-entreprise/:landing_slug/demande/:slug' do
     before do
       landing = Landing.last
-      visit "/votre-demande/nouvelle-demande?landing_id=#{landing.id}&landing_subject_id=#{landing.landing_subjects.first.id}"
+      visit "/aide-entreprise/#{landing.slug}/demande/#{landing.landing_subjects.first.slug}"
     end
 
     it { is_expected.to be_accessible }

--- a/spec/controllers/landings/landings_controller_spec.rb
+++ b/spec/controllers/landings/landings_controller_spec.rb
@@ -55,7 +55,7 @@ RSpec.describe Landings::LandingsController, type: :controller do
 
       it do
         get :show, params: { landing_slug: landing.slug }
-        expect(response).to redirect_to new_solicitation_path(landing_id: landing.id, landing_subject_id: landing_subject.id)
+        expect(response).to redirect_to new_solicitation_path(landing.slug, landing_subject.slug)
       end
     end
   end


### PR DESCRIPTION
- modification de la route `new_solicitation`, pour arrêter de perdre les bots, et rester cohérent (pas de redirection requise) : https://sentry.io/organizations/place-des-entreprises-org/issues/3314753404/events/?cursor=0%3A100%3A0&project=5747178
- correction d'une url dans la `sitemap` : https://sentry.io/organizations/place-des-entreprises-org/issues/3314427368/?environment=production&project=5747178&query=is%3Aunresolved