### PR TITLE
add gem matrix

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -69,6 +69,7 @@ gem 'highline'
 gem 'caxlsx'
 gem 'caxlsx_rails'
 gem 'split', require: 'split/dashboard'
+gem 'matrix'
 
 # Notifiers
 gem "sentry-ruby"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -377,8 +377,6 @@ GEM
     nokogiri (1.13.8)
       mini_portile2 (~> 2.8.0)
       racc (~> 1.4)
-    nokogiri (1.13.8-x86_64-darwin)
-      racc (~> 1.4)
     orm_adapter (0.5.0)
     parallel (1.22.1)
     parallel_tests (3.11.1)
@@ -697,6 +695,7 @@ DEPENDENCIES
   kaminari
   letter_opener_web
   listen
+  matrix
   metamagic
   parallel_tests
   pg


### PR DESCRIPTION
Matrix was removed in ruby 3.1
https://www.ruby-lang.org/en/news/2021/12/25/ruby-3-1-0-released/