### PR TITLE
Amélioration erreurs autocompletion siret

### DIFF
--- a/app/front/javascripts/pages/controllers/pages_siret_autocomplete_controller.js
+++ b/app/front/javascripts/pages/controllers/pages_siret_autocomplete_controller.js
@@ -17,6 +17,12 @@ export default class extends SiretAutocompleteController {
     }
   }
 
+  manageSourceError(results) {
+    this.loaderTarget.style.display = 'none'
+    this.noResultLinkTarget.style.display = 'block'
+    this.statusMessage = results.error
+  }
+
   manageSourceSuccess(items) {
     this.loaderTarget.style.display = 'none'
     if (items.length == 0) {

--- a/app/front/javascripts/shared/controllers/siret_autocomplete_controller.js
+++ b/app/front/javascripts/shared/controllers/siret_autocomplete_controller.js
@@ -40,7 +40,7 @@ export default class extends Controller {
         return `${baseSentence}. ${contentSelectedOption}`
       },
       source: debounce(async (query, populateResults) => {
-         const results = await this.fetchEtablissements(query);
+        const results = await this.fetchEtablissements(query);
         if(!results) return;
         if (results.error) {
           this.manageSourceError(results)

--- a/app/services/api_insee/base.rb
+++ b/app/services/api_insee/base.rb
@@ -28,7 +28,8 @@ module ApiInsee
     end
 
     def handle_error(http_request)
-      raise ApiInseeError, http_request.error_message
+      Sentry.capture_message(http_request.error_message)
+      raise ApiInseeError, I18n.t('api_requests.generic_error')
     end
 
     def id_key


### PR DESCRIPTION
Les Api présentent en ce moment des faiblesses qui bloquaient l'autocomplétion. 
Trois modifications pour fluidifier :

- affichage d'un message standard en bon francais dans le champs d'autocompletion si une erreur inattendue est renvoyée par l'API
- en parallèle, envoi d'un notif d'erreur dans notre gestionnaire d'erreurs
- apparition du lien pour saisir manuellement son siret en cas d'erreur (pour le moment, c'était qu'en cas de résultat vide, ce qui est clairement pas suffisant)

