### PR TITLE
corrige la duplication d'un utilisateur

### DIFF
--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -322,7 +322,7 @@ class User < ApplicationRecord
     user_experts = self.relevant_experts - self.personal_skillsets
     # si c'est une équipe
     if user_experts.present?
-      new_user.relevant_experts = user_experts
+      new_user.relevant_experts << user_experts
       new_user.save
     # si c'est un expert personnel on attribue les sujets à l'expert personnel du nouvel utilisateur
     elsif self.personal_skillsets.map(&:experts_subjects).present?

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -313,18 +313,19 @@ RSpec.describe User, type: :model do
     let(:a_subject) { create :subject }
     let(:institution_subject) { create :institution_subject, institution: institution, subject: a_subject }
     let(:expert_subject) { create :expert_subject, institution_subject: institution_subject }
-    let(:old_user) { create :user, :invitation_accepted, :manager, experts: [expert], antenne: antenne }
+    let(:old_user) { create :user, :invitation_accepted, :manager, experts: [expert], antenne: antenne, full_name: 'Old User' }
 
     context 'with team' do
       let(:expert) { create :expert_with_users, experts_subjects: [expert_subject] }
-      let(:new_user) { old_user.duplicate({ full_name: 'Bruce Benamran', email: 'test1@email.com', phone_number: '0303030303' }) }
+      let(:new_user) { old_user.duplicate({ full_name: 'New User', email: 'test1@email.com', phone_number: '0303030303' }) }
 
       it "duplicate a user and add it to old_user team" do
-        expect(new_user.full_name).to eq 'Bruce Benamran'
+        expect(new_user.full_name).to eq 'New User'
         expect(new_user.email).to eq 'test1@email.com'
         expect(new_user.phone_number).to eq '03 03 03 03 03'
         expect(new_user.job).to eq old_user.job
         expect(new_user.antenne).to eq old_user.antenne
+        expect(new_user.antenne.experts.count).to eq 2
         expect(new_user.experts.map { |e| e.subjects }.flatten).to match_array [a_subject]
         expect(new_user.relevant_experts).to match_array [expert]
         expect(new_user.user_rights.count).to eq 1


### PR DESCRIPTION
Deux experts personnel pour le même utilisateur étaient créés

closes #2672 