### PR TITLE
desactive turbo sur les liens des relances et sollicitations

### DIFF
--- a/app/views/application/_navbar.html.haml
+++ b/app/views/application/_navbar.html.haml
@@ -48,10 +48,10 @@
                 %span.ri-file-text-line.fr-mr-1w{ 'aria-hidden': 'true' }
                 = t('.reports')
             - if policy(User).admin?
-              = active_link_to conseiller_solicitations_path, class: 'fr-nav__link', wrap_tag: :li, wrap_class: 'fr-nav__item', class_active: 'fr-nav__item--active' do
+              = active_link_to conseiller_solicitations_path, class: 'fr-nav__link', wrap_tag: :li, wrap_class: 'fr-nav__item', class_active: 'fr-nav__item--active', data: { turbo: false } do
                 %span.ri-message-2-line.fr-mr-1w{ 'aria-hidden': 'true' }
                 = t('solicitations.index.title')
-              = active_link_to reminders_path, class: 'fr-nav__link', wrap_tag: :li, wrap_class: 'fr-nav__item', class_active: 'fr-nav__item--active' do
+              = active_link_to reminders_path, class: 'fr-nav__link', wrap_tag: :li, wrap_class: 'fr-nav__item', class_active: 'fr-nav__item--active', data: { turbo: false } do
                 %span.ri-feedback-line.fr-mr-1w{ 'aria-hidden': 'true' }
                 = t('reminders.index.title')
           %ul.fr-nav__list


### PR DESCRIPTION
Permet à la recherche par territoire d'être correctement chargé