### PR TITLE
Relance cards

### DIFF
--- a/app/front/stylesheets/components/cards.sass
+++ b/app/front/stylesheets/components/cards.sass
@@ -146,8 +146,7 @@
       width: 100%
       order: 1
   .fr-accordion__btn
-    padding-left: 0
-    margin: 0
+    padding: 0.25rem 0.75rem
 
 .close-need-box
   .fr-card__title

--- a/app/front/stylesheets/components/components.sass
+++ b/app/front/stylesheets/components/components.sass
@@ -24,6 +24,8 @@
     .picto
       font-size: 1rem
       margin-right: 0.5rem
+    .picto[title]
+        cursor: help
 
 hr.separation
   height: 1px

--- a/app/front/stylesheets/components/components.sass
+++ b/app/front/stylesheets/components/components.sass
@@ -62,7 +62,7 @@ hr.separation
     margin-top: 0.7rem
 
 .feedback
-  margin-bottom: 3rem
+  margin-bottom: 2rem
   .author
     display: flex
     align-items: center
@@ -71,9 +71,10 @@ hr.separation
   .author-name
     display: flex
     align-items: center
-    margin-top: 0.5rem
+    margin-top: 0.15rem
   .date
     line-height: 0.5rem
+    font-size: 0.75rem
     @media (max-width: $bp-sm)
       line-height: 1.5rem
   .icon
@@ -81,7 +82,7 @@ hr.separation
   .delete-form
     display: flex
   .content
-    margin: 0.5rem 0rem 0rem 3rem
+    margin-left: 3rem
     position: relative
     &::before
       content: ""
@@ -95,6 +96,8 @@ hr.separation
       border-width: 0 0 0 1px
   .fr-icon-delete-line
     padding-top: 1.2rem
+  button.fr-tag.custom-modal-tag.custom-modal-tag--blue
+    background-color: transparent
 
 .feedbacks-form
   label

--- a/app/front/stylesheets/components/components.sass
+++ b/app/front/stylesheets/components/components.sass
@@ -1,5 +1,7 @@
 .block-infos
   line-height: 1.8rem
+  &:not(:last-child)
+    margin-bottom: 0.875rem
   ul
     li
       display: flex
@@ -14,6 +16,7 @@
     margin-right: 1rem
   &.compact
     line-height: 1.6rem
+    font-size: 0.875rem
     ul
       li
         margin-bottom: 0

--- a/app/helpers/badges_helper.rb
+++ b/app/helpers/badges_helper.rb
@@ -5,10 +5,4 @@ module BadgesHelper
     tag.div(badge.title, class: 'label',
                 style: "border: 1px solid #{badge.color}; color: #{badge.color}")
   end
-
-  def expert_positionning_rate_tag(expert)
-    # Pour avoir un pourcentage de positionnement, et non de non positionnement
-    rate = 100 - (PositionningRate::Member.new(expert).rate.round(2) * 100)
-    tag.div("#{rate.to_i} %", class: 'fr-tag')
-  end
 end

--- a/app/views/application/_user_admin_view.haml
+++ b/app/views/application/_user_admin_view.haml
@@ -1,0 +1,19 @@
+.block-infos.compact
+  %ul.list-unstyled.fr-pl-1v
+    %li.name
+      %b
+        = link_to user.full_name.presence, admin_user_path(user), title: t('admin_link')
+        - if user.invitation_not_accepted?
+          %span.picto.ri-mail-forbid-line{ 'aria-hidden': 'true' }
+    - if user.job.present?
+      %li
+        %span.picto.ri-contacts-book-line{ 'aria-hidden': 'true' }
+        = user.job
+    - if user.phone_number.present?
+      %li
+        %span.picto.ri-phone-line{ 'aria-hidden': 'true' }
+        = link_to(user.phone_number, "tel:#{ERB::Util.url_encode(user.phone_number)}", class: 'fr-link')
+    - if user.email.present?
+      %li
+        %span.picto.ri-mail-line{ 'aria-hidden': 'true' }
+        = mail_to user.email, user.email, class: 'fr-link'

--- a/app/views/application/_user_admin_view.haml
+++ b/app/views/application/_user_admin_view.haml
@@ -2,9 +2,9 @@
   %ul.list-unstyled.fr-pl-1v
     %li.name
       %b
-        = link_to user.full_name.presence, admin_user_path(user), title: t('admin_link')
+        = link_to user.full_name, admin_user_path(user), title: t('admin_link')
         - if user.invitation_not_accepted?
-          %span.picto.ri-mail-forbid-line{ 'aria-hidden': 'true' }
+          %span.picto.ri-mail-forbid-line{ 'aria-hidden': 'true', title: t('.invitation_not_accepted') }
     - if user.job.present?
       %li
         %span.picto.ri-contacts-book-line{ 'aria-hidden': 'true' }

--- a/app/views/feedbacks/_feedback.haml
+++ b/app/views/feedbacks/_feedback.haml
@@ -8,11 +8,11 @@
       %span.icon{ class: (mine ? 'ri-chat-1-fill blue' : 'ri-chat-1-line'), 'aria-hidden': 'true' }
     .author-data
       .date= I18n.l(feedback.created_at, format: :long)
-      %p.author-name
+      %p.author-name.fr-text--sm
         - if mine
           %b= user.full_name
         - else
-          %button.fr-tag.fr-icon-information-line.fr-tag--icon-left.custom-modal-tag.custom-modal-tag--blue{ 'aria-controls': "modal-user-#{user.id}", 'data-fr-opened': 'false', title: t('application.modal.see_person_coordinates') }
+          %button.fr-text--sm.fr-tag.fr-icon-information-line.fr-tag--icon-left.custom-modal-tag.custom-modal-tag--blue{ 'aria-controls': "modal-user-#{user.id}", 'data-fr-opened': 'false', title: t('application.modal.see_person_coordinates') }
             = user.full_name
 
         = " - #{user.antenne}"

--- a/app/views/reminders/experts/_expert.haml
+++ b/app/views/reminders/experts/_expert.haml
@@ -41,13 +41,6 @@
             - expert.users.each do |user|
               = person_block(user, compact: true)
   .fr-card__body
-    - cache ["positionning_rate", expert, expert.received_quo_matches] do
-      .fr-grid-row
-        .fr-col-7
-          .card-expert__subtitle= t('.positionning_rate')
-        .fr-col-5
-          = expert_positionning_rate_tag(expert)
-
     - cache ["received_matches", expert, expert.received_matches] do
       .card-expert__subtitle= t('.matches_total')
       .fr-tags-group

--- a/app/views/reminders/experts/_expert.haml
+++ b/app/views/reminders/experts/_expert.haml
@@ -61,7 +61,8 @@
           .fr-ml-1v= t(:archived, scope: 'needs.collections').downcase
 
     %hr
-    %div{ id: "display-feedbacks-#{expert.id}" }
+    = render 'feedbacks/form', feedback: expert.reminder_feedbacks.new
+    .fr-mt-3w{ id: "display-feedbacks-#{expert.id}" }
       - feedbacks = expert.reminder_feedbacks.order(created_at: :desc)
       = render partial: 'feedbacks/feedback', collection: feedbacks.limit(2)
       -# On affiche les 2 premiers commentaires, les autres sont dépliables
@@ -73,7 +74,6 @@
             = t('.see_remaining_feedbacks', count: remaining_feedbacks.size)
         .fr-collapse.fr-pt-2w{ id: "hidden-feedbacks-#{expert.id}" }
           = render partial: 'feedbacks/feedback', collection: remaining_feedbacks
-    = render 'feedbacks/form', feedback: expert.reminder_feedbacks.new
 
   .card__footer
     = form_with model: expert, url: send_reminder_email_reminders_expert_path(expert), method: :post do |f|

--- a/app/views/reminders/experts/_expert.haml
+++ b/app/views/reminders/experts/_expert.haml
@@ -10,6 +10,10 @@
             %li
               %span.picto.ri-contacts-book-line{ 'aria-hidden': 'true' }
               = expert.job
+          - if expert.antenne.present?
+            %li
+              %span.picto.ri-government-line{ 'aria-hidden': 'true' }
+              = expert.antenne.name
           - if expert.phone_number.present?
             %li
               %span.picto.ri-phone-line{ 'aria-hidden': 'true' }
@@ -35,11 +39,10 @@
       .fr-grid-row
         .fr-col-7
           .fr-accordion__title
-            %button.fr-accordion__btn{ 'aria-controls': "accordion-#{expert.id}", 'aria-expanded': 'false' }
+            %button.fr-accordion__btn.fr-btn.fr-btn--secondary.fr-btn--sm{ 'aria-controls': "accordion-#{expert.id}", 'aria-expanded': 'false' }
               = t('.team_composition')
           .fr-collapse.team-members{ id: "accordion-#{expert.id}" }
-            - expert.users.each do |user|
-              = person_block(user, compact: true)
+            = render partial: 'user_admin_view', collection: expert.users, as: :user
   .fr-card__body
     - cache ["received_matches", expert, expert.received_matches] do
       .card-expert__subtitle= t('.matches_total')

--- a/app/views/reminders/experts/_expert.haml
+++ b/app/views/reminders/experts/_expert.haml
@@ -59,7 +59,17 @@
 
     %hr
     %div{ id: "display-feedbacks-#{expert.id}" }
-      = render partial: 'feedbacks/feedback', collection: expert.reminder_feedbacks.order(:created_at)
+      - feedbacks = expert.reminder_feedbacks.order(created_at: :desc)
+      = render partial: 'feedbacks/feedback', collection: feedbacks.limit(2)
+      -# On affiche les 2 premiers commentaires, les autres sont dépliables
+      - if expert.reminder_feedbacks.size > 2
+        - remaining_feedbacks = feedbacks.offset(2)
+        %section.fr-accordion
+          %h4.fr-accordion__title
+          %button.fr-accordion__btn.fr-text--sm{ aria: { expanded: "false", controls: "hidden-feedbacks-#{expert.id}" } }
+            = t('.see_remaining_feedbacks', count: remaining_feedbacks.size)
+        .fr-collapse.fr-pt-2w{ id: "hidden-feedbacks-#{expert.id}" }
+          = render partial: 'feedbacks/feedback', collection: remaining_feedbacks
     = render 'feedbacks/form', feedback: expert.reminder_feedbacks.new
 
   .card__footer

--- a/config/locales/views.fr.yml
+++ b/config/locales/views.fr.yml
@@ -53,6 +53,7 @@ fr:
       reassign_matches:
         save: Enregistrer
         select_user: Utilisateur pour la réatribution des mises en relation
+  admin_link: Lien admin
   annuaire:
     base:
       import_errors:

--- a/config/locales/views.fr.yml
+++ b/config/locales/views.fr.yml
@@ -848,8 +848,8 @@ fr:
         expert_creation_date: Inscription le %{date}
         manager_name: 'Responsable : %{name}'
         matches_total: Demandes depuis le début
-        positionning_rate: Taux de positionnement sur 60 jours
         received_matches: reçues
+        see_remaining_feedbacks: Voir les commentaires + anciens (%{count})
         send_reminders_email: Envoyer l’email de relance
         team_composition: Composition de l'équipe
       index:

--- a/config/locales/views.fr.yml
+++ b/config/locales/views.fr.yml
@@ -120,6 +120,8 @@ fr:
     pde_partnership_mention: Ce service public de mise en relation est proposé par Place des Entreprises.
     person_modal:
       manager_name: 'Responsable : %{name}'
+    user_admin_view:
+      invitation_not_accepted: Cette personne n'a pas encore accepté son invitation
   at_your_disposal: Nous restons à votre disposition pour tout complément d’informations.
   attributes:
     is_global_zone: Territoire national
@@ -850,7 +852,7 @@ fr:
         manager_name: 'Responsable : %{name}'
         matches_total: Demandes depuis le début
         received_matches: reçues
-        see_remaining_feedbacks: Voir les commentaires + anciens (%{count})
+        see_remaining_feedbacks: Voir les commentaires plus anciens (%{count})
         send_reminders_email: Envoyer l’email de relance
         team_composition: Composition de l'équipe
       index:


### PR DESCRIPTION
close #2860 
Reste à gérer : " la couleur sur la partie grisée des cartes pour égayer l’interface, selon les 3 catégories"

A faire une fois que la relance expert est calée