### PR TITLE
Nettoyage automatique des landing subjects

### DIFF
--- a/app/models/landing_subject.rb
+++ b/app/models/landing_subject.rb
@@ -54,6 +54,8 @@ class LandingSubject < ApplicationRecord
   #
   scope :ordered_for_landing, -> { order(:position, :id) }
 
+  before_save :autoclean_textareas
+
   validate :unique_required_field_if_siret
 
   def to_s
@@ -89,6 +91,15 @@ class LandingSubject < ApplicationRecord
     if (requires_siret == true) && (required_fields.length > 1)
       errors.add(:base, "ne peut être coché en même temps que d'autres champs")
       landing_theme.errors.add(:base, "ne peut être coché en même temps que d'autres champs")
+    end
+  end
+
+  private
+
+  def autoclean_textareas
+    cleanable_fields = %i[description description_explanation description_prefill form_description]
+    cleanable_fields.each do |attribute_name|
+      self[attribute_name] = self[attribute_name].gsub('<p><br></p>','') if self[attribute_name].present?
     end
   end
 end

--- a/spec/models/landing_subject_spec.rb
+++ b/spec/models/landing_subject_spec.rb
@@ -1,0 +1,22 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe LandingSubject do
+  describe 'autoclean_textareas' do
+    let!(:landing_subject) do
+      create :landing_subject,
+             description: '<p>Description</p>',
+             description_explanation: "<ul><li>votre activité </li><li>le statut de l'entreprise</li></ul><p><br></p>",
+             description_prefill: "Bonjour,\r\n\r\nMon entreprise a une activité de \r\n\r\nMerci d'avance pour votre appel",
+             form_description: "<p><br></p><p>Quelque chose.</p><p><br></p>"
+    end
+
+    it do
+      expect(landing_subject.description).to eq('<p>Description</p>')
+      expect(landing_subject.description_explanation).to eq("<ul><li>votre activité </li><li>le statut de l'entreprise</li></ul>")
+      expect(landing_subject.description_prefill).to eq("Bonjour,\r\n\r\nMon entreprise a une activité de \r\n\r\nMerci d'avance pour votre appel")
+      expect(landing_subject.form_description).to eq('<p>Quelque chose.</p>')
+    end
+  end
+end


### PR DESCRIPTION
close #2883 

A faire tourner en console : 
```ruby
LandingSubject.all.map do |ls|
  ls.send(:autoclean_textareas)
  ls.save
end
```