### PR TITLE
corrige le message affiché quand on cloture un besoin et laisse un commentaire

### DIFF
--- a/app/views/feedbacks/create.js.haml
+++ b/app/views/feedbacks/create.js.haml
@@ -13,6 +13,10 @@ var form = document.getElementsByClassName('from_alert_box');
 if (form.length > 0) {
 form[0].insertAdjacentHTML('beforebegin', "#{j I18n.t('feedbacks.form.thank_you_html').html_safe}");
 form[0].parentNode.removeChild(form[0]);
+var orangeBox = document.getElementsByClassName('orange-box')
+-# Si orangeBox est présent c'est que le besoin à été refusé
+if (orangeBox.length > 0) {
 text = document.getElementsByClassName('explanations');
 text[0].innerHTML = "#{j I18n.t('needs.match_actions.need_canceled_short')}";
+}
 }


### PR DESCRIPTION
quand on clôturait un message avec une aide proposée et qu'on laissait un commentaire, un texte nous indiquant qu'on avait bien refusé était affiché