### PR TITLE
Correction RGAA

### DIFF
--- a/app/views/landings/landings/_pde_partnership_mention.html.haml
+++ b/app/views/landings/landings/_pde_partnership_mention.html.haml
@@ -1,5 +1,5 @@
 .fr-container--fluid.section-grey.fr-py-2w.section-pde-partnership-mention
   .fr-container.text-center
     .iframe-pde-logo
-      = image_tag 'logo-PDE.svg', alt: t('logos.pde')
+      = image_tag 'logo-PDE.svg', alt: t('logos.pde'), 'aria-hidden': 'true'
     %p= t('application.pde_partnership_mention')


### PR DESCRIPTION
Bonjour, nous avons fait un audit RGAA pour mon-entreprise et ils nous on remonté que l'image PdE en bas de l'iframe était de trop pour un lecteur d'écran, ajouter simplement un `aria-hidden="true"` leur conviendrait.

> critère 1.2 - Chaque image de décoration est-elle correctement ignorée par les technologies d’assistance ?

![image](https://user-images.githubusercontent.com/6691954/233950445-e72d2ea4-8425-4d93-b04f-ab656a011a76.png)

Sur cette image :
![image](https://user-images.githubusercontent.com/6691954/233951174-7e0fdbb3-e9a1-45c9-bd69-548559bfe340.png)