### PR TITLE
Notifie les experts qui n'ont pas pris en charge quand c'est un admin qui poste un commentaire

### DIFF
--- a/app/models/feedback.rb
+++ b/app/models/feedback.rb
@@ -52,7 +52,11 @@ class Feedback < ApplicationRecord
   # Notify experts of this need
   # don't send an email to their personal address
   def persons_to_notify
-    users_and_experts_to_notify = self.need.matches.where(status: [:taking_care, :done_not_reachable]).map(&:expert)
+    users_and_experts_to_notify = if self.user.is_admin?
+      self.need.matches.where(status: [:quo, :taking_care, :done_not_reachable]).map(&:expert)
+    else
+      self.need.matches.where(status: [:taking_care, :done_not_reachable]).map(&:expert)
+    end
 
     # don’t notify the author themselves
     users_and_experts_to_notify -= self.user.experts

--- a/spec/models/feedback_spec.rb
+++ b/spec/models/feedback_spec.rb
@@ -47,7 +47,7 @@ RSpec.describe Feedback do
       let!(:author) { create :user, :admin }
 
       it 'Don’t notify advisor' do
-        is_expected.to contain_exactly(expert_taking_care, expert_not_reachable)
+        is_expected.to contain_exactly(expert_taking_care, expert_not_reachable, expert_quo)
       end
     end
   end


### PR DESCRIPTION
C'est un raté quand on a simplifié l'envoie des emails en décembre. On a oublié quand c'est envoyé par un admin

closes #3045