### PR TITLE
Améliore la suppression des sollicitations en admin

### DIFF
--- a/app/admin/solicitation.rb
+++ b/app/admin/solicitation.rb
@@ -99,7 +99,7 @@ ActiveAdmin.register Solicitation do
     else
       resource.diagnosis&.destroy
       resource.destroy
-      redirect_to admin_solicitations_path, notice: t('active_admin.solicitations.deleted')
+      redirect_to admin_solicitations_path, notice: t('active_admin.solicitations.deleted.one')
     end
   end
 
@@ -262,5 +262,23 @@ ActiveAdmin.register Solicitation do
       Solicitation.where(id: ids).each { |s| s.badges.delete(badge) }
     end
     redirect_to collection_path, notice: I18n.t('active_admin.badges.modified', action: inputs[:action].gsub('er', 'é'))
+  end
+
+  batch_action(I18n.t('active_admin.solicitations.batch_delete')) do |ids|
+    errors_count = 0
+    batch_action_collection.find(ids).each do |resource|
+      if resource.diagnosis.present? && resource.diagnosis_completed?
+        errors_count += 1
+      else
+        resource.diagnosis&.destroy
+        resource.destroy
+      end
+    end
+    message = if errors_count.positive?
+      { alert: t('active_admin.solicitations.not_deleted', count: errors_count) }
+    else
+      { notice: t('active_admin.solicitations.deleted', count: ids.count) }
+    end
+    redirect_back fallback_location: collection_path, **message
   end
 end

--- a/app/admin/solicitation.rb
+++ b/app/admin/solicitation.rb
@@ -103,7 +103,7 @@ ActiveAdmin.register Solicitation do
     end
   end
 
-  action_item :export_csv, only: :show, method: :post do
+  action_item :delete_solicitation, only: :show, method: :post do
     link_to t('active_admin.solicitations.delete'), delete_admin_solicitation_path(resource), method: :delete, 'data-confirm': t('active_admin.solicitations.delete_confirm')
   end
 

--- a/app/admin/solicitation.rb
+++ b/app/admin/solicitation.rb
@@ -5,6 +5,8 @@ ActiveAdmin.register Solicitation do
 
   menu priority: 7
 
+  actions :all, :except => [:destroy]
+
   ## Index
   #
   scope :step_complete, default: true
@@ -78,7 +80,7 @@ ActiveAdmin.register Solicitation do
     end
   end
 
-  before_action :only => :index do
+  before_action only: :index do
     @landing_themes = if params[:q].present? && params[:q][:landing_id_eq].present?
       Landing.find(params[:q][:landing_id_eq]).landing_themes
     else
@@ -89,6 +91,20 @@ ActiveAdmin.register Solicitation do
     else
       LandingSubject.all
     end
+  end
+
+  member_action :delete, method: :delete do
+    if resource.diagnosis_completed?
+      redirect_to resource_path, alert: t('active_admin.solicitations.diagnosis_exists')
+    else
+      resource.diagnosis.destroy
+      resource.destroy
+      redirect_to admin_solicitations_path, notice: t('active_admin.solicitations.deleted')
+    end
+  end
+
+  action_item :export_csv, only: :show, method: :post do
+    link_to t('active_admin.solicitations.delete'), delete_admin_solicitation_path(resource), method: :delete, 'data-confirm': t('active_admin.solicitations.delete_confirm')
   end
 
   ## Filters

--- a/app/admin/solicitation.rb
+++ b/app/admin/solicitation.rb
@@ -94,10 +94,10 @@ ActiveAdmin.register Solicitation do
   end
 
   member_action :delete, method: :delete do
-    if resource.diagnosis_completed?
+    if resource.diagnosis.present? && resource.diagnosis_completed?
       redirect_to resource_path, alert: t('active_admin.solicitations.diagnosis_exists')
     else
-      resource.diagnosis.destroy
+      resource.diagnosis&.destroy
       resource.destroy
       redirect_to admin_solicitations_path, notice: t('active_admin.solicitations.deleted')
     end

--- a/config/locales/models.fr.yml
+++ b/config/locales/models.fr.yml
@@ -107,6 +107,10 @@ fr:
       without_subjects: Sans compétence
       without_users: Aucun membre
     solicitations:
+      delete: Supprimer la sollicitation
+      delete_confirm: Voulez-vous supprimer cette sollicitation ?
+      deleted: Sollicitation supprimée
+      diagnosis_exists: Une analyse transmise existe, la suppression de la sollicitation n’est pas possible.
       need_show: Fiche besoin : 
       no_siret: SIRET non fourni
     subject:

--- a/config/locales/models.fr.yml
+++ b/config/locales/models.fr.yml
@@ -107,12 +107,18 @@ fr:
       without_subjects: Sans compétence
       without_users: Aucun membre
     solicitations:
+      batch_delete: Supprimer
       delete: Supprimer la sollicitation
       delete_confirm: Voulez-vous supprimer cette sollicitation ?
-      deleted: Sollicitation supprimée
+      deleted:
+        one: Sollicitation supprimée
+        other: Sollicitations supprimées
       diagnosis_exists: Une analyse transmise existe, la suppression de la sollicitation n’est pas possible.
       need_show: Fiche besoin : 
       no_siret: SIRET non fourni
+      not_deleted:
+        one: Une sollicitation n’a pas été supprimée car une analyse transmise existe.
+        other: "%{count} sollicitations n'ont pas été supprimées car une analyse transmise existe."
     subject:
       copy_experts_button: Copier le référencement
       copy_experts_confirm: Copier le référencement ? Vous ne pourrez pas annuler.


### PR DESCRIPTION
Si une sollicitation n'a pas d'analyse ou a une analyse en cours, on supprime l'analyse et la sollicitation. S'il y a une analyse transmise, on affiche un message d’erreur.

closed #3064