### PR TITLE
Add registre info rne

### DIFF
--- a/app/services/api_consumption/models/company/api_entreprise.rb
+++ b/app/services/api_consumption/models/company/api_entreprise.rb
@@ -22,6 +22,8 @@ module ApiConsumption::Models
         :effectifs_entreprise_annuel,
         :mandataires_sociaux,
         :forme_exercice,
+        :rne_rcs,
+        :rne_rnm
       ]
     end
 
@@ -35,13 +37,21 @@ module ApiConsumption::Models
     end
 
     def inscrit_rcs
-      return false if rcs.blank?
-      rcs["error"].nil?
+      # api rcs peut retourner false juste parce qu'il n'a pas la donnée
+      if api_rcs_value == true
+        return true
+      else
+        return api_rne_rcs_value
+      end
     end
 
     def inscrit_rm
-      return false if rm.blank?
-      rm["error"].nil?
+      # api rm peut retourner false juste parce qu'il n'a pas la donnée
+      if api_rm_value == true
+        return true
+      else
+        return api_rne_rnm_value
+      end
     end
 
     def forme_juridique_libelle
@@ -137,6 +147,26 @@ module ApiConsumption::Models
 
     def effectifs_entreprise_annuel_annee
       effectifs_entreprise_annuel['annee'] || nil
+    end
+
+    def api_rcs_value
+      return false if rcs.nil?
+      rcs["error"].nil?
+    end
+
+    def api_rne_rcs_value
+      return false if rne_rcs.nil?
+      rne_rcs['estPresent']
+    end
+
+    def api_rm_value
+      return false if rm.nil?
+      rm["error"].nil?
+    end
+
+    def api_rne_rnm_value
+      return false if rne_rnm.nil?
+      rne_rnm['estPresent']
     end
   end
 end

--- a/app/services/api_rne/companies/base.rb
+++ b/app/services/api_rne/companies/base.rb
@@ -25,8 +25,11 @@ module ApiRne::Companies
 
   class Responder < ApiRne::Responder
     def format_data
+      registres = @http_request.data.dig('formality','content','registreAnterieur')
       {
         "forme_exercice" => @http_request.data.dig('formality', 'content', 'formeExerciceActivitePrincipale'),
+        "rne_rcs" => registres['rncs'] || nil,
+        "rne_rnm" => registres['rnm'] || nil
       }
     end
   end

--- a/spec/fixtures/files/api_rne_companies.json
+++ b/spec/fixtures/files/api_rne_companies.json
@@ -1,5 +1,5 @@
 {
-  "updatedAt": "2023-05-13T07:19:58+02:00",
+  "updatedAt": "2023-06-15T13:01:57+02:00",
   "id": "63ab0dc2cbb26e4362019707",
   "formality": {
     "siren": "418166096",
@@ -25,8 +25,7 @@
                 "nom": "Roux",
                 "prenoms": ["OLIVIER"],
                 "nationalite": "Française"
-              },
-              "adresseDomicile": {}
+              }
             },
             "modalite": {
               "detentionPartDirecte": false,
@@ -72,8 +71,7 @@
               "detentionPouvoirNommageMembresConseilAdmin": false,
               "detentionAutresMoyensControle": false,
               "beneficiaireRepresentantLegal": true,
-              "representantLegalPlacementSansGestionDelegue": false,
-              "societeGestion": {}
+              "representantLegalPlacementSansGestionDelegue": false
             }
           }
         ],
@@ -92,7 +90,11 @@
         "etablissementPrincipal": {
           "descriptionEtablissement": {
             "rolePourEntreprise": "2",
+            "pays": "FRANCE",
+            "codePays": "FRA",
             "siret": "41816609600069",
+            "activiteNonSedentaire": false,
+            "nomCommercial": "OCTO-TECHNOLOGY",
             "indicateurEtablissementPrincipal": true
           },
           "adresse": {
@@ -103,27 +105,38 @@
             "codeInseeCommune": "75102",
             "typeVoie": "AV",
             "voie": "DE L OPERA",
-            "numVoie": "34"
+            "numVoie": "34",
+            "caracteristiques": { "ambulant": false }
           },
           "activites": [
             {
               "categoryCode": "02080901",
               "indicateurPrincipal": true,
               "indicateurProlongement": false,
-              "dateDebut": "2016-11-28",
+              "dateDebut": "1998-04-01",
+              "indicateurNonSedentaire": false,
               "formeExercice": "COMMERCIALE",
               "categorisationActivite1": "02",
               "categorisationActivite2": "08",
               "categorisationActivite3": "09",
               "categorisationActivite4": "01",
-              "descriptionDetaillee": "Conseil en systèmes et logiciels informatiques",
-              "indicateurActiviteeApe": true,
+              "descriptionDetaillee": "La conception le développement et la mise en oeuvre d'information et d'applications par le conseil et la mise en oeuvre innovante d'expertises technologiques et méthodologiques , la conception le développement et la distribution de solutions logicielles , l'accompagnement technologique méthodologique et culturel pour la réalisation de produits logiciels innovants et pour la transformation digitale des pratiques, processus et organisations des entreprises la formation dans le domaine des expertises technologiques et méthodologiques.",
+              "indicateurActiviteeApe": false,
+              "indicateurArtisteAuteur": false,
+              "indicateurMarinProfessionnel": false,
               "rolePrincipalPourEntreprise": true,
               "codeApe": "6202A",
               "activiteRattacheeEirl": false
             }
           ],
-          "nomsDeDomaine": []
+          "registreAnterieur": {
+            "raa": { "estPresent": false },
+            "rnm": { "estPresent": false },
+            "rncs": {
+              "estPresent": true,
+              "dateDebut": "1998-04-01T00:00:00+02:00"
+            }
+          }
         },
         "autresEtablissements": [
           {
@@ -155,8 +168,7 @@
                 "codeApe": "6202A",
                 "activiteRattacheeEirl": false
               }
-            ],
-            "nomsDeDomaine": []
+            ]
           },
           {
             "descriptionEtablissement": {
@@ -188,8 +200,7 @@
                 "codeApe": "6202A",
                 "activiteRattacheeEirl": false
               }
-            ],
-            "nomsDeDomaine": []
+            ]
           },
           {
             "descriptionEtablissement": {
@@ -220,8 +231,7 @@
                 "codeApe": "6202A",
                 "activiteRattacheeEirl": false
               }
-            ],
-            "nomsDeDomaine": []
+            ]
           },
           {
             "descriptionEtablissement": {
@@ -252,8 +262,7 @@
                 "codeApe": "6202A",
                 "activiteRattacheeEirl": false
               }
-            ],
-            "nomsDeDomaine": []
+            ]
           },
           {
             "descriptionEtablissement": {
@@ -290,8 +299,7 @@
                 "codeApe": "6202A",
                 "activiteRattacheeEirl": false
               }
-            ],
-            "nomsDeDomaine": []
+            ]
           },
           {
             "descriptionEtablissement": {
@@ -302,7 +310,6 @@
               "activiteNonSedentaire": false,
               "indicateurEtablissementPrincipal": false
             },
-            "domiciliataire": {},
             "adresse": {
               "pays": "FRANCE",
               "codePays": "FRA",
@@ -356,7 +363,6 @@
                 "activiteRattacheeEirl": false
               }
             ],
-            "nomsDeDomaine": [],
             "registreAnterieur": {
               "raa": { "estPresent": false },
               "rnm": { "estPresent": false },
@@ -367,7 +373,6 @@
             }
           }
         ],
-        "detailCessationEntreprise": { "repreneurs": [] },
         "observations": {
           "rcs": [
             {
@@ -399,92 +404,14 @@
             "montantCapital": 509525.3,
             "deviseCapital": "EUR",
             "indicateurOrigineFusionScission": false,
+            "indicateurAssocieUnique": false,
             "indicateurAssocieUniqueDirigeant": false
-          },
-          "nomsDeDomaine": [],
-          "entreprisesIntervenant": []
+          }
         },
         "composition": {
           "pouvoirs": [
             {
-              "individu": {
-                "descriptionPersonne": {
-                  "dateDeNaissance": "1972-01",
-                  "nom": "Cinquin",
-                  "prenoms": ["LUDOVIC"],
-                  "nationalite": "Française",
-                  "situationMatrimoniale": "1"
-                },
-                "adresseDomicile": {
-                  "pays": "FRANCE",
-                  "codePays": "FRA",
-                  "codePostal": "75012",
-                  "commune": "Paris",
-                  "codeInseeCommune": "75112"
-                }
-              },
-              "indicateurActifAgricole": false
-            },
-            {
-              "individu": {
-                "descriptionPersonne": {
-                  "dateDeNaissance": "1972-01",
-                  "role": "63",
-                  "nom": "CINQUIN",
-                  "prenoms": ["LUDOVIC"],
-                  "nationalite": "Française",
-                  "situationMatrimoniale": "1"
-                },
-                "adresseDomicile": {
-                  "pays": "FRANCE",
-                  "codePays": "FRA",
-                  "codePostal": "92300",
-                  "commune": "Levallois Perret",
-                  "codeInseeCommune": "92044"
-                }
-              },
-              "indicateurActifAgricole": false
-            },
-            {
-              "individu": {
-                "descriptionPersonne": {
-                  "dateDeNaissance": "1980-07",
-                  "role": "63",
-                  "nom": "Roux",
-                  "prenoms": ["OLIVIER"],
-                  "nationalite": "Française",
-                  "situationMatrimoniale": "1"
-                },
-                "adresseDomicile": {
-                  "pays": "FRANCE",
-                  "codePays": "FRA",
-                  "codePostal": "78800",
-                  "commune": "Houilles",
-                  "codeInseeCommune": "78311"
-                }
-              },
-              "indicateurActifAgricole": false
-            },
-            {
-              "individu": {
-                "descriptionPersonne": {
-                  "dateDeNaissance": "1972-01",
-                  "nom": "Cinquin",
-                  "prenoms": ["LUDOVIC"],
-                  "nationalite": "Française",
-                  "situationMatrimoniale": "1"
-                },
-                "adresseDomicile": {
-                  "pays": "FRANCE",
-                  "codePays": "FRA",
-                  "codePostal": "75002",
-                  "commune": "Paris",
-                  "codeInseeCommune": "75102"
-                }
-              },
-              "indicateurActifAgricole": false
-            },
-            {
+              "typeDePersonne": "ENTREPRISE",
               "entreprise": {
                 "roleEntreprise": "71",
                 "denomination": "KPMG",
@@ -498,135 +425,10 @@
                 "codeInseeCommune": "92050",
                 "voie": "2 avenue Gambetta Tour Eqho "
               },
-              "representant": {
-                "descriptionPersonne": {},
-                "adresseDomicile": {}
-              },
               "indicateurActifAgricole": false
             },
             {
-              "individu": {
-                "descriptionPersonne": {
-                  "dateDeNaissance": "1965-03",
-                  "role": "61",
-                  "nom": "Girard",
-                  "prenoms": ["OLIVIER"],
-                  "nationalite": "Française",
-                  "situationMatrimoniale": "1"
-                },
-                "adresseDomicile": {
-                  "pays": "FRANCE",
-                  "codePays": "FRA",
-                  "codePostal": "78150",
-                  "commune": "Le Chesnay",
-                  "codeInseeCommune": "78158"
-                }
-              },
-              "indicateurActifAgricole": false
-            },
-            {
-              "individu": {
-                "descriptionPersonne": {
-                  "dateDeNaissance": "1961-04",
-                  "role": "64",
-                  "nom": "Bokobza",
-                  "prenoms": ["JEAN-PIERRE"],
-                  "nationalite": "Française",
-                  "situationMatrimoniale": "1"
-                },
-                "adresseDomicile": {
-                  "pays": "FRANCE",
-                  "codePays": "FRA",
-                  "codePostal": "75116",
-                  "commune": "Paris",
-                  "codeInseeCommune": "75116"
-                }
-              },
-              "indicateurActifAgricole": false
-            },
-            {
-              "individu": {
-                "descriptionPersonne": {
-                  "dateDeNaissance": "1961-03",
-                  "role": "64",
-                  "nom": "Campbell",
-                  "prenoms": ["ALLAN"],
-                  "nationalite": "Britannique",
-                  "situationMatrimoniale": "1"
-                },
-                "adresseDomicile": {
-                  "pays": "FRANCE",
-                  "codePays": "FRA",
-                  "codePostal": "78160",
-                  "commune": "Marly-le-Roi",
-                  "codeInseeCommune": "78372"
-                }
-              },
-              "indicateurActifAgricole": false
-            },
-            {
-              "individu": {
-                "descriptionPersonne": {
-                  "dateDeNaissance": "1959-02",
-                  "role": "72",
-                  "nom": "Simon",
-                  "prenoms": ["JEAN-LOUIS"],
-                  "nationalite": "Française",
-                  "situationMatrimoniale": "1"
-                },
-                "adresseDomicile": {
-                  "pays": "FRANCE",
-                  "codePays": "FRA",
-                  "codePostal": "92400",
-                  "commune": "Courbevoie",
-                  "codeInseeCommune": "92026"
-                }
-              },
-              "indicateurActifAgricole": false
-            },
-            {
-              "individu": {
-                "descriptionPersonne": {
-                  "dateDeNaissance": "1967-03",
-                  "role": "64",
-                  "nom": "Ben Mahmoud",
-                  "prenoms": ["SIHEM"],
-                  "nomUsage": "Jouini",
-                  "nationalite": "Française",
-                  "situationMatrimoniale": "1"
-                },
-                "adresseDomicile": {
-                  "pays": "FRANCE",
-                  "codePays": "FRA",
-                  "codePostal": "75007",
-                  "commune": "Paris",
-                  "codeInseeCommune": "75107"
-                }
-              },
-              "indicateurActifAgricole": false
-            },
-            {
-              "entreprise": {
-                "roleEntreprise": "71",
-                "siren": "784824153",
-                "denomination": "MAZARS",
-                "formeJuridique": "Société anonyme"
-              },
-              "adresseEntreprise": {
-                "pays": "FRANCE",
-                "codePays": "FRA",
-                "codePostal": "92400",
-                "commune": "Courbevoie",
-                "codeInseeCommune": "92026",
-                "voie": "61 rue Henri Regnault "
-              },
-              "representant": {
-                "descriptionPersonne": {},
-                "adresseDomicile": {}
-              },
-              "indicateurActifAgricole": false
-            },
-            {
+              "typeDePersonne": "INDIVIDU",
               "individu": {
                 "descriptionPersonne": {
                   "dateDeNaissance": "1980-07",
@@ -663,7 +465,6 @@
     },
     "typePersonne": "M",
     "diffusionCommerciale": true,
-    "historique": [],
     "formeJuridique": "5710"
   },
   "siren": "418166096"

--- a/spec/services/api_consumption/models/company/api_entreprise_spec.rb
+++ b/spec/services/api_consumption/models/company/api_entreprise_spec.rb
@@ -79,4 +79,59 @@ RSpec.describe ApiConsumption::Models::Company::ApiEntreprise do
       end
     end
   end
+
+  describe 'inscrit_rcs' do
+    context 'rcs true && rne_rcs true' do
+      let!(:params) do
+        {
+          rcs: {
+            siren: "418166096",
+            date_extrait: "27 FEVRIER 2023",
+            date_immatriculation: "1998-03-27"
+          },
+          rne_rcs: {
+            estPresent: true, dateDebut: "1998-04-01T00:00:00+02:00"
+          },
+        }
+      end
+
+      it 'returns inscrit_rcs true' do
+        expect(described_class.new(params).inscrit_rcs).to be(true)
+      end
+    end
+
+    context 'rcs false && rne_rcs true' do
+      let!(:params) do
+        {
+          rcs: {
+            error: "Entité non trouvée : L'identifiant indiqué n'existe pas, n'est pas connu ou ne comporte aucune information pour cet appel."
+          },
+          rne_rcs: {
+            estPresent: true, dateDebut: "1998-04-01T00:00:00+02:00"
+          },
+        }
+      end
+
+      it 'returns inscrit_rcs true' do
+        expect(described_class.new(params).inscrit_rcs).to be(true)
+      end
+    end
+
+    context 'rcs false && rne_rcs false' do
+      let!(:params) do
+        {
+          rcs: {
+            error: "Entité non trouvée : L'identifiant indiqué n'existe pas, n'est pas connu ou ne comporte aucune information pour cet appel."
+          },
+          rne_rcs: {
+            estPresent: false
+          },
+        }
+      end
+
+      it 'returns inscrit_rcs true' do
+        expect(described_class.new(params).inscrit_rcs).to be(false)
+      end
+    end
+  end
 end

--- a/spec/services/api_consumption/models/company/api_entreprise_spec.rb
+++ b/spec/services/api_consumption/models/company/api_entreprise_spec.rb
@@ -129,7 +129,7 @@ RSpec.describe ApiConsumption::Models::Company::ApiEntreprise do
         }
       end
 
-      it 'returns inscrit_rcs true' do
+      it 'returns inscrit_rcs false' do
         expect(described_class.new(params).inscrit_rcs).to be(false)
       end
     end


### PR DESCRIPTION
J'anticipe la disparition prochaine de l'API RNM en récupérant les infos registres renvoyées par l'API RNE. 
Pas sûre de la stabilité de l'API RNE, je propose donc de brancher quand il sera temps et de surveiller les données renvoyées d'ici là

Aussi : suppression de l'initialisation de la couverture de référencement (tâche lancée en prod)