### PR TITLE
Earlier reminders generation

### DIFF
--- a/app/models/clockwork.rb
+++ b/app/models/clockwork.rb
@@ -54,6 +54,6 @@ module Clockwork
     every(1.day, 'send_quarterly_reports_emails', at: '08:00', if: -> (t) { t.day == 21 && (t.month == 1 || t.month == 4 || t.month == 7 || t.month == 10) }) do
       QuarterlyReports::NotifyManagers.new.delay(queue: :low_priority).call
     end
-    every(1.day, 'reminders_registers', :at => ['01:00', '13:00']) { RemindersService.delay(queue: :low_priority).create_reminders_registers }
+    every(1.day, 'reminders_registers', :at => ['00:01', '11:00']) { RemindersService.delay(queue: :low_priority).create_reminders_registers }
   end
 end

--- a/app/models/clockwork.rb
+++ b/app/models/clockwork.rb
@@ -3,57 +3,57 @@ require './config/boot'
 require './config/environment'
 
 module Clockwork
-  every(1.week, 'send_app_administrators_statistics_email', at: 'Monday 07:30') do
+  every(1.week, 'send_app_administrators_statistics_email', at: 'Monday 07:30', tz: 'UTC') do
     AdminMailersService.delay(queue: :low_priority).send_statistics_email
   end
-  every(1.week, 'send_experts_reminders', at: 'Tuesday 9:00') do
+  every(1.week, 'send_experts_reminders', at: 'Tuesday 9:00', tz: 'UTC') do
     ExpertReminderService.delay(queue: :low_priority).send_reminders
   end
-  every(1.week, 'anonymize_old_diagnoses', at: 'sunday 5:00') do
+  every(1.week, 'anonymize_old_diagnoses', at: 'sunday 5:00', tz: 'UTC') do
     `rake anonymize_old_diagnoses`
   end
-  every(1.day, 'revoke_api_keys', at: ('2:00'), if: -> (t) { t.day == 1 }) do
+  every(1.day, 'revoke_api_keys', at: ('2:00'), if: -> (t) { t.day == 1 }, tz: 'UTC') do
     ApiKeysManagement.delay.batch_revoke
   end
-  every(1.day, 'archive_expired_matches', at: '02:11') do
+  every(1.day, 'archive_expired_matches', at: '02:11', tz: 'UTC') do
     NeedsService.delay.archive_expired_matches
   end
-  every(1.day, 'abandon_needs', at: '03:11') do
+  every(1.day, 'abandon_needs', at: '03:11', tz: 'UTC') do
     NeedsService.delay.abandon_needs
   end
-  every(1.day, 'rattrapage_analyse', at: ('3:41')) do
+  every(1.day, 'rattrapage_analyse', at: ('3:41'), tz: 'UTC') do
     `rake rattrapage_analyse`
   end
-  every(1.day, 'purge_csv_exports', at: ('4:11')) do
+  every(1.day, 'purge_csv_exports', at: ('4:11'), tz: 'UTC') do
     CsvExport.delay.purge_later
   end
-  every(1.day, 'send_retention_emails', at: ('4:41')) do
+  every(1.day, 'send_retention_emails', at: ('4:41'), tz: 'UTC') do
     CompanyMailerService.delay.send_retention_emails
   end
-  every(1.day, 'not_supported_solicitations', at: ('5:00')) do
+  every(1.day, 'not_supported_solicitations', at: ('5:00'), tz: 'UTC') do
     NotYetTakenCareEmailService.new.delay.call
   end
-  every(1.day, 'send_satisfaction_emails', at: ('5:41')) do
+  every(1.day, 'send_satisfaction_emails', at: ('5:41'), tz: 'UTC') do
     CompanyMailerService.delay.send_satisfaction_emails
   end
-  every(1.day, 'inteligent_retention', at: ('06:30')) do
+  every(1.day, 'inteligent_retention', at: ('06:30'), tz: 'UTC') do
     RetentionService.delay(queue: :low_priority).send_emails
   end
-  every(1.day, 'send_failed_jobs_email', at: '10:00') do
+  every(1.day, 'send_failed_jobs_email', at: '10:00', tz: 'UTC') do
     AdminMailersService.delay(queue: :low_priority).send_failed_jobs
   end
-  every(1.day, 'relaunch_solicitations', at: ('12:00')) do
+  every(1.day, 'relaunch_solicitations', at: ('12:00'), tz: 'UTC') do
     SolicitationsRelaunchService.delay(queue: :low_priority).perform
   end
   if Rails.env == 'production'
-    every(1.day, 'generate_quarterly_reports', at: '01:00', if: -> (t) { t.day == 20 && (t.month == 1 || t.month == 4 || t.month == 7 || t.month == 10) }) do
+    every(1.day, 'generate_quarterly_reports', at: '01:00', if: -> (t) { t.day == 20 && (t.month == 1 || t.month == 4 || t.month == 7 || t.month == 10) }, tz: 'UTC') do
       Antenne.find_each do |antenne|
         QuarterlyReports::GenerateReports.new(antenne).delay(queue: :low_priority).call
       end
     end
-    every(1.day, 'send_quarterly_reports_emails', at: '08:00', if: -> (t) { t.day == 21 && (t.month == 1 || t.month == 4 || t.month == 7 || t.month == 10) }) do
+    every(1.day, 'send_quarterly_reports_emails', at: '08:00', if: -> (t) { t.day == 21 && (t.month == 1 || t.month == 4 || t.month == 7 || t.month == 10) }, tz: 'UTC') do
       QuarterlyReports::NotifyManagers.new.delay(queue: :low_priority).call
     end
-    every(1.day, 'reminders_registers', :at => ['00:01', '11:00']) { RemindersService.delay(queue: :low_priority).create_reminders_registers }
+    every(1.day, 'reminders_registers', :at => ['01:00', '13:00'], tz: 'UTC') { RemindersService.delay(queue: :low_priority).create_reminders_registers }
   end
 end

--- a/app/views/application/_navbar.html.haml
+++ b/app/views/application/_navbar.html.haml
@@ -33,7 +33,7 @@
                 %span.ri-inbox-fill.fr-mr-1w{ 'aria-hidden': 'true' }
                 = t('needs.index.title')
                 - cache([current_user, current_user.needs_quo.size]) do
-                  - if current_user.needs_quo.exists?
+                  - if current_user.needs_quo.size > 0
                     %span.ri-mail-unread-fill.orange.fr-ml-1w
             - if policy(User).manager?
               = active_link_to manager_needs_path, class: 'fr-nav__link', wrap_tag: :li, wrap_class: 'fr-nav__item', class_active: 'fr-nav__item--active' do


### PR DESCRIPTION
Il y a un décalage de timezone avec le serveur, vraisemblablement.
On voudrait que les paniers soient générés vers 13h, or ils sont générés vers 15h. 
Quick fix pour diminuer les incompréhensions des collègues.

A terme, on aura peut-être une harmonisation des time zones à rechercher