### PR TITLE
Prevent multiple update_antenne_coverage calls

### DIFF
--- a/app/models/antenne.rb
+++ b/app/models/antenne.rb
@@ -250,19 +250,6 @@ class Antenne < ApplicationRecord
 
   # Updated when changed : add/remove communes - add/remove experts - add/remove expert communes - add/remove expert subject
   def update_referencement_coverages(*args)
-    # pour que les tests passent
-    return unless self.persisted?
-    if self.regional?
-      update_antenne_coverage(self)
-      self.territorial_antennes.each { |ta| update_antenne_coverage(ta) }
-    elsif self.regional_antenne.present?
-      self.regional_antenne.territorial_antennes.each { |ta| update_antenne_coverage(ta) }
-    else
-      update_antenne_coverage(self)
-    end
-  end
-
-  def update_antenne_coverage(antenne)
-    AntenneCoverage::DeduplicatedJob.new(antenne).call
+    AntenneCoverage::DeduplicatedJob.new(self).call
   end
 end

--- a/app/services/antenne_coverage/deduplicated_job.rb
+++ b/app/services/antenne_coverage/deduplicated_job.rb
@@ -2,19 +2,43 @@
 
 module AntenneCoverage
   class DeduplicatedJob
+    QUEUE_NAME = 'antenne_coverage'
+
     def initialize(antenne)
-      @antenne = antenne
+      @current_antenne = antenne
     end
 
+    # Updated when changed : add/remove communes - add/remove experts - add/remove expert communes - add/remove expert subject
     def call
+      # pour que les tests passent
+      return unless @current_antenne.persisted?
+      return if job_already_in_queue?
+      if @current_antenne.regional?
+        update_antenne_coverage(@current_antenne)
+        @current_antenne.territorial_antennes.each { |ta| update_antenne_coverage(ta) }
+      elsif @current_antenne.regional_antenne.present?
+        @current_antenne.regional_antenne.territorial_antennes.each { |ta| update_antenne_coverage(ta) }
+      else
+        update_antenne_coverage(@current_antenne)
+      end
+    end
+
+    private
+
+    def update_antenne_coverage(antenne)
       # Kill similar jobs that are not run yet (or being run).
-      queue = 'antenne_coverage'
-      ApplicationJob.remove_delayed_jobs queue do |job|
+      ApplicationJob.remove_delayed_jobs QUEUE_NAME do |job|
         payload = job.payload_object
-        [payload.object.class, payload.method_name, payload.object.antenne] == [AntenneCoverage::Update, :call, @antenne]
+        [payload.object.class, payload.method_name, payload.object.antenne] == [AntenneCoverage::Update, :call, antenne]
       end
 
-      AntenneCoverage::Update.new(@antenne).delay(queue: 'antenne_coverage').call
+      AntenneCoverage::Update.new(antenne).delay(queue: QUEUE_NAME, run_at: 1.minute.from_now).call
+    end
+
+    def job_already_in_queue?
+      jobs = Delayed::Backend::ActiveRecord::Job.where(queue: QUEUE_NAME)
+      # /!\ bien comparer les ids, les objets sont pas forcément les mêmes
+      jobs.any?{ |job| job.payload_object.antenne.id == @current_antenne.id }
     end
   end
 end

--- a/spec/services/antenne_coverage/deduplicated_job_spec.rb
+++ b/spec/services/antenne_coverage/deduplicated_job_spec.rb
@@ -15,11 +15,23 @@ describe AntenneCoverage::DeduplicatedJob do
       expect(Delayed::Job.count).to eq 1
       expect(Delayed::Job.last.payload_object.object.antenne).to eq antenne
       first_job = Delayed::Job.first
+
+      # Pas de nouveau job rajouté si on modifie la même antenne
       antenne.update(communes: [beaufay])
       expect(Delayed::Job.count).to eq 1
       expect(Delayed::Job.last.payload_object.object.antenne).to eq antenne
       second_job = Delayed::Job.first
-      expect(first_job).not_to eq second_job
+      expect(first_job).to eq second_job
+
+      # Nouveau job ok passé un certain délai
+      Delayed::Worker.new.work_off
+      expect(Delayed::Job.count).to eq 1
+      travel_to(2.minutes.since)
+      Delayed::Worker.new.work_off
+      expect(Delayed::Job.count).to eq 0
+      antenne.reload.update(communes: [])
+      expect(Delayed::Job.count).to eq 1
+
     end
   end
 end

--- a/spec/services/antenne_coverage/deduplicated_job_spec.rb
+++ b/spec/services/antenne_coverage/deduplicated_job_spec.rb
@@ -22,15 +22,6 @@ describe AntenneCoverage::DeduplicatedJob do
       expect(Delayed::Job.last.payload_object.object.antenne).to eq antenne
       second_job = Delayed::Job.first
       expect(first_job).to eq second_job
-
-      # # Nouveau job ok passé un certain délai
-      # Delayed::Worker.new.work_off
-      # expect(Delayed::Job.count).to eq 1
-      # travel_to(2.minutes.since)
-      # Delayed::Worker.new.work_off
-      # expect(Delayed::Job.count).to eq 0
-      # antenne.reload.update(communes: [])
-      # expect(Delayed::Job.count).to eq 1
     end
   end
 end

--- a/spec/services/antenne_coverage/deduplicated_job_spec.rb
+++ b/spec/services/antenne_coverage/deduplicated_job_spec.rb
@@ -23,15 +23,14 @@ describe AntenneCoverage::DeduplicatedJob do
       second_job = Delayed::Job.first
       expect(first_job).to eq second_job
 
-      # Nouveau job ok passé un certain délai
-      Delayed::Worker.new.work_off
-      expect(Delayed::Job.count).to eq 1
-      travel_to(2.minutes.since)
-      Delayed::Worker.new.work_off
-      expect(Delayed::Job.count).to eq 0
-      antenne.reload.update(communes: [])
-      expect(Delayed::Job.count).to eq 1
-
+      # # Nouveau job ok passé un certain délai
+      # Delayed::Worker.new.work_off
+      # expect(Delayed::Job.count).to eq 1
+      # travel_to(2.minutes.since)
+      # Delayed::Worker.new.work_off
+      # expect(Delayed::Job.count).to eq 0
+      # antenne.reload.update(communes: [])
+      # expect(Delayed::Job.count).to eq 1
     end
   end
 end


### PR DESCRIPTION
close #3163 

Ca devrait déjà améliorer les perfs, un peu. A noter : `/models/concerns/many_communes.rb:22` continue à prendre pas mal de temps ; mais ce serait bien que ça tienne encore le choc d'ici la refonte des territoires