### PR TITLE
Optimize Antenne#territorial_antennes

### DIFF
--- a/app/models/antenne.rb
+++ b/app/models/antenne.rb
@@ -171,14 +171,6 @@ class Antenne < ApplicationRecord
     end&.first
   end
 
-  def territorial_antennes_old
-    return [] if self.local?
-    same_region_antennes = institution.antennes_in_region(region_ids)
-    same_region_antennes.select do |a|
-      !a.regional? && Utilities::Arrays.included_in?(a.commune_ids, commune_ids)
-    end
-  end
-
   def territorial_antennes
     return [] if self.local?
     Antenne.not_deleted.where(institution_id: institution_id, territorial_level: 'local')

--- a/app/models/antenne.rb
+++ b/app/models/antenne.rb
@@ -171,12 +171,21 @@ class Antenne < ApplicationRecord
     end&.first
   end
 
-  def territorial_antennes
+  def territorial_antennes_old
     return [] if self.local?
     same_region_antennes = institution.antennes_in_region(region_ids)
     same_region_antennes.select do |a|
       !a.regional? && Utilities::Arrays.included_in?(a.commune_ids, commune_ids)
     end
+  end
+
+  def territorial_antennes
+    return [] if self.local?
+    Antenne.not_deleted.where(institution_id: institution_id, territorial_level: 'local')
+      .left_joins(:communes, :experts)
+      .where(communes: { id: commune_ids })
+      .or(Antenne.not_deleted.where(institution_id: institution_id, territorial_level: 'local').where(experts: { is_global_zone: true }))
+      .distinct
   end
 
   ## Périmètre d'exercice :


### PR DESCRIPTION
On passe à 2 requêtes SQL au lieu de 3 requêtes + X requêtes supplémentaires (X étant le nombre d'antennes dans la région de l'antenne sur laquelle on se trouve) + du code ruby pour itérer
Mes premières vérifications sont bonnes, il faut que je poursuive pour s'assurer d'avoir ceinture et bretelles.