### PR TITLE
Poule : dans panier à partir de 2 et non de 3

### DIFF
--- a/app/services/reminders_service.rb
+++ b/app/services/reminders_service.rb
@@ -40,16 +40,16 @@ class RemindersService
     old_quo_matches = quo_matches.where(sent_at: ..MATCHES_AGE[:old])
     quo_matches_size = quo_matches.size
     has_old_quo_matches = (old_quo_matches.size >= MATCHES_COUNT[:quo])
-    # Panier avec plus de 5 besoins en attentes dont 2 superieur à 15 jours
+    # Poulet : Panier avec plus de 5 besoins en attentes dont 2 superieur à 15 jours
     basket = if has_old_quo_matches &&
       (quo_matches_size > MATCHES_COUNT[:many])
       :many_pending_needs
-      # Panier entre 2 et 5 besoins en attentes dont 2 superieur à 15 jours
+    # Poule : Panier entre 2 et 5 besoins en attentes dont 2 superieur à 15 jours
     elsif has_old_quo_matches &&
-      (quo_matches_size > MATCHES_COUNT[:medium]) &&
+      (quo_matches_size >= MATCHES_COUNT[:medium]) &&
       (quo_matches_size <= MATCHES_COUNT[:many])
       :medium_pending_needs
-      # Panier avec un nouveau besoin en attente et le dernier besoin recu avant est vieux de + de 3 mois
+    # Poussin : Panier avec un nouveau besoin en attente et le dernier besoin recu avant est vieux de + de 3 mois
     elsif (old_quo_matches.size < MATCHES_COUNT[:medium] && quo_matches.present?) &&
       (latest_received_match_at(expert).present? && (latest_received_match_at(expert) <= MATCHES_AGE[:prehistorical]))
       :one_pending_need

--- a/app/services/reminders_service.rb
+++ b/app/services/reminders_service.rb
@@ -40,16 +40,16 @@ class RemindersService
     old_quo_matches = quo_matches.where(sent_at: ..MATCHES_AGE[:old])
     quo_matches_size = quo_matches.size
     has_old_quo_matches = (old_quo_matches.size >= MATCHES_COUNT[:quo])
-    # Poulet : Panier avec plus de 5 besoins en attentes dont 2 superieur à 15 jours
+    # Panier avec plus de 5 besoins en attentes dont 2 superieur à 15 jours
     basket = if has_old_quo_matches &&
       (quo_matches_size > MATCHES_COUNT[:many])
       :many_pending_needs
-    # Poule : Panier entre 2 et 5 besoins en attentes dont 2 superieur à 15 jours
+    # Panier entre 2 et 5 besoins en attentes dont 2 superieur à 15 jours
     elsif has_old_quo_matches &&
       (quo_matches_size >= MATCHES_COUNT[:medium]) &&
       (quo_matches_size <= MATCHES_COUNT[:many])
       :medium_pending_needs
-    # Poussin : Panier avec un nouveau besoin en attente et le dernier besoin recu avant est vieux de + de 3 mois
+    # Panier avec un nouveau besoin en attente et le dernier besoin recu avant est vieux de + de 3 mois
     elsif (old_quo_matches.size < MATCHES_COUNT[:medium] && quo_matches.present?) &&
       (latest_received_match_at(expert).present? && (latest_received_match_at(expert) <= MATCHES_AGE[:prehistorical]))
       :one_pending_need

--- a/spec/controllers/reminders/experts_controller_spec.rb
+++ b/spec/controllers/reminders/experts_controller_spec.rb
@@ -19,7 +19,7 @@ RSpec.describe Reminders::ExpertsController do
     describe '#GET medium_pending_needs' do
       before { get :medium_pending_needs }
 
-      it { expect(assigns(:active_experts)).to contain_exactly(expert_with_medium_old_quo_matches) }
+      it { expect(assigns(:active_experts)).to contain_exactly(expert_with_medium_old_quo_matches, expert_with_only_old_quo_matches) }
     end
 
     describe '#GET one_pending_need' do

--- a/spec/services/reminders_service_spec.rb
+++ b/spec/services/reminders_service_spec.rb
@@ -12,7 +12,7 @@ describe RemindersService do
       describe 'create correct baskets' do
         it do
           expect(RemindersRegister.many_pending_needs_basket.map(&:expert)).to contain_exactly(expert_with_many_old_quo_matches)
-          expect(RemindersRegister.medium_pending_needs_basket.map(&:expert)).to contain_exactly(expert_with_medium_old_quo_matches)
+          expect(RemindersRegister.medium_pending_needs_basket.map(&:expert)).to contain_exactly(expert_with_medium_old_quo_matches, expert_with_only_old_quo_matches)
           expect(RemindersRegister.one_pending_need_basket.map(&:expert)).to contain_exactly(expert_with_one_quo_match_1, expert_with_one_old_quo_match)
         end
       end

--- a/spec/support/reminders_spec_helper.rb
+++ b/spec/support/reminders_spec_helper.rb
@@ -24,6 +24,10 @@ module RemindersSpecHelper
     let!(:quo_matches_3) { create_list :match, 2, status: :quo, expert: expert_with_medium_old_quo_matches }
     let!(:medium_old_quo_matches) { travel_to(16.days.ago) { create_list :match, 2, status: :quo, expert: expert_with_medium_old_quo_matches } }
 
+    # Expert avec uniquement 2 besoins de plus de 15 jours en attente
+    let!(:expert_with_only_old_quo_matches) { create :expert_with_users, :with_reminders_register, job: 'expert_with_only_old_quo_matches' }
+    let!(:only_old_quo_matches) { travel_to(16.days.ago) { create_list :match, 2, status: :quo, expert: expert_with_only_old_quo_matches } }
+
     # Expert avec plus de 2 besoins de plus de 45 jours en attente
     # et avec un stock > 2 < 5 de besoins non pris en charge
     let!(:expert_with_medium_abandoned_matches) { create :expert_with_users, :with_reminders_register, job: 'expert_with_medium_abandoned_matches' }


### PR DESCRIPTION
Jusqu'ici, le code intégrait les experts avec des vieux besoins > 2, et non >= 2.