### PR TITLE
Remove navigation with turbo on side menu with counters...

### DIFF
--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -4,7 +4,7 @@ module ApplicationHelper
       options, url, count, title = url, count, title, capture(&block)
     end
     tag.li class: 'fr-sidemenu__item item-with-tag' do
-      active_link_to(url, options.merge(class: 'fr-sidemenu__link', class_active: 'fr-sidemenu__item--active')) do
+      active_link_to(url, options.merge(class: 'fr-sidemenu__link', class_active: 'fr-sidemenu__item--active', data: { turbo: false })) do
        title
      end + tag.span("#{count}", class: "fr-tag fr-ml-2v")
     end


### PR DESCRIPTION
...in order to get rid of the blink on counters and form when turbo is fetching cache during preview phase

Après moult péripéties, j'ai fini par comprendre, c'est turbo qui avant de recevoir la réponse HTML regarde dans son cache si il a pas déjà la page pour la proposer durant la phase de preview. Les filtres étant gérés via la session rails, l'URL est connue, il render donc le HTML de la dernière page dans son historique, ce qui provoque le blink quand la réponse HTML définitive est render.

J'ai fait le choix de désactiver turbo sur le menu, ce qui corrige le blink (compteur et formulaire aussi qui reprenait la dernière valeurs du select) sur sollicitations, relances et paniers qualité. Par ailleurs je pense que ça améliore un peu les perfs, le rendering ne se faisant plus qu'une seule fois, je n'ai pas mesuré mais ça donne cette impression. En tout cas ça utilise moins de puissance de calcul coté client car on s'économise un render et ce qui va avec.

close #3232 