### PR TITLE
Ajout nom antenne au survol dans l'annuaire

### DIFF
--- a/app/views/annuaire/users/_table.html.haml
+++ b/app/views/annuaire/users/_table.html.haml
@@ -42,7 +42,7 @@
             - highlighted_class = highlighted_ids&.include?(user.id) ? 'blue' : ''
             %tr{ class: [antenne_separation_class, highlighted_class].compact.join(" ") }
               - if antenne_first_row
-                %td.td-header.td-header--antenne{ rowspan: teams.values.sum(&:size) }
+                %td.td-header.td-header--antenne{ rowspan: teams.values.sum(&:size), title: antenne.name }
                   = link_to antenne, admin_antenne_path(antenne)
               - if index_in_team == 0
                 %td.td-header.td-header--expert{ rowspan: users.size }


### PR DESCRIPTION
En lien avec https://trello.com/c/m8xb7I26/358-annuaire-on-ne-voit-pas-le-nom-de-lantenne-si-trop-long
Franchement, je comprends pas pourquoi les cases sont si longues, j'ai pas réussi à débugguer. Je me demande si ce bug là date pas d'assez longtemps en fait (en enlevant le + gros des dernières modifs, ça flanche toujours).
Alors comme pis aller, je propose d'afficher le nom de l'antenne au survol. 

On pourra faire encore mieux quand on aura le composant tooltip à dispo !