### PR TITLE
améliore les performances de la génération des paniers qualité

### DIFF
--- a/app/services/reminders_service.rb
+++ b/app/services/reminders_service.rb
@@ -12,7 +12,7 @@ class RemindersService
     medium: 2
   }
 
-  def initialize(experts = Expert.not_deleted.with_users.with_active_matches)
+  def initialize(experts = Expert.not_deleted.with_users.with_active_matches.left_joins(:reminders_registers))
     @experts_with_active_matches = experts
   end
 
@@ -20,7 +20,7 @@ class RemindersService
     last_run_number = RemindersRegister.last_run_number.presence || 0
     current_run = last_run_number + 1
     ActiveRecord::Base.transaction do
-      @experts_with_active_matches.each do |expert|
+      @experts_with_active_matches.find_each do |expert|
         basket = select_basket(expert)
         next if basket.nil?
         category = select_category(expert, last_run_number)


### PR DESCRIPTION
au début : 46 secondes pour jouer le `each` sur `@experts_with_active_matches` 
avec le `find_each` : 43 secondes
avec le `joins` : 37 secondes

Je ne sais pas si ça va régler le problème du worker par contre