### PR TITLE
Ajoute des filtres pour les commentaires en admin

### DIFF
--- a/app/admin/feedback.rb
+++ b/app/admin/feedback.rb
@@ -17,7 +17,6 @@ ActiveAdmin.register Feedback do
     selectable_column
     id_column
     column :created_at
-
     column :feedbackable
     column(:category) { |feedback| human_attribute_status_tag feedback, :category }
     column :user
@@ -26,10 +25,17 @@ ActiveAdmin.register Feedback do
     actions dropdown: true
   end
 
+  filter :subject, as: :ajax_select, data: { url: :admin_subjects_path, search_fields: [:label] }
+  filter :theme, as: :ajax_select, data: { url: :admin_themes_path, search_fields: [:label] }
+  filter :landing, as: :ajax_select, data: { url: :admin_landings_path, search_fields: [:title] }
+  filter :mtm_campaign, as: :string
   filter :description
   filter :category, as: :select, collection: -> { Feedback.human_attribute_values(:category, raw_values: true).invert.to_a }
-  filter :created_at
+  filter :need_created_at, as: :date_range, label: I18n.t('activeadmin.feedback.need_created_at')
+  filter :created_at, as: :date_range, label: I18n.t('activeadmin.feedback.created_at')
   filter :user, as: :ajax_select, data: { url: :admin_users_path, search_fields: [:full_name] }
+  filter :user_antenne, as: :ajax_select, data: { url: :admin_antennes_path, search_fields: [:name] }
+  filter :user_institution, as: :ajax_select, data: { url: :admin_institutions_path, search_fields: [:name] }
 
   ## CSV
   #

--- a/app/models/feedback.rb
+++ b/app/models/feedback.rb
@@ -36,19 +36,67 @@ class Feedback < ApplicationRecord
   belongs_to :user, inverse_of: :feedbacks
   has_many :experts, through: :user, inverse_of: :feedbacks
 
+  # Associations used for joins in scopes
+  belongs_to :feedback_need, -> { where(feedbacks: { feedbackable_type: 'Need' }) }, class_name: 'Need', foreign_key: 'feedbackable_id', inverse_of: :feedbacks, optional: true
+  belongs_to :feedback_solicitation, -> { where(feedbacks: { feedbackable_type: 'Solicitation' }) }, class_name: "Solicitation", foreign_key: 'feedbackable_id', inverse_of: :feedbacks, optional: true
+  belongs_to :feedback_expert, -> { where(feedbacks: { feedbackable_type: 'Expert' }) }, class_name: 'Expert', foreign_key: 'feedbackable_id', inverse_of: :feedbacks, optional: true
+
   ## Validations
   #
   validates :description, presence: true
 
   ## Scopes
-
+  #
   scope :for_need, -> { where(feedbackable_type: 'Need') }
   scope :for_solicitation, -> { where(feedbackable_type: 'Solicitation') }
   scope :for_expert, -> { where(feedbackable_type: 'Expert') }
 
+  ## Ransack scopes
+  #
+  scope :subject_eq, -> (subject) { joins(feedback_need: :subject).where(needs: { subjects: subject }) }
+  scope :theme_eq, -> (theme) { joins(feedback_need: { subject: :theme }).where(subjects: { themes: theme }) }
+  scope :landing_eq, -> (landing) do
+    joins(feedback_need: { diagnosis: { solicitation: :landing } }).where(diagnoses: { solicitations: { landings: landing } })
+  end
+  scope :mtm_campaign_cont, -> (query) do
+    Feedback.joins(feedback_need: { diagnosis: :solicitation }).where("solicitations.form_info::json->>'mtm_campaign' ILIKE ?", "%#{query}%")
+      .or(Feedback.joins(feedback_need: { diagnosis: :solicitation }).where("solicitations.form_info::json->>'pk_campaign' ILIKE ?", "%#{query}%"))
+  end
+  scope :mtm_campaign_eq, -> (query) do
+    Feedback.joins(feedback_need: { diagnosis: :solicitation }).where('form_info @> ?', { pk_campaign: query }.to_json)
+      .or(Feedback.joins(feedback_need: { diagnosis: :solicitation }).where('form_info @> ?', { mtm_campaign: query }.to_json))
+  end
+  scope :mtm_campaign_start, -> (query) do
+    Feedback.joins(feedback_need: { diagnosis: :solicitation }).where("solicitations.form_info::json->>'pk_campaign' ILIKE ?", "#{query}%")
+      .or(Feedback.joins(feedback_need: { diagnosis: :solicitation }).where("solicitations.form_info::json->>'mtm_campaign' ILIKE ?", "#{query}%"))
+  end
+  scope :mtm_campaign_end, -> (query) do
+    Feedback.joins(feedback_need: { diagnosis: :solicitation }).where("solicitations.form_info::json->>'pk_campaign' ILIKE ?", "%#{query}")
+      .or(Feedback.joins(feedback_need: { diagnosis: :solicitation }).where("solicitations.form_info::json->>'mtm_campaign' ILIKE ?", "%#{query}"))
+  end
+  scope :mtm_kwd_cont, -> (query) do
+    Feedback.joins(feedback_need: { diagnosis: :solicitation }).where("solicitations.form_info::json->>'mtm_kwd' ILIKE ?", "%#{query}%")
+      .or(Feedback.joins(feedback_need: { diagnosis: :solicitation }).where("solicitations.form_info::json->>'pk_kwd' ILIKE ?", "%#{query}%"))
+  end
+  scope :mtm_kwd_eq, -> (query) do
+    Feedback.joins(feedback_need: { diagnosis: :solicitation }).where('form_info @> ?', { pk_kwd: query }.to_json)
+      .or(Feedback.joins(feedback_need: { diagnosis: :solicitation }).where('form_info @> ?', { mtm_kwd: query }.to_json))
+  end
+  scope :mtm_kwd_start, -> (query) do
+    Feedback.joins(feedback_need: { diagnosis: :solicitation }).where("solicitations.form_info::json->>'pk_kwd' ILIKE ?", "#{query}%")
+      .or(Feedback.joins(feedback_need: { diagnosis: :solicitation }).where("solicitations.form_info::json->>'mtm_kwd' ILIKE ?", "#{query}%"))
+  end
+  scope :mtm_kwd_end, -> (query) do
+    Feedback.joins(feedback_need: { diagnosis: :solicitation }).where("solicitations.form_info::json->>'pk_kwd' ILIKE ?", "%#{query}")
+      .or(Feedback.joins(feedback_need: { diagnosis: :solicitation }).where("solicitations.form_info::json->>'mtm_kwd' ILIKE ?", "%#{query}"))
+  end
+  scope :need_created_at_gteq, -> (val) { joins(:feedback_need).where('needs.created_at >= ?', val) }
+  scope :need_created_at_lteq, -> (val) { joins(:feedback_need).where('needs.created_at <= ?', val) }
+  scope :user_antenne_eq, -> (antenne) { joins(:user).where(users: { antenne: antenne }) }
+  scope :user_institution_eq, -> (institution) { joins(user: { antenne: :institution }).where(users: { institutions: institution }) }
+
   ##
   #
-
   def notify_for_need!
     return unless category_need?
     persons_to_notify.each do |person|
@@ -92,5 +140,12 @@ class Feedback < ApplicationRecord
 
   def self.ransackable_associations(auth_object = nil)
     ["feedbackable", "user"]
+  end
+
+  def self.ransackable_scopes(auth_object = nil)
+    [
+      :subject_eq, :theme_eq, :landing_eq, :mtm_campaign_cont, :mtm_campaign_eq, :mtm_campaign_start, :mtm_campaign_end,
+      :need_created_at_gteq, :need_created_at_lteq, :user_antenne_eq, :user_institution_eq
+    ]
   end
 end

--- a/config/locales/models.fr.yml
+++ b/config/locales/models.fr.yml
@@ -163,6 +163,10 @@ fr:
     users:
       deep_soft_deleted: Utilisateurs et experts solo supprimés avec succès
       delete_confirmation: Voulez-vous supprimer ces utilisateurs ? Cela va aussi supprimer leur expert personnel.
+  activeadmin:
+    feedback:
+      created_at: Date de création du commentaire
+      need_created_at: Date de création du besoin
   activerecord:
     attributes:
       additional_subject_questions:
@@ -248,7 +252,7 @@ fr:
         readable_locality: Commune
       feedback:
         category: Catégorie
-        feedbackable: Sujet
+        feedbackable: Relation
         match_closed_at: Date de clôture de la mise en relation
         real_subject: Sujet réel
         real_theme: Thème réel
@@ -817,6 +821,7 @@ fr:
     expert: Expert
     expert_antenne: Antenne de l’expert
     expert_institution: Institution de l’expert
+    expert_reminder: Relances par expert
     expert_subject: Domaine d’intervention
     experts:
       one: Expert
@@ -857,6 +862,7 @@ fr:
     is_archived: Archivé
     key: Identifiant
     label: Intitulé
+    landing: page d’atterrissage
     landing_subject_title: Option choisie sur le site
     landing_subjects: Sujets de landing
     landing_theme_title: Thème choisi sur le site
@@ -887,6 +893,7 @@ fr:
     need_created_at: Date de création du besoin
     need_id: Identifiant du besoin
     need_last_chance_at: Date d’envoi mail de la dernière chance
+    need_reminder: Relances par besoin
     need_status: Statut du besoin
     needs:
       one: Besoin
@@ -962,6 +969,8 @@ fr:
     title: Titre
     updated_at: Date de mise à jour
     user: Conseiller
+    user_antenne: Antenne
+    user_institution: Institution
     visit: Visite
     visitee: Personne rencontrée
   deleted_account:


### PR DESCRIPTION
J'ai fait une première version simple pour qu'Adeline puisse trier les commentaires par date de besoin. Mais quand on voudra se servir de cet onglet pour les autres types de commentaires, il faudra adapter les filtres en fonction du scope
closes #3341