### PR TITLE
Do not run CI on main and production branches

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -128,5 +128,15 @@ workflows:
   version: 2
   build_and_test:
     jobs:
-      - test
-      - lint
+      - test:
+        filters:
+          branches:
+            ignore:
+              - main
+              - production
+      - lint:
+        filters:
+          branches:
+            ignore:
+              - main
+              - production


### PR DESCRIPTION
We require branches to be rebased before merging, and never commit directly to main or production. 

After a merge on `main`, the git repo is in the exact same state than the HEAD of the branch that was merged. For example, the HEAD on `main` is currently the commit 67f6616484eb087b31ff70265e714c733994e5df, and the HEAD of the last merged branch (`lucien/debug/02-09`), was the commit d5e05929de0b7e7b3d4dd4f647007166bfd2ad8b.
```sh
$ git cat-file -p 67f6616484eb087b31ff70265e714c733994e5df | grep tree
tree c80e0f21854e1a84564c3ed79ad6b78a776ad736
$ git cat-file -p d5e05929de0b7e7b3d4dd4f647007166bfd2ad8b | grep tree
tree c80e0f21854e1a84564c3ed79ad6b78a776ad736
```
![eIxbzM-1661372933](https://github.com/user-attachments/assets/60ea8894-e78f-432d-bb20-b5df5291c36c)

Even better, the `production` branch always follows `main`. The HEAD of `production` is always a commit that is also, or was, the HEAD of `main`.

There’s no need to rerun the same tests three times.