### PR TITLE
corriger les incohérences sur la catégorie "expirés" dans les sorties de PQ

### DIFF
--- a/app/services/reminders_service.rb
+++ b/app/services/reminders_service.rb
@@ -82,9 +82,12 @@ class RemindersService
     expert_for_outputs.each do |expert|
       last_run_register = expert.reminders_registers.find_by(run_number: last_run_number)
       current_expired_count = expired_matches(expert).size
-      # On considère que la sortie est due a l'expiration des besoins si au moins un besoin a expiré
-      if last_run_register.present? && (
-        (current_expired_count > last_run_register.expired_count) || (current_expired_count == last_run_register.expired_count && in_expired_needs_not_processed.include?(expert))
+      # L'expert va dans la catégorie "expired_needs" si :
+      # - Il a actuellement des besoins expirés (non pris en charge depuis plus de 45 jours)
+      # - ET soit de nouveaux besoins ont expiré, soit il était déjà en "expired_needs" non traité
+      # Sinon, il va dans "output" (sortie normale car il a traité ses besoins ou n'a plus de besoins actifs)
+      if last_run_register.present? && current_expired_count > 0 && (
+        (current_expired_count > last_run_register.expired_count) || in_expired_needs_not_processed.include?(expert)
       )
         RemindersRegister.create!(expert: expert, category: :expired_needs, run_number: current_run)
       else


### PR DESCRIPTION
Ah mon avis il y avait un scénario de bug qui pouvait arriver 
  1. Un expert a des besoins expirés
  2. L'expert prend en charge ces besoins
  3. `expired_matches(expert)` retourne maintenant 0 car ces matches ne sont plus en status quo
  4. Mais la condition à la ligne 87 vérifie : `current_expired_count == last_run_register.expired_count && 
  in_expired_needs_not_processed.include?(expert)`
  5. Si l'expert était déjà dans expired_needs non traité, il reste dans cette catégorie même s'il a pris en charge ses besoins.

closes #4007 