### PR TITLE
réduit la longueur du mot de passe de 16 à 12

### DIFF
--- a/config/initializers/devise.rb
+++ b/config/initializers/devise.rb
@@ -178,7 +178,7 @@ Devise.setup do |config|
 
   # ==> Configuration for :validatable
   # Range for password length.
-  config.password_length = 16..128
+  config.password_length = 12..128
 
   # Email regex used to validate email formats. It simply asserts that
   # one (and only one) @ exists in the given string. This is mainly

--- a/config/locales/devise.fr.yml
+++ b/config/locales/devise.fr.yml
@@ -62,7 +62,7 @@ fr:
     omniauth_callbacks:
       failure: 'Nous n’avons pas pu vous authentifier via %{kind} : ''%{reason}''.'
       success: Authentifié avec succès via %{kind}.
-    password_minimum_characters: 16 caractères minimum, avec au moins 4 types de caractères différents (majuscules, minuscules, chiffres et caractères spéciaux)
+    password_minimum_characters: 12 caractères minimum, avec au moins 4 types de caractères différents (majuscules, minuscules, chiffres et caractères spéciaux)
     passwords:
       edit:
         change_own_password: Enregistrer le mot de passe


### PR DESCRIPTION
Après plusieurs mois de mot de passe à 16 caractères, il s'avère que c'est trop compliqué pour beaucoup de conseillers.