### PR TITLE
Add missing comma in webmanifest

### DIFF
--- a/app/assets/images/favicon/site.webmanifest.erb
+++ b/app/assets/images/favicon/site.webmanifest.erb
@@ -6,7 +6,7 @@
             "src": "<%= asset_path 'favicon/android-chrome-192x192.png' %>",
             "sizes": "192x192",
             "type": "image/png"
-        }
+        },
         {
             "src": "<%= asset_path 'favicon/android-chrome-512x512.png' %>",
             "sizes": "512x512",


### PR DESCRIPTION
Chrome says:
> Manifest: Line: 10, column: 9, Unexpected token.

Safari says:
> Parsing application manifest : The manifest is not valid JSON data.

(Firefox doesn’t use the webmanifest.)