### PR TITLE
Modifie l'ordre des chiffres sur la page comment ça marche

### DIFF
--- a/app/views/stats/_ministats.haml
+++ b/app/views/stats/_ministats.haml
@@ -1,16 +1,16 @@
 .fr-grid-row.fr-py-17v
   .fr-col-12.fr-col-md-4.text-center.stats-item
     %p.fr-m-md-0
-      = stats_count(stats[:companies_by_employees])
-      %span.bold.fr-mt-2v
-        = t('stats.series.companies_by_employees.ministats')
-  .fr-col-12.fr-col-md-4.text-center.stats-item
-    %p.fr-m-md-0
       = stats_count(stats[:needs])
       %span.bold.fr-mt-2v
         = t('stats.series.needs.title')
   .fr-col-12.fr-col-md-4.text-center.stats-item
     %p.fr-m-md-0
+      = stats_count(stats[:companies_by_employees])
+      %span.bold.fr-mt-2v
+        = t('stats.series.companies_by_employees.ministats')
+  .fr-col-12.fr-col-md-4.text-center.stats-item
+    %p.fr-m-md-0
       = stats_count(stats[:users])
       %span.bold.fr-mt-2v
-        = t('stats.series.advisors.title')
+        = t('stats.series.users.ministats')

--- a/config/locales/views.fr.yml
+++ b/config/locales/views.fr.yml
@@ -1197,6 +1197,8 @@ fr:
         visits: Visites par un conseiller
       transmitted_needs:
         title: Besoins transmis
+      users:
+        ministats: Conseillers experts
     skeleton_card:
       loading: Graphique en cours de chargement...
     stats_chart:


### PR DESCRIPTION
closes #4013

Modifie l'ordre des chiffres sur la page comment ça marche
avant : 
<img width="1238" height="252" alt="Screenshot 2025-11-06 at 15 35 01" src="https://github.com/user-attachments/assets/b2cdb753-9362-4314-a317-785cd55bc5ee" />

après : 
<img width="1278" height="301" alt="Screenshot 2025-11-06 at 15 34 19" src="https://github.com/user-attachments/assets/1e1b259c-91a7-4124-9dbb-5c8f50774de9" />


J'en ai profité pour corriger une erreur de géocoder
