### PR TITLE
Fix excel export blue stats

### DIFF
--- a/app/services/xlsx_export/antenne_stats_worksheet_generator/by_antenne_methods.rb
+++ b/app/services/xlsx_export/antenne_stats_worksheet_generator/by_antenne_methods.rb
@@ -44,32 +44,14 @@ module XlsxExport
       end
 
       def finalise_by_antenne_calculation_style(start_row = 5, territorial_antennes_count = @antenne.territorial_antennes.count)
-        # highlight positionning
+        # highlight positionning (D), positionning_accepted (E), done (F).
         last_row = territorial_antennes_count + (start_row)
-        sheet.add_conditional_formatting("D#{start_row}:D#{last_row}",
+        sheet.add_conditional_formatting("D#{start_row}:F#{last_row}",
           type: :cellIs,
           operator: :lessThan,
-          formula: format_rate_for_print(@rate_positionning),
+          formula: "D$#{start_row - 1}", # The cell of @rate_positioning; the column is relative, the row is absolute.
           dxfId: @blue_bg,
           priority: 1)
-        # highlight positionning_accepted
-        sheet.add_conditional_formatting("E#{start_row}:E#{last_row}",
-          type: :cellIs,
-          operator: :lessThan,
-          formula: format_rate_for_print(@rate_positionning_accepted),
-          dxfId: @blue_bg,
-          priority: 1)
-        # highlight done
-        sheet.add_conditional_formatting("F#{start_row}:F#{last_row}",
-          type: :cellIs,
-          operator: :lessThan,
-          formula: format_rate_for_print(@rate_done),
-          dxfId: @blue_bg,
-          priority: 1)
-      end
-
-      def format_rate_for_print(rate)
-        "%.1f%%" % (100 * rate)
       end
     end
   end

--- a/app/services/xlsx_export/antenne_stats_worksheet_generator/by_territory.rb
+++ b/app/services/xlsx_export/antenne_stats_worksheet_generator/by_territory.rb
@@ -63,26 +63,12 @@ module XlsxExport
       private
 
       def finalise_by_territory_calculation_style(start_row = 5)
-        # highlight positionning
+        # highlight positionning (D), positionning_accepted (E), done (F).
         last_row = Territory.regions.count + (start_row - 1)
-        sheet.add_conditional_formatting("D#{start_row}:D#{last_row}",
+        sheet.add_conditional_formatting("D#{start_row}:F#{last_row}",
           type: :cellIs,
           operator: :lessThan,
-          formula: format_rate_for_print(@rate_positionning),
-          dxfId: @pink_bg,
-          priority: 1)
-        # highlight positionning_accepted
-        sheet.add_conditional_formatting("E#{start_row}:E#{last_row}",
-          type: :cellIs,
-          operator: :lessThan,
-          formula: format_rate_for_print(@rate_positionning_accepted),
-          dxfId: @pink_bg,
-          priority: 1)
-        # highlight done
-        sheet.add_conditional_formatting("F#{start_row}:F#{last_row}",
-          type: :cellIs,
-          operator: :lessThan,
-          formula: format_rate_for_print(@rate_done),
+          formula: "D$#{start_row - 1}", # The cell of @rate_positioning; the column is relative, the row is absolute.
           dxfId: @pink_bg,
           priority: 1)
       end


### PR DESCRIPTION
fixes #4020
Look at me I’m writing excel formulas in ruby!

Avant, on avait ça:

<img width="595" height="200" alt="Capture d’écran 2025-11-12 à 17 51 53" src="https://github.com/user-attachments/assets/924fb338-bd54-4075-8dbb-d6f110230ae0" />


Maintenant, on a ça:

<img width="587" height="97" alt="Capture d’écran 2025-11-12 à 17 51 01" src="https://github.com/user-attachments/assets/a32ba972-b396-4228-bb12-13e28154024b" />

Je continue de penser qu’on devrait plutôt hardcoder le style dans les cellules, plutôt que d’utiliser du style conditionnels, mais c’est déjà plus cohérent. (Et surtout, le bug est corrigé.)