### PR TITLE
replace "Dossier de presse" with "Brochure de présentation"

### DIFF
--- a/config/locales/views.fr.yml
+++ b/config/locales/views.fr.yml
@@ -666,8 +666,8 @@ fr:
       know_us: Nous connaître
       legifrance_title: Lien vers le site legifrance.gouv.fr
       open_cookies: Ouvre la fenêtre de gestion des cookies
-      service_presentation: Dossier de presse (PDF 500 ko)
-      service_presentation_title: Dossier de presse de Conseillers-Entreprises - lien de téléchargement (PDF 500 ko)
+      service_presentation: Brochure de présentation (PDF 500 ko)
+      service_presentation_title: Brochure de présentation de Conseillers-Entreprises - lien de téléchargement (PDF 500 ko)
       service_public_title: Lien vers le site service-public.gouv.fr
       service_short_description: Échangez avec les conseillers qui peuvent vous aider dans vos projets, vos difficultés ou les transformations nécessaires à la réussite de votre entreprise.
       source_code: Github, lien vers le code source du site


### PR DESCRIPTION
Change le titre du lien dans le footer de "Dossier de presse" à "Brochure de présentation"