### PR TITLE
Afficher toutes les dates dans la boite de réception

### DIFF
--- a/app/assets/stylesheets/components/cards.sass
+++ b/app/assets/stylesheets/components/cards.sass
@@ -18,6 +18,11 @@
       display: block
   .fr-text--lg
     margin-bottom: 0
+  ul.fr-card__detail
+    display: block
+    list-style: none
+    padding: 0
+    margin: 0
     
 .comment__container
   order: 3

--- a/app/views/needs/_need.html.haml
+++ b/app/views/needs/_need.html.haml
@@ -14,7 +14,10 @@
                 %ul.fr-badges-group
                   %li
                     %p.fr-badge.fr-badge--yellow-moutarde= need.cooperation.name
-              %p.fr-card__detail
-                %time{ datetime: need.match_sent_at }= t('needs.dates.match_sent_at', date: l(need.match_sent_at, format: :long_sentence))
+              %ul.fr-card__detail
+                %li.fr-p-0
+                  %time{ datetime: need.solicited_at }= t('needs.dates.solicited_at', date: l(need.solicited_at, format: :long_sentence))
+                %li
+                  %time{ datetime: need.match_sent_at }= t('needs.dates.match_sent_at', date: l(need.match_sent_at, format: :long_sentence))
                 - if params[:query].present?
                   %span.label.grey-blue= t(need.status, scope: 'needs.collections_single')


### PR DESCRIPTION
Affiche les dates de dépôt de sollicitation et les dates d'envoi du besoin sur les cartes dans la boite de réception.
<img width="935" height="244" alt="Screenshot 2025-12-12 at 10 43 17" src="https://github.com/user-attachments/assets/529830cd-ed7d-480b-83df-5c5ce7b5971b" />

Clôture également le ticket sur le bug quand on filtre par date dans la boite de réception. Le filtre prend en compte la date de dépôt du besoin. Ce qui est ce qu'on veut mais elle n'était pas affichée


closes #4135 
closes #4126 