### PR TITLE
Fix crash in companies#needs

### DIFF
--- a/app/controllers/companies_controller.rb
+++ b/app/controllers/companies_controller.rb
@@ -56,23 +56,12 @@ class CompaniesController < ApplicationController
   def needs
     @facility = authorize Facility.find(params.permit(:id)[:id])
 
-    @needs_in_progress = policy_scope(@facility.needs)
-      .in_progress
-      .order(created_at: :desc)
-    @needs_done = policy_scope(@facility.needs)
-      .done
-      .order(created_at: :desc)
+    @needs_in_progress = policy_scope(@facility.needs).in_progress.order(created_at: :desc)
+    @needs_done = policy_scope(@facility.needs).done.order(created_at: :desc)
 
     email_needs = Need.for_emails(@facility.company.contacts.pluck(:email))
-
-    @contact_needs_in_progress = policy_scope(email_needs)
-      .in_progress
-      .where.not(id: @needs_in_progress)
-      .order(created_at: :desc)
-    @contact_needs_done = policy_scope(email_needs)
-      .done
-      .where.not(id: @needs_done)
-      .order(created_at: :desc)
+    @contact_needs_in_progress = policy_scope(email_needs).in_progress.order(created_at: :desc) - @needs_in_progress
+    @contact_needs_done = policy_scope(email_needs).done.order(created_at: :desc) - @needs_done
   end
 
   private


### PR DESCRIPTION
refs #4179

Le bug est facile à reproduire en local en accédant à `http://localhost:3000/entreprises/164790/besoins` (ou n’importe quelle entreprise).

Le problème, c’est que les requêtes génèrent ce genre de SQL:

```sql
SELECT DISTINCT
	"needs".*
FROM
	"needs"
	INNER JOIN "diagnoses" ON "diagnoses"."id" = "needs"."diagnosis_id"
	INNER JOIN "solicitations" ON "solicitations"."id" = "diagnoses"."solicitation_id"
	INNER JOIN "matches" ON "matches"."need_id" = "needs"."id"
	INNER JOIN "experts" ON "experts"."id" = "matches"."expert_id"
WHERE
"needs"."status" IN ('quo', 'taking_care')
	AND "needs"."id" NOT IN ( SELECT DISTINCT
			"needs"."id"
		FROM
			"needs"
			INNER JOIN "diagnoses" ON "needs"."diagnosis_id" = "diagnoses"."id"
			INNER JOIN "matches" ON "matches"."need_id" = "needs"."id"
			INNER JOIN "experts" ON "experts"."id" = "matches"."expert_id"
		WHERE
			"diagnoses"."facility_id" = 14
			AND "needs"."status" IN ('quo', 'taking_care')
		ORDER BY
			"needs"."created_at" DESC)
ORDER BY
	"needs"."created_at" DESC;
```
La subquery fait un SELECT DISTINCT, qui n’est d’ailleurs pas nécessaire ici, avec un ORDER BY, et le champ de tri n’est pas dans le select. Bref, les ORM?


Cette PR est un workaround pour le moment. En principe, companies_controller_spec aurait du révéler le bug, ce qui est un autre mystère.
