### PR TITLE
Add `status` attribute to `Need` and fix query logic in diagnoses controller

### DIFF
--- a/app/controllers/conseiller/diagnoses_controller.rb
+++ b/app/controllers/conseiller/diagnoses_controller.rb
@@ -7,7 +7,7 @@ class Conseiller::DiagnosesController < ApplicationController
     @diagnosis = DiagnosisCreation::NewDiagnosis.new(@current_solicitation).call
     if @current_solicitation.present?
       @needs = Need.where(id: Need.diagnosis_completed.for_emails(@current_solicitation.email))
-        .or(where(id: Need.diagnosis_completed.for_sirets(@current_solicitation.siret)))
+        .or(Need.where(id: Need.diagnosis_completed.for_sirets(@current_solicitation.siret)))
       @tab = 'search_manually' if @current_solicitation.siret.nil?
     else
       @needs = []

--- a/app/models/need.rb
+++ b/app/models/need.rb
@@ -36,6 +36,7 @@ class Need < ApplicationRecord
   include RangeScopes
   include MandatoryAnswers
 
+  attribute :status, :string
   enum :status, {
     diagnosis_not_complete: 'diagnosis_not_complete',
       quo: 'quo',


### PR DESCRIPTION
Premier bug, il manquais le `Need` dans le `.or`  :
```ruby
    if @current_solicitation.present?
      @needs = Need.where(id: Need.diagnosis_completed.for_emails(@current_solicitation.email))
        .or(Need.where(id: Need.diagnosis_completed.for_sirets(@current_solicitation.siret)))
      @tab = 'search_manually' if @current_solicitation.siret.nil?
    else
```

deuxieme :  
Rails ne reconnaît pas automatiquement le type de l'enum PostgreSQL `need.status` . Il faut déclarer explicitement l'attribut avec son type avant de définir l'enum.