### PR TITLE
Do not display count of User.without_activity in admin/users

### DIFF
--- a/app/admin/user.rb
+++ b/app/admin/user.rb
@@ -37,7 +37,7 @@ ActiveAdmin.register User do
   config.sort_order = 'created_at_desc'
 
   scope I18n.t("active_admin.user.active"), :active, default: true
-  scope :without_activity
+  scope :without_activity, show_count: false
   scope :currently_absent
   scope :deleted
 


### PR DESCRIPTION
Contournement temporaire pour https://github.com/betagouv/conseillers-entreprises/issues/4168#issuecomment-3682817358: on n’affiche pas le compte.