### PR TITLE
Ajoute les colonnes Nb de besoins et Taux de refus dans les fichiers stats

### DIFF
--- a/app/services/xlsx_export/antenne_stats_worksheet_generator/by_refused_subject.rb
+++ b/app/services/xlsx_export/antenne_stats_worksheet_generator/by_refused_subject.rb
@@ -9,9 +9,11 @@ module XlsxExport
 
         sheet.add_row [
           I18n.t('antenne_stats_exporter.antenne_refused_subjects'),
+          I18n.t('antenne_stats_exporter.needs_count_on_subject'),
           I18n.t('antenne_stats_exporter.refusals_count'),
+          I18n.t('antenne_stats_exporter.refusal_rate_on_subject'),
           I18n.t('antenne_stats_exporter.needs_refused_percentage'),
-        ], style: [@left_header, @right_header, @right_header]
+        ], style: [@left_header, @right_header, @right_header, @right_header, @right_header]
 
         generate_by_subject_table(refused_needs)
       end
@@ -26,30 +28,42 @@ module XlsxExport
         @current_needs ||= @refused_needs
       end
 
-      # Ici, on ne veut que 3 colonnes, d'où surcharge de la méthode
-      def add_agglomerate_rows(needs, row_title, recipient, ratio = nil)
+      def generate_subjects_row(needs_by_subjects, recipient = @antenne)
+        needs_by_subjects.sort_by { |_, needs| -needs.count }.each do |subject_label, needs|
+          all_needs_on_subject = @needs.where(subject: needs.first.subject)
+          refused_rate_on_subject = calculate_rate(needs.count, all_needs_on_subject)
+          ratio = calculate_rate(needs.count, current_needs)
+          add_agglomerate_rows(needs, subject_label, recipient, all_needs_on_subject.size, refused_rate_on_subject, ratio)
+        end
+      end
+
+      def add_agglomerate_rows(needs, row_title, recipient, all_needs_on_subject_size, refused_rate_on_subject, ratio = nil)
         sheet.add_row [
           row_title,
+          all_needs_on_subject_size,
           needs.size,
+          refused_rate_on_subject,
           ratio,
-        ], style: [nil, nil, @rate]
+        ], style: [nil, nil, nil, @rate, @rate]
       end
 
       def add_subject_table_header(tab_scope)
         sheet.add_row [
           I18n.t(tab_scope, scope: ['antenne_stats_exporter']),
+          I18n.t('antenne_stats_exporter.needs_count_on_subject'),
           I18n.t('antenne_stats_exporter.refusals_count'),
+          I18n.t('antenne_stats_exporter.refusal_rate_on_subject'),
           I18n.t('antenne_stats_exporter.needs_refused_percentage'),
-        ], style: [@left_header, @right_header, @right_header]
+        ], style: [@left_header, @right_header, @right_header, @right_header, @right_header]
       end
 
       def finalise_agglomerate_style
         [
-          'A1:C1',
-          'A2:C2',
+          'A1:E1',
+          'A2:E2',
         ].each { |range| sheet.merge_cells(range) }
 
-        sheet.column_widths 70, 20, 25
+        sheet.column_widths 70, 20, 20, 20, 25
       end
     end
   end

--- a/config/locales/models.fr.yml
+++ b/config/locales/models.fr.yml
@@ -905,6 +905,7 @@ fr:
     national: National
     needs: Besoins
     needs_count: Nb de besoins
+    needs_count_on_subject: Nb de besoins
     needs_percentage: Part des besoins
     needs_refused_percentage: Part des besoins refusés
     no_antennes_without_needs: "* Les antennes qui n’ont pas reçu de besoin n’apparaissent pas dans ce tableau."
@@ -931,6 +932,7 @@ fr:
     quo_caption_definition: L’expert ne s’est pas positionné sur le besoin malgré les relances de l’équipe de Conseillers-Entreprises.
     quo_caption_label: En attente de positionnement
     quo_rate: Taux de sans positionnement
+    refusal_rate_on_subject: Taux de refus
     refusals: Refus trim.
     refusals_count: Nb de refus
     region: Région


### PR DESCRIPTION
Ajoute les colonnes Nb de besoins et Taux de refus dans les fichiers stats pour mieux suivre les refus par sujet.

Avant
<img width="953" height="270" alt="Screenshot 2026-01-07 at 11 10 10" src="https://github.com/user-attachments/assets/6bf052a6-a2a1-4b57-852c-c577a19396f5" />

Apres
<img width="1260" height="283" alt="Screenshot 2026-01-07 at 11 09 32" src="https://github.com/user-attachments/assets/0296ec9d-57c0-4734-ae10-125dbb61bb26" />


⚠️ Régénérer les fichiers du dernier trimestre après l'avoir mis en prod

closes #4191 