### PR TITLE
Gestion de l’url de provenance pour les sollicitations MTE

### DIFF
--- a/app/services/partner_origin.rb
+++ b/app/services/partner_origin.rb
@@ -17,11 +17,20 @@ module PartnerOrigin
     end
   end
 
+  MTE_COOPERATION_NAME = "Mission transition écologique des entreprises"
+  MTE_ORIGIN_URL_CUSTOM = "https://mission-transition-ecologique.beta.gouv.fr/custom"
+
+  def self.from_mte?(solicitation)
+    if solicitation.present?
+      solicitation.cooperation&.name == MTE_COOPERATION_NAME
+    end
+  end
+
   def self.partner_url(solicitation, full: false)
     return if solicitation.nil?
 
     if solicitation.origin_url.present?
-      solicitation.origin_url
+      origin_url(solicitation)
     elsif from_entreprendre?(solicitation: solicitation) && solicitation.kwd.present?
       entreprendre_url(solicitation, full: full)
     else
@@ -39,5 +48,13 @@ module PartnerOrigin
 
   def self.landing_partner_url(solicitation, full: false)
     full ? solicitation.landing.partner_full_url : solicitation.landing.partner_url
+  end
+
+  def self.origin_url(solicitation)
+    if from_mte?(solicitation) && solicitation.origin_url == MTE_ORIGIN_URL_CUSTOM
+      solicitation.cooperation.root_url
+    else
+      solicitation.origin_url
+    end
   end
 end

--- a/spec/services/partner_origin_spec.rb
+++ b/spec/services/partner_origin_spec.rb
@@ -84,6 +84,22 @@ describe PartnerOrigin do
         it { is_expected.to eq "https://entreprendre.service-public.gouv.fr/vosdroits/F1111" }
       end
 
+      context 'partenaire MTE' do
+        context 'valid origin' do
+          let(:cooperation) { build :cooperation, name: 'Mission transition écologique des entreprises', root_url: 'https://mission-transition-ecologique.beta.gouv.fr' }
+          let(:solicitation) { build :solicitation, cooperation: cooperation, origin_url: 'https://mission-transition-ecologique.beta.gouv.fr/custom' }
+
+          it { is_expected.to eq 'https://mission-transition-ecologique.beta.gouv.fr' }
+        end
+
+        context 'custom origin' do
+          let(:cooperation) { build :cooperation, name: 'Mission transition écologique des entreprises', root_url: 'https://mission-transition-ecologique.beta.gouv.fr' }
+          let(:solicitation) { build :solicitation, cooperation: cooperation, origin_url: 'https://mission-transition-ecologique.beta.gouv.fr/aides-entreprise/renovation-petit-tertiaire-prive' }
+
+          it { is_expected.to eq 'https://mission-transition-ecologique.beta.gouv.fr/aides-entreprise/renovation-petit-tertiaire-prive' }
+        end
+      end
+
       context 'with landing url' do
         let(:solicitation) { build :solicitation, landing: create(:landing, cooperation: cooperation, url_path: '/aide-1') }
 


### PR DESCRIPTION
Ajout de comportement spécifique aux sollicitations en provenance de la MTE. Idéalement, on mettra en place une meilleure API pour indique qu’il n’y a pas d’url d’origine.

- [x] suite à #4193, à merger d’abord.