### PR TITLE
Afficher l'url de provenance pour la coopération Site ministère du Travail

### DIFF
--- a/app/services/partner_origin.rb
+++ b/app/services/partner_origin.rb
@@ -60,17 +60,9 @@ module PartnerOrigin
     end
   end
 
-  MINISTERE_DU_TRAVAIL_KWD_PATCHES = {
-    "burn-out-et-rps" => "burn-out-et-risques-psychosociaux-comprendre-pour-mieux-prevenir",
-    "cadre-general-detachement" => "cadre-general-du-detachement-des-salaries",
-    "comment-fonctionne-la-formation" => "comment-fonctionne-la-formation-des-salaries",
-    "creation-ou-reprise-activite" => "creation-ou-reprise-dactivite-quels-dispositifs",
-    "presentation-service" => "ouverture-nationale-du-service-place-des-entreprises",
-  }
   def self.ministere_du_travail_url(solicitation, full: false)
     if full && solicitation.kwd.present?
-      kwd = MINISTERE_DU_TRAVAIL_KWD_PATCHES.fetch(solicitation.kwd, solicitation.kwd)
-      "#{solicitation.cooperation.root_url}/#{kwd}"
+      "#{solicitation.cooperation.root_url}/#{solicitation.kwd}"
     else
       solicitation.cooperation.root_url
     end

--- a/spec/services/partner_origin_spec.rb
+++ b/spec/services/partner_origin_spec.rb
@@ -107,13 +107,6 @@ describe PartnerOrigin do
 
           it { is_expected.to eq 'https://travail-emploi.gouv.fr/le-travail-de-nuit' }
         end
-
-        context 'kwd with override' do
-          let(:cooperation) { build :cooperation, mtm_campaign: 'ministere-du-travail', root_url: 'https://travail-emploi.gouv.fr' }
-          let(:solicitation) { build :solicitation, cooperation: cooperation, mtm_kwd: 'creation-ou-reprise-activite' }
-
-          it { is_expected.to eq 'https://travail-emploi.gouv.fr/creation-ou-reprise-dactivite-quels-dispositifs' }
-        end
       end
 
       context 'with landing url' do


### PR DESCRIPTION
fixes #4133 

- [ ] basé sur #4193 et #4197, à merger d’abord.

On reconstruit l’url à partir du kwd passé en paramètre. Malheureusement, dans certains cas (5%) il ne correspond pas au chemin de la page. Pour le moment, on met des patch en dur, et on avise avec l’équipe du ministère.