### PR TITLE
Switch to gem.coop

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,4 +1,4 @@
-source 'https://rubygems.org'
+source 'https://gem.coop'
 
 git_source(:github) do |repo_name|
   if repo_name.exclude?('/')

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,5 +1,5 @@
 GEM
-  remote: https://rubygems.org/
+  remote: https://gem.coop/
   specs:
     aasm (5.5.2)
       concurrent-ruby (~> 1.0)


### PR DESCRIPTION
It’s already being used in production for
- RDVSP: https://github.com/betagouv/rdv-service-public/pull/6068
- DN: https://github.com/demarche-numerique/demarche.numerique.gouv.fr/pull/12159