### PR TITLE
Change le style du lien vers l'origine de la sollicitation

### DIFF
--- a/app/views/needs/show.html.haml
+++ b/app/views/needs/show.html.haml
@@ -23,10 +23,12 @@
                     = question_label(answer.key, :long)
                     %strong= answer_label(answer.key, answer.filter_value)
             - if display_partner_url
-              %p.fr-text--sm
-                = t('.origin_source')
-                %br
-                = link_to partner_title(@need.solicitation), PartnerOrigin.partner_url(@need.solicitation, full: true), title: "#{to_new_window_title(t('.origin_source_title'))}", target: '_blank', rel: 'noopener'
+              .fr-callout
+                %p.fr-callout__text
+                  %span.ri-information-line.fr-mr-1v{ 'aria-hidden': 'true' }
+                  = t('.origin_source')
+                  %br
+                  = link_to partner_title(@need.solicitation), PartnerOrigin.partner_url(@need.solicitation, full: true), title: "#{to_new_window_title(t('.origin_source_title'))}", target: '_blank', rel: 'noopener', class: 'fr-link fr-link--icon-right fr-icon-external-link-line'
 
     .fr-col-md-4.order-minus-one.bp-sm
       .fr-grid-row.need-metadata


### PR DESCRIPTION
closes #4221 

Avant 
<img width="422" height="150" alt="Screenshot 2026-02-04 at 14 39 30" src="https://github.com/user-attachments/assets/ddd766d3-d1c5-4e53-8a02-e6afe15725f4" />

Apres
<img width="587" height="147" alt="Screenshot 2026-02-04 at 14 39 07" src="https://github.com/user-attachments/assets/6a3e4204-ad5a-4c43-9f02-31185a8762a4" />
