### PR TITLE
Affiche un lien vers la provenance sur la carte des sollicitations

### DIFF
--- a/app/helpers/solicitation_helper.rb
+++ b/app/helpers/solicitation_helper.rb
@@ -58,8 +58,9 @@ module SolicitationHelper
   end
 
   def display_solicitation_attribute(solicitation, attribute)
-    if attribute == :provenance_detail && solicitation.from_entreprendre?
-      link_to solicitation.send(attribute), PartnerOrigin.partner_url(solicitation, full: true), title: "#{to_new_window_title(t('needs.show.origin_source_title'))}", target: '_blank', rel: 'noopener', data: { turbo: false }
+    partner_url = PartnerOrigin.partner_url(solicitation, full: true)
+    if attribute == :provenance_detail && partner_url.present?
+      link_to solicitation.send(attribute), partner_url, title: "#{to_new_window_title(t('needs.show.origin_source_title'))}", target: '_blank', rel: 'noopener', data: { turbo: false }
     elsif attribute == :siret
       link_to(solicitation.normalized_siret, show_with_siret_companies_path(solicitation.siret), data: { turbo: false })
     else


### PR DESCRIPTION
closes #4210 

Affiche systématiquement un lien vers la provenance dans la carte des sollicitations au lieu d'afficher un lien pour Entreprendre uniquement

<img width="477" height="63" alt="Screenshot 2026-02-16 at 11 25 46" src="https://github.com/user-attachments/assets/53806910-d73d-4a19-91bd-43c846249a4c" />
