### PR TITLE
Modifie l'affichage du lien vers l'origine de la demande dans la fiche entreprise

### DIFF
--- a/app/views/needs/show.html.haml
+++ b/app/views/needs/show.html.haml
@@ -23,8 +23,8 @@
                     = question_label(answer.key, :long)
                     %strong= answer_label(answer.key, answer.filter_value)
             - if display_partner_url
-              .fr-callout
-                %p.fr-callout__text
+              .fr-highlight
+                %p
                   %span.ri-information-line.fr-mr-1v{ 'aria-hidden': 'true' }
                   = t('.origin_source')
                   %br


### PR DESCRIPTION
closes #4255 

suite de #4238

Avant :  
<img width="837" height="150" alt="Screenshot 2026-02-16 at 14 07 23" src="https://github.com/user-attachments/assets/0f5e3092-0a88-43b4-8357-9e1107b6caa0" />

Après : 
<img width="539" height="116" alt="Screenshot 2026-02-16 at 14 07 43" src="https://github.com/user-attachments/assets/10e5ed62-d17f-4ae1-bd3e-95b4e05cf008" />

