### PR TITLE
Do not use custom ::marker content (unsupported on Safari)

### DIFF
--- a/app/assets/stylesheets/components/components.sass
+++ b/app/assets/stylesheets/components/components.sass
@@ -6,19 +6,6 @@
     li
       margin-bottom: 0
       line-height: 1.6rem
-      &.li--marker
-        margin-left: 1.5rem
-        padding-left: 1rem
-        &::marker
-          font-family: 'remixicon' !important
-          font-size: 1.5rem
-      &.li--mail-line::marker
-        content: "\eef6" // ri-mail-line
-      &.li--phone-line::marker
-        content: "\efec" // ri-phone-line
-        
-
-
     &:last-child
       margin-bottom: 0
   .name

--- a/app/views/application/_person.haml
+++ b/app/views/application/_person.haml
@@ -13,8 +13,10 @@
         %span.picto.ri-contacts-book-line{ 'aria-hidden': 'true' }
         = job
     - if phone_number.present?
-      %li.li--marker.li--phone-line
+      %li
+        %span.picto.ri-phone-line{ 'aria-hidden': 'true' }
         = link_to(phone_number, "tel:#{ERB::Util.url_encode(phone_number)}", class: 'fr-link')
     - if email.present?
-      %li.li--marker.li--mail-line
+      %li
+        %span.picto.ri-mail-line{ 'aria-hidden': 'true' }
         = mail_to email, email, class: 'fr-link'


### PR DESCRIPTION
(fait en passant de #4263)

Sur safari, on a des espaces vides là où on devrait voir des icônes. (https://caniuse.com/css-marker-pseudo) :

| avant | après |
|-|-|
| <img width="599" height="290" alt="Capture d’écran 2026-02-17 à 10 57 05" src="https://github.com/user-attachments/assets/3b6e0458-a18b-4fb5-a5e6-87f358c482a3" /> | <img width="599" height="293" alt="image" src="https://github.com/user-attachments/assets/764fddff-0429-4ea6-80d3-89555de29077" /> |


Ça a été fait exprès dans #3470, mais j’ai du mal à comprendre ce que ça corrigeait 🤔 

