### PR TITLE
Remove obsolete inverse relation

### DIFF
--- a/app/models/landing_theme.rb
+++ b/app/models/landing_theme.rb
@@ -32,7 +32,7 @@ class LandingTheme < ApplicationRecord
 
   has_many :subjects, through: :landing_subjects, inverse_of: :landing_themes
   has_many :themes, -> { distinct }, through: :subjects, inverse_of: :landing_themes
-  has_many :theme_territories, -> { distinct }, through: :subjects, inverse_of: :landing_themes, source: :territorial_zones
+  has_many :theme_territories, -> { distinct }, through: :subjects, source: :territorial_zones
   has_many :solicitations, through: :landing_subjects, inverse_of: :landing_theme
   has_many :matches, through: :solicitations, inverse_of: :landing_theme
 


### PR DESCRIPTION
TerritorialZone has no relation to LandingTheme

(This makes /admin/landings/<slug> crash if the landing theme does have regional zones, see PLACE-DES-ENTREPRISES-APP-46T)