### PR TITLE
Corrige les liens vers les sujets dans les emails de rétention intelligent

### DIFF
--- a/app/admin/email_retentions.rb
+++ b/app/admin/email_retentions.rb
@@ -29,8 +29,8 @@ ActiveAdmin.register EmailRetention do
       div I18n.t('mailers.hello')
       div email_retention.first_paragraph.html_safe
       div I18n.t('mailers.company_mailer.intelligent_retention.and_you').html_safe
-      div link_to email_retention.first_subject_label, new_solicitation_url(Landing.accueil, Landing.accueil.landing_subjects.joins(:subject).find_by(subject: email_retention.first_subject))
-      div link_to email_retention.second_subject_label, new_solicitation_url(Landing.accueil, Landing.accueil.landing_subjects.joins(:subject).find_by(subject: email_retention.second_subject))
+      div link_to email_retention.first_subject_label, new_solicitation_url(landing_slug: Landing.accueil.slug, landing_subject_slug: Landing.accueil.landing_subjects.joins(:subject).find_by(subject: email_retention.first_subject).slug)
+      div link_to email_retention.second_subject_label, new_solicitation_url(landing_slug: Landing.accueil.slug, landing_subject_slug: Landing.accueil.landing_subjects.joins(:subject).find_by(subject: email_retention.second_subject).slug)
       div I18n.t('mailers.company_mailer.why_this_message_html').html_safe
       div I18n.t('mailers.company_mailer.explanation_html').html_safe
     end

--- a/app/views/mailers/company_mailer/intelligent_retention.mjml
+++ b/app/views/mailers/company_mailer/intelligent_retention.mjml
@@ -7,11 +7,11 @@
     <mj-text><%= t('.and_you') %></mj-text>
 
     <% campaign = '?' + { mtm_campaign: 'retention2', mtm_kwd: "retention2-#{@email_retention.subject.label.parameterize}" }.to_query %>
-    <mj-button href="<%= new_solicitation_url(Landing.accueil, Landing.accueil.landing_subjects.joins(:subject).find_by(subject: @email_retention.first_subject)) + campaign %>"
+    <mj-button href="<%= new_solicitation_url(landing_slug: Landing.accueil.slug, landing_subject_slug: Landing.accueil.landing_subjects.joins(:subject).find_by(subject: @email_retention.first_subject).slug) + campaign %>"
                 background-color="#000091" color="white" border-radius="0" font-weight="700">
       <%= @email_retention.first_subject_label %>
     </mj-button>
-    <mj-button href="<%= new_solicitation_url(Landing.accueil, Landing.accueil.landing_subjects.joins(:subject).find_by(subject: @email_retention.second_subject)) + campaign %>"
+    <mj-button href="<%= new_solicitation_url(landing_slug: Landing.accueil.slug, landing_subject_slug: Landing.accueil.landing_subjects.joins(:subject).find_by(subject: @email_retention.second_subject).slug) + campaign %>"
                background-color="#000091" color="white" border-radius="0" font-weight="700">
       <%= @email_retention.second_subject_label %>
     </mj-button>


### PR DESCRIPTION
closes #4287 

Corrige les liens vers les sujets dans les emails de rétention intelligents. J'ai peur que ça n'ai jamais fonctionné

Avant
<img width="264" height="33" alt="Screenshot 2026-02-24 at 12 06 06" src="https://github.com/user-attachments/assets/6a29e8f8-970a-46fd-99c0-40670e56e36c" />

Après
<img width="302" height="33" alt="Screenshot 2026-02-24 at 12 06 15" src="https://github.com/user-attachments/assets/eb4c84a5-3bcc-4721-b25f-6e1df7fcffde" />
