### PR TITLE
Evite les longs chargement sur les filtres des MER en admin

### DIFF
--- a/app/admin/match.rb
+++ b/app/admin/match.rb
@@ -7,40 +7,9 @@ ActiveAdmin.register Match do
     include DynamicallyFiltrable
 
     def scoped_collection
-      base_includes = [
-        :need, :facility, :company, :advisor, :expert, :subject, :theme,
-      ]
-      additional_includes = []
-
-      if params[:scope] == 'sent' || params[:scope].nil?
-        # Default scope: load all associations for complete display
-        additional_includes += [
-          :related_matches, :advisor_antenne, :advisor_institution,
-          :expert_antenne, :expert_institution, :solicitation, :diagnosis,
-          :landing, :landing_theme, :landing_subject, { need: :subject }
-        ]
-      else
-        additional_includes += [
-          :advisor_antenne, :advisor_institution, :expert_antenne, :solicitation, :diagnosis,
-          { need: :subject }
-        ]
-      end
-
-      # Optimize based on active filters
-      if params.dig(:q, :expert_id_eq).present? || params.dig(:q, :expert_antenne_id_eq).present?
-        additional_includes += [:expert, :expert_antenne, :expert_institution]
-      end
-
-      if params.dig(:q, :landing_id_eq).present? || params.dig(:q, :landing_theme_id_eq).present?
-        additional_includes += [:landing, :landing_theme, :landing_subject]
-      end
-
-      if params.dig(:q, :theme_id_eq).present? || params.dig(:q, :subject_id_eq).present?
-        additional_includes += [:subject, :theme]
-      end
-
-      includes = base_includes + additional_includes
-      super.includes(includes.uniq)
+      # Performance fix for #4295: Minimize eager loading to avoid slow queries
+      # Only eager load what's necessary for the index display
+      super.includes(:need, :expert, :subject)
     end
   end
 


### PR DESCRIPTION
Closes #4295 
Réduit les includes au minimum pour afficher l'index. On préfere avoir quelques N+1 que beaucoup de LEFT OUTER JOIN

Avant :  
```sql
SELECT COUNT(DISTINCT "matches"."id")
FROM "matches"
  -- JOINs nécessaires pour les filtres
  INNER JOIN "needs" ON "needs"."id" = "matches"."need_id"
  INNER JOIN "diagnoses" ON "diagnoses"."id" = "needs"."diagnosis_id"
  INNER JOIN "solicitations" ON "solicitations"."id" = "diagnoses"."solicitation_id"
  INNER JOIN "needs" "needs_matches" ON "needs_matches"."id" = "matches"."need_id"
  INNER JOIN "diagnoses" "diagnoses_needs_join" ON "diagnoses_needs_join"."id" = "needs"."diagnosis_id"
  INNER JOIN "facilities" ON "facilities"."id" = "diagnoses_needs_join"."facility_id"

  -- JOINs générés par .includes() pour eager loading
  LEFT OUTER JOIN "subjects" ON "subjects"."id" = "needs_matches"."subject_id"
  LEFT OUTER JOIN "needs" "needs_matches_join" ON "needs_matches_join"."id" = "matches"."need_id"
  LEFT OUTER JOIN "diagnoses" "diagnoses_matches_join" ON "diagnoses_matches_join"."id" = "needs_matches_join"."diagnosis_id"
  LEFT OUTER JOIN "facilities" "facilities_matches" ON "facilities_matches"."id" = "diagnoses_matches_join"."facility_id"
  LEFT OUTER JOIN "facilities" "facilities_matches_join" ON "facilities_matches_join"."id" = "diagnoses_matches_join"."facility_id"
  LEFT OUTER JOIN "companies" ON "companies"."id" = "facilities_matches_join"."company_id"
  LEFT OUTER JOIN "users" ON "users"."id" = "diagnoses_matches_join"."advisor_id"
  LEFT OUTER JOIN "experts" ON "experts"."id" = "matches"."expert_id"
  LEFT OUTER JOIN "subjects" "subjects_matches" ON "subjects_matches"."id" = "matches"."subject_id"
  LEFT OUTER JOIN "themes" ON "themes"."id" = "subjects_matches"."theme_id"

  -- JOIN related_matches (pas utilisé dans l'affichage)
  LEFT OUTER JOIN "matches" "related_matches_matches" ON "related_matches_matches"."need_id" = "needs_matches_join"."id"

  -- Multiples JOINs sur antennes 
  LEFT OUTER JOIN "antennes" ON "antennes"."id" = "users"."antenne_id"
  LEFT OUTER JOIN "antennes" "antennes_matches_join" ON "antennes_matches_join"."id" = "users"."antenne_id"
  LEFT OUTER JOIN "institutions" ON "institutions"."id" = "antennes_matches_join"."institution_id"
  LEFT OUTER JOIN "antennes" "expert_antennes_matches" ON "expert_antennes_matches"."id" = "experts"."antenne_id"
  LEFT OUTER JOIN "antennes" "antennes_matches_join_2" ON "antennes_matches_join_2"."id" = "experts"."antenne_id"
  LEFT OUTER JOIN "institutions" "expert_institutions_matches" ON "expert_institutions_matches"."id" = "antennes_matches_join_2"."institution_id"

  -- Re-JOINs sur diagnoses/solicitations (déjà présents plus haut)
  LEFT OUTER JOIN "diagnoses" "diagnoses_matches" ON "diagnoses_matches"."id" = "needs_matches_join"."diagnosis_id"
  LEFT OUTER JOIN "solicitations" "solicitations_matches_join" ON "solicitations_matches_join"."id" = "diagnoses_matches"."solicitation_id"
  LEFT OUTER JOIN "landings" ON "landings"."id" = "solicitations_matches_join"."landing_id"
  LEFT OUTER JOIN "landing_subjects" ON "landing_subjects"."id" = "solicitations_matches_join"."landing_subject_id"
  LEFT OUTER JOIN "landing_themes" ON "landing_themes"."id" = "landing_subjects"."landing_theme_id"
  LEFT OUTER JOIN "landing_subjects" "landing_subjects_matches" ON "landing_subjects_matches"."id" = "solicitations_matches_join"."landing_subject_id"

WHERE
  "solicitations"."created_at" >= '2026-02-25 00:00:00'
  AND "solicitations"."created_at" <= '2026-02-27 00:00:00'
  AND LEFT(facilities.insee_code, 2) IN ('75', '77', '78', '91', '92', '93', '94', '95')
  AND "solicitations"."landing_subject_id" = 55
  AND "matches"."sent_at" IS NOT NULL;
```

Apres : 
```sql
SELECT COUNT(DISTINCT "matches"."id")
FROM "matches"
  -- JOINs nécessaires pour les filtres (identiques)
  INNER JOIN "needs" ON "needs"."id" = "matches"."need_id"
  INNER JOIN "diagnoses" ON "diagnoses"."id" = "needs"."diagnosis_id"
  INNER JOIN "solicitations" ON "solicitations"."id" = "diagnoses"."solicitation_id"
  INNER JOIN "needs" "needs_matches" ON "needs_matches"."id" = "matches"."need_id"
  INNER JOIN "diagnoses" "diagnoses_needs_join" ON "diagnoses_needs_join"."id" = "needs"."diagnosis_id"
  INNER JOIN "facilities" ON "facilities"."id" = "diagnoses_needs_join"."facility_id"

  -- JOINs minimaux pour eager loading
  LEFT OUTER JOIN "experts" ON "experts"."id" = "matches"."expert_id"
  LEFT OUTER JOIN "subjects" ON "subjects"."id" = "matches"."subject_id"

WHERE
  "solicitations"."created_at" >= '2026-02-25 00:00:00'
  AND "solicitations"."created_at" <= '2026-02-27 00:00:00'
  AND LEFT(facilities.insee_code, 2) IN ('75', '77', '78', '91', '92', '93', '94', '95')
  AND "solicitations"."landing_subject_id" = 55
  AND "matches"."sent_at" IS NOT NULL;
```