### PR TITLE
Supprime les warnings quand la clé AppSignal n'est pas défini

### DIFF
--- a/config/appsignal.rb
+++ b/config/appsignal.rb
@@ -8,7 +8,7 @@ Appsignal.configure do |config|
   # We recommend removing this line and setting this option with the
   # APPSIGNAL_PUSH_API_KEY environment variable instead.
   # https://docs.appsignal.com/ruby/configuration/options.html#option-push_api_key
-  config.push_api_key = ENV['APPSIGNAL_PUSH_API_KEY']
+  # config.push_api_key = ENV['APPSIGNAL_PUSH_API_KEY']
 
   # Configure actions that should not be monitored by AppSignal.
   # For more information see our docs:


### PR DESCRIPTION
Quand on lance les tests et le serveur on a des warnings comme quoi la clé AppSignal n'existe pas