### PR TITLE
Affiche 15 sollicitations par page

### DIFF
--- a/app/models/solicitation.rb
+++ b/app/models/solicitation.rb
@@ -48,6 +48,8 @@ class Solicitation < ApplicationRecord
   include RangeScopes
   include MandatoryAnswers
 
+  paginates_per 15
+
   ## Associations
   #
   belongs_to :landing, inverse_of: :solicitations, optional: true


### PR DESCRIPTION
Parfois la page des sollicitations est très lente et la vue prend énormement de temps à charger. Je pense que c'est due en partie aux calcules dans les cartes. 
Il va falloir améliorer les requetes mais dans l'immédiat l'équipe a beaucoup de timeout sur cette page.
Discuté avec Ludivine on desend la pagination à 15

cf : https://appsignal.com/conseillers-entreprises/sites/69947776ac612a586e4eba44/performance/incidents/3/samples

Ça ne va pas résoudre 100% du probleme, je créer une issue pour corriger les requetes  https://github.com/betagouv/conseillers-entreprises/issues/4320
