### PR TITLE
Pin connection_pool < 3

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -76,6 +76,8 @@ gem 'progress_bar'
 gem 'decoupage_administratif', '~> 0.3.1'
 gem 'parallel'
 
+gem 'connection_pool', '< 3' # See #4334
+
 # Notifiers
 gem "appsignal"
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -209,7 +209,7 @@ GEM
       execjs
     coffee-script-source (1.12.2)
     concurrent-ruby (1.3.6)
-    connection_pool (3.0.2)
+    connection_pool (2.5.4)
     crack (1.0.1)
       bigdecimal
       rexml
@@ -543,7 +543,7 @@ GEM
     recipient_interceptor (0.3.3)
       mail
     redis (4.8.1)
-    redis-client (0.26.4)
+    redis-client (0.27.0)
       connection_pool
     regexp_parser (2.11.3)
     reline (0.6.3)
@@ -771,6 +771,7 @@ DEPENDENCIES
   caxlsx
   caxlsx_rails
   clockwork
+  connection_pool (< 3)
   css_parser
   daemons
   dartsass-sprockets


### PR DESCRIPTION
Followup #4310, needed now to fix deployment on staging.

This appears only in production, because we don’t use redis for caching in development.

connection_pool 3 introduces incompatibity with sidekiq 7.3.9 (fixed in 7.3.10), and as well as rails < 8.1.2. See:
- https://github.com/mperham/connection_pool/issues/212
- https://stackoverflow.com/questions/79844786/ruby-on-rails-redis-connection-pool-wrong-number-of-arguments-given-1-expected
- https://github.com/rails/rails/pull/56292

We need to wait until we update to rails 8.1 to bump it (#4332)

