### PR TITLE
Improve perfs in /admin/profil_pictures

### DIFF
--- a/app/admin/profil_picture.rb
+++ b/app/admin/profil_picture.rb
@@ -14,6 +14,8 @@ ActiveAdmin.register ProfilPicture do
     actions
   end
 
+  config.filters = false
+
   form do |f|
     f.inputs do
       f.input :user, as: :select, collection: User.not_deleted.admin


### PR DESCRIPTION
refs #4311 

Before:
```
16:03:42 web.1    |   User Load (837.2ms)  SELECT "users".* FROM "users"
16:03:43 web.1    | Completed 200 OK in 3618ms (Views: 2514.6ms | ActiveRecord: 902.1ms (10 queries, 0 cached) | GC: 558.6ms)
```

After:
```
16:04:54 web.1    |   ↳ app/admin/profil_picture.rb:11:in 'block (2 levels) in <main>'
16:04:54 web.1    | Completed 200 OK in 101ms (Views: 55.1ms | ActiveRecord: 24.7ms (9 queries, 0 cached) | GC: 0.0ms)
```

Ce qui posait problème, c’est les filtres automatiquement générés sur la droite, qui chargaient `User.all` dans un `<select>`.