### PR TITLE
Add HTTP timeouts to external API calls

### DIFF
--- a/app/services/api.rb
+++ b/app/services/api.rb
@@ -75,7 +75,7 @@ module Api
     end
 
     def get_url
-      HTTP.get(url)
+      HTTP.timeout(10).get(url)
     end
 
     def success?

--- a/app/services/api/adresse/search_municipality.rb
+++ b/app/services/api/adresse/search_municipality.rb
@@ -25,7 +25,7 @@ module Api::Adresse
     def initialize(location)
       @location = location
       begin
-        @http_response = HTTP.get(url)
+        @http_response = HTTP.timeout(10).get(url)
         @data = @http_response.parse(:json)
       rescue StandardError => e
         @error = e

--- a/app/services/api/api_entreprise.rb
+++ b/app/services/api/api_entreprise.rb
@@ -6,7 +6,7 @@ module Api::ApiEntreprise
     DEFAULT_ERROR_MESSAGE = I18n.t('api_requests.default_error_message.etablissement')
 
     def get_url
-      HTTP.auth("Bearer #{token}").get(url)
+      HTTP.timeout(10).auth("Bearer #{token}").get(url)
     end
 
     def data_error_message

--- a/app/services/api/france_competence.rb
+++ b/app/services/api/france_competence.rb
@@ -6,7 +6,7 @@ module Api::FranceCompetence
     ERROR_CODES = {}
 
     def get_url
-      @http_response = HTTP.auth("Bearer #{token}").get(url, headers: headers)
+      @http_response = HTTP.timeout(10).auth("Bearer #{token}").get(url, headers: headers)
     end
 
     def token

--- a/app/services/api/france_competence/token.rb
+++ b/app/services/api/france_competence/token.rb
@@ -23,7 +23,7 @@ module Api::FranceCompetence::Token
     }.freeze
 
     def initialize
-      @http_response = HTTP.post(url, json: json_params, headers: headers)
+      @http_response = HTTP.timeout(5).post(url, json: json_params, headers: headers)
       begin
         @data = @http_response.body.to_s
       rescue StandardError => e

--- a/app/services/api/insee.rb
+++ b/app/services/api/insee.rb
@@ -18,7 +18,7 @@ module Api::Insee
 
   class Request < Api::Request
     def get_url
-      HTTP.get(url, headers: headers)
+      HTTP.timeout(10).get(url, headers: headers)
     end
 
     def headers

--- a/app/services/api/recherche_entreprises.rb
+++ b/app/services/api/recherche_entreprises.rb
@@ -24,7 +24,7 @@ module Api::RechercheEntreprises
       @query = query
       @options = options
       begin
-        @http_response = HTTP.get(url)
+        @http_response = HTTP.timeout(10).get(url)
         @data = @http_response.parse(:json)
       rescue StandardError => e
         @error = e

--- a/app/services/api/rne.rb
+++ b/app/services/api/rne.rb
@@ -8,7 +8,7 @@ module Api::Rne
 
   class Request < Api::Request
     def get_url
-      HTTP.auth("Bearer #{token}").get(url)
+      HTTP.timeout(10).auth("Bearer #{token}").get(url)
     end
 
     def token

--- a/app/services/api/rne/token.rb
+++ b/app/services/api/rne/token.rb
@@ -34,7 +34,7 @@ module Api::Rne::Token
     def initialize(call_count)
       @call_count = call_count
       begin
-        @http_response = HTTP.post(base_url, json: json_params)
+        @http_response = HTTP.timeout(5).post(base_url, json: json_params)
         @data = @http_response.parse(:json)
       rescue StandardError => e
         @error = e


### PR DESCRIPTION
Difficile à tester en condition réelles. Ça donne quelque chose comme ça:

<img width="1088" height="309" alt="image" src="https://github.com/user-attachments/assets/516b7863-ed13-4fd4-8ef5-e0b227e66afa" />

fixes #4342