### PR TITLE
Fix erreur avec human_attribut_name

### DIFF
--- a/app/models/record_extensions/human_attribute_value.rb
+++ b/app/models/record_extensions/human_attribute_value.rb
@@ -29,6 +29,7 @@ module RecordExtensions
       # > Solicitation.human_attribute_value(:status, :canceled, context: :done, count: 2)
       # => "annulées" # I18n.t('activerecord.attributes.solicitation/statuses/done.canceled.other')
       def human_attribute_value(enum_name, value, options = {})
+        return if value.nil?
         unless options.delete(:disable_cast)
           value = attribute_types[enum_name.to_s].cast(value)
         end


### PR DESCRIPTION
closes #4383 

Visible sur https://localhost:3000/admin/landings/accueil

`human_attribute_name("iframe_categories.integral")` dans Rails 7.1 (https://github.com/rails/rails/pull/44300) ne résout plus correctement vers la clé YAML `activerecord.attributes.landing/iframe_categories.integral` Le fallback remontait jusqu'au hash générique `fr.attributes` et tentait de le pluraliser avec `count: 1`, provoquant l'erreur.