### PR TITLE
A11y for error in step_description

### DIFF
--- a/app/controllers/solicitations_controller.rb
+++ b/app/controllers/solicitations_controller.rb
@@ -135,7 +135,6 @@ class SolicitationsController < PagesController
         CompanyMailer.confirmation_solicitation(@solicitation).deliver_later
         redirect_to form_complete_solicitation_path(@solicitation.uuid, anchor: 'section-breadcrumbs')
       else
-        flash.now.alert = @solicitation.errors.full_messages.to_sentence
         build_subject_answers if @solicitation.subject_answers.blank?
         render :step_description, status: :unprocessable_content
       end

--- a/app/front/javascripts/pages/controllers/pages_error_focus_controller.js
+++ b/app/front/javascripts/pages/controllers/pages_error_focus_controller.js
@@ -1,8 +1,0 @@
-import { Controller } from "stimulus";
-
-export default class extends Controller {
-  connect() {
-    this.element.setAttribute('tabindex', '-1');
-    this.element.focus();
-  }
-}

--- a/app/models/solicitation.rb
+++ b/app/models/solicitation.rb
@@ -207,7 +207,12 @@ class Solicitation < ApplicationRecord
   end
 
   validate if: -> { status_in_progress? || landing&.api? } do
-    errors.add(:description, :blank) if (description.blank? || description == landing_subject&.description_prefill)
+    errors.add(:description, :blank) if (description.blank?)
+
+    if landing_subject&.description_prefill.present?
+      distance = DidYouMean::Levenshtein.distance(description, landing_subject.description_prefill)
+      errors.add(:description, :blank) if distance < 10 # not zero to allow for newline encoding changes
+    end
   end
 
   ## Callbacks

--- a/app/views/solicitations/step_company.html.haml
+++ b/app/views/solicitations/step_company.html.haml
@@ -19,7 +19,7 @@
               = f.label :siret, class: 'fr-label' do
                 = t("solicitations.creation_form.siret")
                 %span.fr-hint-text= t('attributes.help.no_creation_html')
-              = f.text_field :siret, placeholder: t("solicitations.creation_form.placeholder.siret"), class: 'fr-input white-bg', minlength: '9', maxlength: '18'
+              = f.text_field :siret, autofocus: @solicitation.errors[:siret].present?, placeholder: t("solicitations.creation_form.placeholder.siret"), class: 'fr-input white-bg', minlength: '9', maxlength: '18'
             - elsif @solicitation.landing_subject.fields_mode_location?
               .insee-code-wrapper{ data: { controller: 'insee-code', 'insee-code-default-value-value': h(@solicitation.location) } }
                 = f.label :location, class: 'fr-label' do

--- a/app/views/solicitations/step_company.html.haml
+++ b/app/views/solicitations/step_company.html.haml
@@ -29,7 +29,7 @@
                 = f.hidden_field :insee_code, data: { 'insee-code-target': 'hidden' }
 
           - if @solicitation.errors.present?
-            %p.fr-error-text{ data: { controller: "pages-error-focus" } }= @solicitation.errors.full_messages.to_sentence
+            %p.fr-error-text= @solicitation.errors.full_messages.to_sentence
 
       %ul.fr-btns-group.fr-btns-group--inline.fr-btns-group--right
         %li= render 'previous_button',

--- a/app/views/solicitations/step_company_search.html.haml
+++ b/app/views/solicitations/step_company_search.html.haml
@@ -7,7 +7,7 @@
   .fr-col-12.fr-col-md-6.fr-col-offset-md-3.multistep-form.fr-pb-3w
 
     - if @error_message.present?
-      .fr-alert.fr-alert--error.fr-mb-6w{ role: "alert", data: { controller: "pages-error-focus" } }
+      .fr-alert.fr-alert--error.fr-mb-6w{ role: "alert" }
         %h2.fr-alert__title= t('api_requests.embraced_error_title')
         %p= t('api_requests.embraced_error_html', message: @error_message, url: step_company_solicitation_path(@solicitation.uuid, anchor: 'section-breadcrumbs'))
 

--- a/app/views/solicitations/step_contact.html.haml
+++ b/app/views/solicitations/step_contact.html.haml
@@ -43,12 +43,13 @@
                 required: true,
                 class: 'fr-input white-bg',
                 autocomplete: Solicitation::AUTOCOMPLETE_TYPES[field],
+                autofocus: @solicitation.errors[field].present?,
                 minlength: (field == :phone_number ? '10' : nil),
                 pattern: (field == :phone_number ? '\+?[0-9\s]+' : nil),
                 value: (f.object.send(field) || params[field])
 
-          - if @solicitation.errors.present?
-            %p.fr-error-text{ data: { controller: "pages-error-focus" } }= @solicitation.errors.full_messages_for(field).to_sentence
+          - if @solicitation.errors[field].present?
+            %p.fr-error-text= @solicitation.errors.full_messages_for(field).to_sentence
 
       .fr-btns-group.fr-btns-group--icon-lg.fr-btns-group--inline.fr-btns-group--right
         = render 'solicitations/next_button'

--- a/app/views/solicitations/step_description.html.haml
+++ b/app/views/solicitations/step_description.html.haml
@@ -22,11 +22,11 @@
             = f.text_area 'description', placeholder: t("solicitations.creation_form.placeholder.description_html"),
                 rows: 12, required: true, class: 'fr-input white-bg',
                 data: { 'prefill-textarea-target': 'destinationField' },
+                autofocus: @solicitation.errors[:description].present?,
                 aria: { describedby: (@solicitation.errors[:description].present? ? 'description-error' : nil), invalid: (@solicitation.errors[:description].present? ? 'true' : nil) }
 
           - if @solicitation.errors[:description].present?
-            %p.fr-error-text{ id: 'description-error',
-                data: { controller: "pages-error-focus" } }= @solicitation.errors.full_messages_for(:description).to_sentence
+            %p.fr-error-text{ id: 'description-error' }= @solicitation.errors.full_messages_for(:description).to_sentence
 
       = f.fields_for :subject_answers, @solicitation.subject_answers do |ff|
         - question_key = ff.object.key


### PR DESCRIPTION
fixes #4290 

- Fix an unrelated bug related to newlines encoding and description difference detection.
- Do not display errors in the flash in step_description
- Use autofocus to the field in error instead of focusing on the error label