### PR TITLE
Nettoyage (inline un appel)

### DIFF
--- a/app/controllers/stats/team_controller.rb
+++ b/app/controllers/stats/team_controller.rb
@@ -59,17 +59,13 @@ module Stats
       data = Rails.cache.fetch(cache_key, expires_in: 6.hours) do
         invoke_stats(name, session[:team_stats_params])
       end
-      render_partial(data, name)
+      render partial: 'stats/load_stats', locals: { data: data, name: name }
     end
 
     private
 
     def authorize_team
       authorize Stats::All, :team?
-    end
-
-    def render_partial(data, name)
-      render partial: 'stats/load_stats', locals: { data: data, name: name }
     end
 
     def clean_public_filters


### PR DESCRIPTION
Par cohérence avec les autres implémentations de `#load_data` dans CooperationsController, StatsController, PublicController.

Je me demande d’ailleurs si ça ne pourrait pas être un peu plus factorisé, mais une chose à la fois.

Fait en passant pour #4410.