### PR TITLE
Ré-ajoute le highlight du tab actif dans les stats d’équipe

### DIFF
--- a/app/assets/stylesheets/pages/stats.sass
+++ b/app/assets/stylesheets/pages/stats.sass
@@ -16,7 +16,3 @@
     font-size: 1.5rem
     font-weight: bold
     color: base.$grey-dark
-
-#section-stats
-  .fr-tile__link.active
-    color: base.$blue

--- a/app/views/stats/public/index.haml
+++ b/app/views/stats/public/index.haml
@@ -11,7 +11,7 @@
   - cache("stats_charts-#{@main_stat}", expires_in: 1.hour) do
     = render 'stats/main_stats_chart', data: @main_stat, name: :done_with_help_column
 
-.fr-container--fluid.fr-py-12w.light-blue-bg#section-stats
+.fr-container--fluid.fr-py-12w.light-blue-bg
   .fr-container
     = render 'stats_params', stats: @stats_params
     .fr-grid-row.fr-grid-row--gutters#stats-charts

--- a/app/views/stats/team/_tab.html.haml
+++ b/app/views/stats/team/_tab.html.haml
@@ -1,0 +1,11 @@
+-# locals: (name:, path:, image:)
+
+.fr-col-12.fr-col-md-3
+  .fr-tile.fr-tile--sm.fr-enlarge-link{ class: active_link_to_class(path, class_active: 'fr-tile--grey') }
+    .fr-tile__body
+      .fr-tile__content
+        %h2.fr-tile__title
+          = active_link_to name, path
+    .fr-tile__header
+      .fr-tile__pictogram
+        = display_svg image

--- a/app/views/stats/team/_tabs.html.haml
+++ b/app/views/stats/team/_tabs.html.haml
@@ -1,38 +1,38 @@
 .fr-container--fluid.fr-mb-3w
   .fr-grid-row.fr-grid-row--gutters
     .fr-col-12.fr-col-md-3
-      .fr-tile.fr-tile--sm.fr-enlarge-link
+      .fr-tile.fr-tile--sm.fr-enlarge-link{class: active_link_to_class(public_team_index_path(params: filter_params), class_active: "fr-tile--grey")}
         .fr-tile__body
           .fr-tile__content
             %h2.fr-tile__title
-              = link_to t('stats.team.public'), public_team_index_path(params: filter_params)
+              = active_link_to t('stats.team.public'), public_team_index_path(params: filter_params)
         .fr-tile__header
           .fr-tile__pictogram
             = display_svg("pictos-dsfr/internet.svg")
     .fr-col-12.fr-col-md-3
-      .fr-tile.fr-tile--sm.fr-enlarge-link
+      .fr-tile.fr-tile--sm.fr-enlarge-link{class: active_link_to_class(needs_team_index_path(params: filter_params), class_active: "fr-tile--grey")}
         .fr-tile__body
           .fr-tile__content
             %h2.fr-tile__title
-              = link_to t('stats.team.needs'), needs_team_index_path(params: filter_params)
+              = active_link_to t('stats.team.needs'), needs_team_index_path(params: filter_params)
         .fr-tile__header
           .fr-tile__pictogram
             = display_svg("pictos-dsfr/document.svg")
     .fr-col-12.fr-col-md-3
-      .fr-tile.fr-tile--sm.fr-enlarge-link
+      .fr-tile.fr-tile--sm.fr-enlarge-link{class: active_link_to_class(matches_team_index_path(params: filter_params), class_active: "fr-tile--grey")}
         .fr-tile__body
           .fr-tile__content
             %h2.fr-tile__title
-              = link_to t('stats.team.matches'), matches_team_index_path(params: filter_params)
+              = active_link_to t('stats.team.matches'), matches_team_index_path(params: filter_params)
         .fr-tile__header
           .fr-tile__pictogram
             = display_svg("pictos-dsfr/city-hall.svg")
     .fr-col-12.fr-col-md-3
-      .fr-tile.fr-tile--sm.fr-enlarge-link
+      .fr-tile.fr-tile--sm.fr-enlarge-link{class: active_link_to_class(acquisition_team_index_path(params: filter_params), class_active: "fr-tile--grey")}
         .fr-tile__body
           .fr-tile__content
             %h2.fr-tile__title
-              = link_to t('stats.team.acquisition'), acquisition_team_index_path(params: filter_params)
+              = active_link_to t('stats.team.acquisition'), acquisition_team_index_path(params: filter_params)
         .fr-tile__header
           .fr-tile__pictogram
             = display_svg("pictos-dsfr/data-visualization.svg")

--- a/app/views/stats/team/_tabs.html.haml
+++ b/app/views/stats/team/_tabs.html.haml
@@ -1,38 +1,8 @@
+-# locals: (filter_params:)
+
 .fr-container--fluid.fr-mb-3w
   .fr-grid-row.fr-grid-row--gutters
-    .fr-col-12.fr-col-md-3
-      .fr-tile.fr-tile--sm.fr-enlarge-link{class: active_link_to_class(public_team_index_path(params: filter_params), class_active: "fr-tile--grey")}
-        .fr-tile__body
-          .fr-tile__content
-            %h2.fr-tile__title
-              = active_link_to t('stats.team.public'), public_team_index_path(params: filter_params)
-        .fr-tile__header
-          .fr-tile__pictogram
-            = display_svg("pictos-dsfr/internet.svg")
-    .fr-col-12.fr-col-md-3
-      .fr-tile.fr-tile--sm.fr-enlarge-link{class: active_link_to_class(needs_team_index_path(params: filter_params), class_active: "fr-tile--grey")}
-        .fr-tile__body
-          .fr-tile__content
-            %h2.fr-tile__title
-              = active_link_to t('stats.team.needs'), needs_team_index_path(params: filter_params)
-        .fr-tile__header
-          .fr-tile__pictogram
-            = display_svg("pictos-dsfr/document.svg")
-    .fr-col-12.fr-col-md-3
-      .fr-tile.fr-tile--sm.fr-enlarge-link{class: active_link_to_class(matches_team_index_path(params: filter_params), class_active: "fr-tile--grey")}
-        .fr-tile__body
-          .fr-tile__content
-            %h2.fr-tile__title
-              = active_link_to t('stats.team.matches'), matches_team_index_path(params: filter_params)
-        .fr-tile__header
-          .fr-tile__pictogram
-            = display_svg("pictos-dsfr/city-hall.svg")
-    .fr-col-12.fr-col-md-3
-      .fr-tile.fr-tile--sm.fr-enlarge-link{class: active_link_to_class(acquisition_team_index_path(params: filter_params), class_active: "fr-tile--grey")}
-        .fr-tile__body
-          .fr-tile__content
-            %h2.fr-tile__title
-              = active_link_to t('stats.team.acquisition'), acquisition_team_index_path(params: filter_params)
-        .fr-tile__header
-          .fr-tile__pictogram
-            = display_svg("pictos-dsfr/data-visualization.svg")
+    = render 'tab', name: t('stats.team.public'), path: public_team_index_path(params: filter_params), image: 'pictos-dsfr/internet.svg'
+    = render 'tab', name: t('stats.team.needs'), path: needs_team_index_path(params: filter_params), image: 'pictos-dsfr/document.svg'
+    = render 'tab', name: t('stats.team.matches'), path: matches_team_index_path(params: filter_params), image: 'pictos-dsfr/city-hall.svg'
+    = render 'tab', name: t('stats.team.acquisition'), path: acquisition_team_index_path(params: filter_params), image: 'pictos-dsfr/data-visualization.svg'

--- a/app/views/stats/team/index.html.haml
+++ b/app/views/stats/team/index.html.haml
@@ -7,7 +7,7 @@
 
 = render 'pages/breadcrumbs', title: t('.title')
 
-.fr-container--fluid.fr-py-7w.light-blue-bg#section-stats
+.fr-container--fluid.fr-py-7w.light-blue-bg
   .fr-container
     = render 'tabs', filter_params: stats_filter_params
     = render 'stats_params', stats: @stats_params, institution_antennes: @institution_antennes, iframes: @iframes, apis: @apis, themes: @themes, subjects: @subjects


### PR DESCRIPTION
Ça a du être cassé lors d’une mise à jour de DSFR, l’ancien css parle d’une classe `fr-tile__link`.

Fait en passant pour #4410.


| Avant | Après |
|-|-|
| <img width="1170" height="917" alt="Capture d’écran 2026-04-14 à 18 41 12" src="https://github.com/user-attachments/assets/d4278b88-e6d0-4e93-b947-0f6c701eba36" /> | <img width="1170" height="917" alt="Capture d’écran 2026-04-14 à 18 44 28" src="https://github.com/user-attachments/assets/36995252-befb-43ee-9a9f-55c17a2d3259" /> |