### PR TITLE
Fix custom badge colors in admin

### DIFF
--- a/app/admin/patches/head_style.rb
+++ b/app/admin/patches/head_style.rb
@@ -1,0 +1,15 @@
+module Admin
+  module Patches
+    module HeadStyle
+      ## !! Monkey-patch override !!
+      # Add the dynamic badges css tag to the activeadmin <head>
+      def build_active_admin_head
+        within super do
+          text_node badges_css_tag
+        end
+      end
+    end
+
+    ActiveAdmin::Views::Pages::Base.prepend HeadStyle
+  end
+end

--- a/app/assets/stylesheets/active_admin.sass
+++ b/app/assets/stylesheets/active_admin.sass
@@ -255,3 +255,8 @@ body.active_admin nav.pagination
       margin-right: 0.2rem
     //span
     //  display: contents
+
+.label
+  padding: 0.2rem
+  text-align: center
+  border: 1px solid

--- a/app/views/admin/solicitations/_badges.html.haml
+++ b/app/views/admin/solicitations/_badges.html.haml
@@ -1,4 +1,4 @@
--# haml-lint:disable InlineStyles
+-# locals: (badges:)
+
 - badges.each do |badge|
-  %div{ style: "color: #{badge.color}" }
-    = badge.title.tr(' ', "\u00A0")
+  = badge_label(badge)


### PR DESCRIPTION
Fait en passant pour #4410. (Ça n’a rien à voir, j’ai juste ouvert le fichier par erreur et vu le `lint:disable`.)

Cassé depuis #4346

| Avant | Après |
|-|-|
| <img width="118" height="66" alt="Capture d’écran 2026-04-14 à 18 42 03" src="https://github.com/user-attachments/assets/47a95e85-dbb5-4855-b22e-9c7341b0858a" /> | <img width="97" height="70" alt="Capture d’écran 2026-04-14 à 18 43 09" src="https://github.com/user-attachments/assets/f5000ec4-f3cb-413c-af78-760f2611be32" /> |