### PR TITLE
Use a proper badge class to avoid css clash in active admin

### DIFF
--- a/app/assets/stylesheets/active_admin.sass
+++ b/app/assets/stylesheets/active_admin.sass
@@ -256,7 +256,7 @@ body.active_admin nav.pagination
     //span
     //  display: contents
 
-.label
+.badge
   padding: 0.2rem
   text-align: center
   border: 1px solid

--- a/app/helpers/badges_helper.rb
+++ b/app/helpers/badges_helper.rb
@@ -3,13 +3,13 @@ module BadgesHelper
     tag.style(nonce: content_security_policy_nonce) do
       Rails.cache.fetch(Badge.all) do
         Badge.colored.map do |badge|
-          ".label--#{badge.long_name} { border: 1px solid #{badge.color}; color: #{badge.color} }"
+          ".badge--#{badge.long_name} { border: 1px solid #{badge.color}; color: #{badge.color} }"
         end.join(' ').html_safe
       end
     end
   end
 
   def badge_label(badge)
-    tag.div(badge.title, class: "label label--#{badge.long_name}")
+    tag.div(badge.title, class: "label badge badge--#{badge.long_name}")
   end
 end


### PR DESCRIPTION
fixup #4417 🤦 

| avant | après |
|-|-|
| <img width="240" height="588" alt="avant" src="https://github.com/user-attachments/assets/e70aaf8c-6cfd-45b8-b819-dc90ea0f0b7a" /> | <img width="240" height="546" alt="après" src="https://github.com/user-attachments/assets/3d455b1d-4e48-49e8-955b-89118d53bfcd" /> |
