### PR TITLE
Try running CI without install-browser-tools

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -71,8 +71,6 @@ jobs:
     parallelism: 4
     steps:
       - checkout
-      - browser-tools/install-browser-tools:
-          chrome-version: '140.0.7339.127'
       - browser-tools/install-chrome
       - browser-tools/install-chromedriver
       - *check_chrome_installation


### PR DESCRIPTION
CI is stuck installing Firefox, but as far as I know we don’t actually need firefox in CI?

(I have no idea what I’m doing)