### PR TITLE
Corrige l'attribut `itemReviewed` des données structurées

### DIFF
--- a/app/helpers/seo/base_schemas.rb
+++ b/app/helpers/seo/base_schemas.rb
@@ -45,7 +45,10 @@ module Seo
         '@id': "#{root_url}#organization",
         name: I18n.t('landings.landings.seo.service_name'),
         url: root_url,
-        logo: image_url('logo-ce.png'),
+        logo: {
+          '@type': "ImageObject",
+          url: image_url('logo-ce.png')
+        },
         contactPoint: {
           '@type': "ContactPoint",
           email: ENV['APPLICATION_EMAIL'],

--- a/app/helpers/seo/content_schemas.rb
+++ b/app/helpers/seo/content_schemas.rb
@@ -86,7 +86,7 @@ module Seo
       {
         '@type': "Review",
         '@id': "#{request.original_url}#review-#{index}",
-        itemReviewed: { '@id': "#{root_url}#service" },
+        itemReviewed: { '@id': "#{root_url}#organization" },
         reviewBody: strip_tags(content),
         author: {
           '@type': "Person",


### PR DESCRIPTION
closes #4428 

Les `itemReviewed` ne peuvent pas pointer vers un service, mais vers une organisation oui.
Corrige aussi une erreur non critique d'url de logo non valide