### PR TITLE
Add missing sponsor UserRight validation

### DIFF
--- a/app/models/user_right.rb
+++ b/app/models/user_right.rb
@@ -52,7 +52,8 @@ class UserRight < ApplicationRecord
            :be_admin_to_have_rights_for_admins,
            :only_one_user_by_referent,
            :territorial_referent_has_managed_region,
-           :only_one_territorial_referent_per_region
+           :only_one_territorial_referent_per_region,
+           :sponsor_has_institution
 
   before_validation :create_territorial_zone_if_needed
   after_save :finalize_territorial_zone_link
@@ -100,6 +101,13 @@ class UserRight < ApplicationRecord
     return unless existing_territorial_referent_for_region?
 
     errors.add(:rightable_element_id, I18n.t('errors.one_territorial_referent_per_region'))
+  end
+
+  def sponsor_has_institution
+    return unless category_sponsor?
+    return if rightable_element.is_a?(Institution)
+
+    errors.add(:rightable_element_id, I18n.t('errors.sponsor_without_institution'))
   end
 
   def valid_territorial_zone_region?

--- a/config/locales/fr.yml
+++ b/config/locales/fr.yml
@@ -194,6 +194,7 @@ fr:
     only_one_cooperation: Une seule coopération peut être attribuée au responsable de coopération. S'il faut modifier cette règle, demandez aux devs !
     page_title: Erreur - %{title}
     satisfaction_without_comment: Vous ne pouvez pas partager une satisfaction sans commentaire
+    sponsor_without_institution: Une institution doit être attribuée à ce pilotage ministériel
     template:
       body: 'Veuillez vérifier les champs suivants : '
       header:

--- a/spec/models/user_right_spec.rb
+++ b/spec/models/user_right_spec.rb
@@ -189,6 +189,16 @@ RSpec.describe UserRight do
         end
       end
     end
+
+    describe 'sponsor_has_institution' do
+      let(:user) { create :user }
+      let(:user_right) { build :user_right, user: user, category: :sponsor }
+
+      it do
+        expect(user_right).not_to be_valid
+        expect(user_right.errors[:rightable_element_id]).to include(I18n.t('errors.sponsor_without_institution'))
+      end
+    end
   end
 
   describe 'Constants' do


### PR DESCRIPTION
fixup #4410

On veut empêcher la création de droit de sponsor qui ne soit pas lié à une institution.