### PR TITLE
Prévient le retour en arrière du status des analyses

### DIFF
--- a/app/models/diagnosis.rb
+++ b/app/models/diagnosis.rb
@@ -57,6 +57,7 @@ class Diagnosis < ApplicationRecord
   validate :step_completed_has_advisor
   validate :without_solicitation_has_advisor
   validate :only_one_solicitation
+  validate :step_cannot_go_backward, on: :update
 
   accepts_nested_attributes_for :facility
   accepts_nested_attributes_for :needs, allow_destroy: true
@@ -196,6 +197,13 @@ class Diagnosis < ApplicationRecord
 
   def update_needs
     needs.each { |n| n.update_status }
+  end
+
+  def step_cannot_go_backward
+    return unless step_changed?
+    if Diagnosis.steps[step] < Diagnosis.steps[step_was]
+      errors.add(:step, :cannot_go_backward)
+    end
   end
 
   def step_needs_has_contact

--- a/config/locales/models.fr.yml
+++ b/config/locales/models.fr.yml
@@ -745,6 +745,8 @@ fr:
               solicitation_has_no_preselected_subject: il n’y a pas de sujet présélectionné
             solicitation:
               has_already_a_diagnosis: Une analyse existe deja pour cette sollicitation.
+            step:
+              cannot_go_backward: ne peut pas revenir à une étape précédente.
         expert:
           attributes:
             base:

--- a/spec/models/diagnosis_spec.rb
+++ b/spec/models/diagnosis_spec.rb
@@ -118,6 +118,35 @@ RSpec.describe Diagnosis do
       end
     end
 
+    describe 'step_cannot_go_backward' do
+      subject(:diagnosis) { create :diagnosis_completed }
+
+      it 'allows step to stay the same' do
+        expect(diagnosis.update(step: :completed)).to be true
+      end
+
+      it 'forbids going from completed to matches' do
+        expect(diagnosis.update(step: :matches)).to be false
+        expect(diagnosis.errors[:step]).to be_present
+      end
+
+      it 'forbids going from completed to needs' do
+        expect(diagnosis.update(step: :needs)).to be false
+        expect(diagnosis.errors[:step]).to be_present
+      end
+
+      it 'forbids going from matches to needs' do
+        diagnosis.update_column(:step, 4)
+        expect(diagnosis.update(step: :needs)).to be false
+        expect(diagnosis.errors[:step]).to be_present
+      end
+
+      it 'allows going forward' do
+        diagnosis.update_column(:step, 3)
+        expect(diagnosis.update(step: :matches)).to be true
+      end
+    end
+
     describe 'only one diagnosis by solicitation' do
       let(:solicitation) { create :solicitation }
       let!(:another_diagnosis) { create :diagnosis, solicitation: solicitation }


### PR DESCRIPTION
closes #4444 

D'après ce que j'ai pu observer la date de mise à jour des analyses en question concorde avec l'ajout ou le changement de status d'une MER