### PR TITLE
Nouvelles statistiques d’équipe

### DIFF
--- a/app/controllers/stats/team_controller.rb
+++ b/app/controllers/stats/team_controller.rb
@@ -47,6 +47,7 @@ module Stats
         acquisitions_overall_distribution_solicitations acquisitions_overall_distribution_solicitations_column
         acquisitions_overall_distribution_needs_transmitted acquisitions_overall_distribution_needs_transmitted_column
         acquisitions_overall_distribution_needs_done_with_help acquisitions_overall_distribution_needs_done_with_help_column
+        acquisitions_by_new_companies
       ]
       render :index
     end

--- a/app/controllers/stats/team_controller.rb
+++ b/app/controllers/stats/team_controller.rb
@@ -16,7 +16,7 @@ module Stats
     def public
       @charts_names = %w[
         solicitations_completed solicitations_diagnoses needs_exchange_with_expert needs_done
-        needs_taken_care_in_three_days needs_taken_care_in_five_days
+        needs_taken_care_in_three_days needs_taken_care_in_five_days needs_helped_in_five_days
         needs_themes_all needs_subjects_all companies_by_employees companies_by_naf_code
       ]
       render :index

--- a/app/services/stats/acquisitions/by_new_companies.rb
+++ b/app/services/stats/acquisitions/by_new_companies.rb
@@ -1,0 +1,69 @@
+module Stats::Acquisitions
+  class ByNewCompanies
+    include ::Stats::BaseStats
+    include Stats::Acquisitions::NeedsBase
+
+    def main_query
+      base_scope.where(status: :done).joins(:solicitation)
+    end
+
+    def first_solicitations
+      Solicitation.joins(diagnosis: :facility)
+        .group('facilities.id')
+        .select('min(solicitations.id) as id')
+    end
+
+    def build_series
+      query = filtered_main_query
+      @from_new_companies = []
+      @from_known_companies = []
+
+      search_range_by_month.each do |range|
+        month_query = month_query(query, range)
+        @from_new_companies.push(month_query
+                                   .where(solicitations: { id: first_solicitations })
+                                   .count)
+        @from_known_companies.push(month_query
+                                     .where.not(solicitations: { id: first_solicitations })
+                                     .count)
+      end
+
+      as_series(@from_known_companies, @from_new_companies)
+    end
+
+    def month_query(query, range)
+      query.created_between(range.first, range.last)
+    end
+
+    def as_series(from_known_companies, from_new_companies)
+      [
+        {
+          name: I18n.t('stats.from_known_companies'),
+          data: from_known_companies
+        },
+        {
+          name: I18n.t('stats.from_new_companies'),
+          data: from_new_companies
+        }
+      ]
+    end
+
+    def count
+      series
+      percentage_two_numbers(@from_new_companies, @from_known_companies)
+    end
+
+    def secondary_count
+      series
+      @from_new_companies.sum
+    end
+
+    def colors
+      %w[#F15C80 #9F3BCA]
+    end
+
+    def chart
+      'percentage-column-chart'
+    end
+  end
+end

--- a/app/services/stats/needs/concerns/response_time.rb
+++ b/app/services/stats/needs/concerns/response_time.rb
@@ -1,14 +1,8 @@
-module Stats::Needs::Concerns::TakingCareTime
+module Stats::Needs::Concerns::ResponseTime
   include ::Stats::BaseStats
 
-  def main_query
-    Need.with_exchange
-      .joins(:matches)
-      .where(created_at: @start_date..@end_date)
-  end
-
-  def number_of_days
-    @number_of_days ||= 5
+  def base_scope
+    Need.joins(:matches).where(created_at: @start_date..@end_date)
   end
 
   def build_series

--- a/app/services/stats/needs/helped_in_five_days.rb
+++ b/app/services/stats/needs/helped_in_five_days.rb
@@ -1,0 +1,19 @@
+module Stats::Needs
+  class HelpedInFiveDays
+    include ::Stats::Needs::Concerns::ResponseTime
+
+    def main_query = base_scope.status_done
+
+    def number_of_days
+      @number_of_days ||= 5
+    end
+
+    def taken_care_after_label
+      I18n.t('stats.taken_care_in_five_days.taken_care_after')
+    end
+
+    def taken_care_before_label
+      I18n.t('stats.taken_care_in_five_days.taken_care_before')
+    end
+  end
+end

--- a/app/services/stats/needs/taken_care_in_five_days.rb
+++ b/app/services/stats/needs/taken_care_in_five_days.rb
@@ -1,6 +1,8 @@
 module Stats::Needs
   class TakenCareInFiveDays
-    include ::Stats::Needs::Concerns::TakingCareTime
+    include ::Stats::Needs::Concerns::ResponseTime
+
+    def main_query = base_scope.with_exchange
 
     def number_of_days
       @number_of_days ||= 5

--- a/app/services/stats/needs/taken_care_in_three_days.rb
+++ b/app/services/stats/needs/taken_care_in_three_days.rb
@@ -1,6 +1,8 @@
 module Stats::Needs
   class TakenCareInThreeDays
-    include ::Stats::Needs::Concerns::TakingCareTime
+    include ::Stats::Needs::Concerns::ResponseTime
+
+    def main_query = base_scope.with_exchange
 
     def number_of_days
       @number_of_days ||= 3

--- a/app/views/stats/_load_stats.html.haml
+++ b/app/views/stats/_load_stats.html.haml
@@ -1,3 +1,5 @@
+-# locals: (data:, name:)
+
 - name = h(name)
 = turbo_frame_tag name do
   - chart_name = "chart-#{name}"

--- a/config/locales/views.fr.yml
+++ b/config/locales/views.fr.yml
@@ -1153,6 +1153,9 @@ fr:
         title_table: Nombre de besoins d’entreprises transmis ayant donné lieu à un échange avec un conseiller
         with_exchange: Avec échange
         without_exchange: Sans échange
+      needs_helped_in_five_days:
+        title: des besoins sont clôturés par une aide dans les 5 jours après la transmission du besoin
+        title_table: Délai de clôture des besoins par une aide proposée
       needs_not_for_me:
         title: des besoins transmis sont refusés, soit %{secondary_count} besoins
         title_table: Nombre de besoins refusés

--- a/config/locales/views.fr.yml
+++ b/config/locales/views.fr.yml
@@ -977,6 +977,8 @@ fr:
   stats:
     done_no_help_status: Statut « cloturé sans aide »
     done_status: Statut « cloturé avec aide »
+    from_known_companies: Entreprises déjà connues de Conseillers-Entreprises
+    from_new_companies: Entreprises contactant le service pour la première fois
     less_than_72h: Moins de 72h
     main_stats_chart:
       title: Notre mesure d’impact phare
@@ -993,6 +995,9 @@ fr:
       stats_params:
         datepicker_format: 'Format attendu : JJ/MM/AAAA'
     series:
+      acquisitions_by_new_companies:
+        title: des besoins ont été déposés par des entreprises utilisant le service pour la première fois soit %{secondary_count} besoins
+        title_table: Répartition des besoins reçus selon que l’entreprise utilise Conseillers-Entreprises pour la première fois ou non.
       acquisitions_entreprendre:
         title:
           one: des besoins transmis aux conseillers proviennent du site Entreprendre.Service-Public.fr, soit %{secondary_count} besoin


### PR DESCRIPTION
fixes #4406

### Réactivité de l’aide proposée:

<img width="1222" height="516" alt="image" src="https://github.com/user-attachments/assets/6fcd55b4-2741-44ea-99fe-5328f1a62cfa" />

### Acquisition - premières fois:

<img width="1265" height="663" alt="image" src="https://github.com/user-attachments/assets/6ff8f259-93c3-49e9-b8d1-4ad881d7d294" />
(on est sûrs pour le rose et le violet?)

