### PR TITLE
Do not hardcode the “autres besoins” subject id

### DIFF
--- a/app/models/subject.rb
+++ b/app/models/subject.rb
@@ -129,7 +129,7 @@ class Subject < ApplicationRecord
 
   # Sujet avec traitement spécifique
   def self.other_need_subject
-    Subject.find(59)
+    Subject.find_by(slug: 'autres_typologies_de_besoins_autre_besoin_non_reference')
   end
 
   def compute_slug

--- a/spec/controllers/conseiller/diagnoses_controller_spec.rb
+++ b/spec/controllers/conseiller/diagnoses_controller_spec.rb
@@ -48,7 +48,7 @@ RSpec.describe Conseiller::DiagnosesController do
 
     context 'when from solicitation creation succeeds' do
       let(:diagnosis) { create :diagnosis, solicitation: create(:solicitation) }
-      let!(:other_need_subject) { create :subject, id: 59 }
+      let!(:other_need_subject) { create :subject, :other_need }
 
       it 'redirects to the diagnosis page' do
         post :create, params: { diagnosis: some_params }

--- a/spec/factories/subjects.rb
+++ b/spec/factories/subjects.rb
@@ -3,9 +3,10 @@ FactoryBot.define do
     label { Faker::Lorem.sentence(word_count: 4) }
     sequence(:slug) { |n| Faker::Lorem.word + n.to_s }
     theme
-  end
 
-  trait :default do
-    label { "Autre besoin non référencé" }
+    trait :other_need do
+      label { "Autre besoin non référencé" }
+      theme factory: %i[theme other_need]
+    end
   end
 end

--- a/spec/factories/themes.rb
+++ b/spec/factories/themes.rb
@@ -1,5 +1,9 @@
 FactoryBot.define do
   factory :theme do
     label { Faker::Lorem.sentence(word_count: 5) }
+
+    trait :other_need do
+      label { "Autres typologies de besoins" }
+    end
   end
 end

--- a/spec/services/diagnosis_creation/create_matches_spec.rb
+++ b/spec/services/diagnosis_creation/create_matches_spec.rb
@@ -4,7 +4,7 @@ describe DiagnosisCreation::CreateMatches do
     let(:diagnosis) { create :diagnosis, solicitation: solicitation }
     let(:solicitation) { create :solicitation }
     let(:need) { create :need, diagnosis: diagnosis }
-    let!(:other_need_subject) { create :subject, id: 59 }
+    let!(:other_need_subject) { create :subject, :other_need }
 
     let!(:expert_subject) do
       create :expert_subject,

--- a/spec/services/diagnosis_creation/steps_spec.rb
+++ b/spec/services/diagnosis_creation/steps_spec.rb
@@ -58,7 +58,7 @@ describe DiagnosisCreation::Steps do
     let!(:diagnosis) { build :diagnosis, solicitation: solicitation, step: 'needs', facility: create(:facility, insee_code: insee_code) }
     let(:solicitation) { create :solicitation }
     let!(:need) { create :need, diagnosis: diagnosis }
-    let!(:other_need_subject) { create :subject, id: 59 }
+    let!(:other_need_subject) { create :subject, :other_need }
 
     let!(:expert_subject) do
       create :expert_subject,


### PR DESCRIPTION
Followup #4438

Les mises en relations automatiques sont désactivées sur ce sujet: la seule institution qui l’a est l’équipe CE. On peut la retirer dans https://conseillers-entreprises.service-public.gouv.fr/admin/institutions/equipe-conseiller-entreprise
