### PR TITLE
Corrige les stats des theme pour les cooperation sur les stats publiques

### DIFF
--- a/app/services/stats/needs/concerns/themes.rb
+++ b/app/services/stats/needs/concerns/themes.rb
@@ -31,8 +31,8 @@ module Stats::Needs::Concerns::Themes
       next if item[:name] == cooperation_label
       label = Theme.stats_label(item[:name], @detailed_graphs)
       if label != item[:name]
-        result.last[:data] = result.last[:data].zip(item[:data]).map { |a, b| a + b }
-        item[:data].map! { |x| x = 0 }
+        result.last[:data] = result.last[:data].zip(item[:data]).map { |a, b| a + b.to_i }
+        item[:data].map! { 0 }
       end
       item
     end


### PR DESCRIPTION
closes https://github.com/betagouv/conseillers-entreprises/issues/4477

Dans certains cas sur la page des stats publiques on a une erreur 500 : "nil can't be coerced into Integer"