### PR TITLE
Fix email parameter extraction in `auth_logging.rb` 

### DIFF
--- a/config/initializers/auth_logging.rb
+++ b/config/initializers/auth_logging.rb
@@ -9,7 +9,7 @@ Rails.application.config.after_initialize do
   end
 
   Warden::Manager.before_failure do |env, opts|
-    email = env.dig('rack.request.form_hash', 'user', 'email').to_s.downcase.strip
+    email = ActionDispatch::Request.new(env).params.dig('user', 'email').to_s.downcase.strip
     ip = Rack::FullRemoteIpAndPort.call(env)
     Rails.logger.error("[AUTH] failure scope=#{opts[:scope]} reason=#{opts[:message]} email=#{email} ip=#{ip}")
   end


### PR DESCRIPTION
Il s'avère finalement que c'est la façon la plus sûre de regarder la request, on n'est pas sûr de quand `rack.request` est peuplé. 