### PR TITLE
Corrige l'affichage sur /conseiller/analyses/new

### DIFF
--- a/app/assets/stylesheets/components/components.sass
+++ b/app/assets/stylesheets/components/components.sass
@@ -113,24 +113,6 @@ hr.separation
   --color-hover: $grey-lighter
   --color-active: $grey-lighter
 
-.company-need
-  .left
-    text-align: left
-  .fr-tile__body
-    flex-direction: row
-    justify-content: space-between
-    align-items: center
-  a
-    font-size: 1.3rem
-  time
-    font-weight: bold
-    font-style: italic
-  @media (max-width: base.$bp-sm)
-    .fr-tile__body
-      flex-direction: column
-    .right
-      margin-top: 1rem
-
 .fr-pagination
   display: flex
   justify-content: center

--- a/app/views/companies/_need.haml
+++ b/app/views/companies/_need.haml
@@ -1,4 +1,4 @@
-.fr-tile.fr-tile--horizontal.company-need.fr-col-12.fr-mb-2w
+.fr-tile.fr-tile--horizontal.fr-col-12.fr-mb-2w
   .fr-tile__body
     .left
       .fr-tile__title.fr-mb-1v

--- a/app/views/conseiller/diagnoses/new.haml
+++ b/app/views/conseiller/diagnoses/new.haml
@@ -6,9 +6,8 @@
 
     - if @needs.present?
       %h2.fr-h3= t('companies.needs.others')
-      .fr-grid-row.fr-grid-row--gutters.fr-mb-2w
-        .fr-col
-          = render partial: 'companies/need', collection: @needs
+      .fr-col
+        = render partial: 'companies/need', collection: @needs
 
     %h2= t('.title')
     %p= t('.sub_title')

--- a/app/views/conseiller/diagnoses/new.haml
+++ b/app/views/conseiller/diagnoses/new.haml
@@ -6,7 +6,9 @@
 
     - if @needs.present?
       %h2.fr-h3= t('companies.needs.others')
-      = render partial: 'companies/need', collection: @needs
+      .fr-grid-row.fr-grid-row--gutters.fr-mb-2w
+        .fr-col
+          = render partial: 'companies/need', collection: @needs
 
     %h2= t('.title')
     %p= t('.sub_title')

--- a/spec/views/companies/needs.html.haml_spec.rb
+++ b/spec/views/companies/needs.html.haml_spec.rb
@@ -31,7 +31,7 @@ RSpec.describe 'companies/needs' do
 
     it('displays title needs in progress') { expect(render).to have_css('h2', text: I18n.t('companies.needs.needs_in_progress')) }
     it('not displays title needs done') { expect(render).to have_no_css('h2', text: I18n.t('companies.needs.needs_done')) }
-    it('displays needs') { expect(render).to have_css('div.company-need', count: 1) }
+    it('displays needs') { expect(render).to have_css('div.fr-tile', count: 1) }
     it('displays need subject') { expect(render).to have_link(text: need.subject.label) }
   end
 
@@ -44,7 +44,7 @@ RSpec.describe 'companies/needs' do
 
     it('displays title needs done') { expect(render).to have_css('h2', text: I18n.t('companies.needs.needs_done')) }
     it('not displays title needs in progress') { expect(render).to have_no_css('h2', text: I18n.t('companies.needs.needs_in_progress')) }
-    it('displays needs') { expect(render).to have_css('div.company-need', count: 2) }
+    it('displays needs') { expect(render).to have_css('div.fr-tile', count: 2) }
     it('displays first need subject') { expect(render).to have_link(text: need.subject.label) }
     it('displays second need subject') { expect(render).to have_link(text: another_need.subject.label) }
   end
@@ -58,7 +58,7 @@ RSpec.describe 'companies/needs' do
 
     it('displays title needs done') { expect(render).to have_css('h2', text: I18n.t('companies.needs.needs_done')) }
     it('displays title needs in progress') { expect(render).to have_css('h2', text: I18n.t('companies.needs.needs_in_progress')) }
-    it('displays needs') { expect(render).to have_css('div.company-need', count: 2) }
+    it('displays needs') { expect(render).to have_css('div.fr-tile', count: 2) }
     it('displays first need subject') { expect(render).to have_link(text: need.subject.label) }
     it('displays second need subject') { expect(render).to have_link(text: another_need.subject.label) }
   end


### PR DESCRIPTION
closes #4260
J'en profite pour supprimer une classe qui ne servait à rien

Avant :  
<img width="1053" height="638" alt="Screenshot 2026-05-19 at 11 36 11" src="https://github.com/user-attachments/assets/e6447415-0291-49c5-9b9d-633ef47e9030" />

Après :  
<img width="1081" height="609" alt="Screenshot 2026-05-19 at 11 36 21" src="https://github.com/user-attachments/assets/083b4727-b8d4-4958-aa9e-44b672d97701" />
