### PR TITLE
Simplification des specs pour TimeDurationService

### DIFF
--- a/spec/services/time_duration_service/months_spec.rb
+++ b/spec/services/time_duration_service/months_spec.rb
@@ -9,18 +9,18 @@ describe TimeDurationService::Months do
         travel_to('2025-01-20') do
           # January 2025 is not finished yet, so only 2024 months are returned
           is_expected.to contain_exactly(
-            ('01/12/2024'.to_date)..('31/12/2024'.to_date),
-            ('01/11/2024'.to_date)..('30/11/2024'.to_date),
-            ('01/10/2024'.to_date)..('31/10/2024'.to_date),
-            ('01/09/2024'.to_date)..('30/09/2024'.to_date),
-            ('01/08/2024'.to_date)..('31/08/2024'.to_date),
-            ('01/07/2024'.to_date)..('31/07/2024'.to_date),
-            ('01/06/2024'.to_date)..('30/06/2024'.to_date),
-            ('01/05/2024'.to_date)..('31/05/2024'.to_date),
-            ('01/04/2024'.to_date)..('30/04/2024'.to_date),
-            ('01/03/2024'.to_date)..('31/03/2024'.to_date),
-            ('01/02/2024'.to_date)..('29/02/2024'.to_date),
-            ('01/01/2024'.to_date)..('31/01/2024'.to_date)
+            '12/2024'.to_date.all_month,
+            '11/2024'.to_date.all_month,
+            '10/2024'.to_date.all_month,
+            '09/2024'.to_date.all_month,
+            '08/2024'.to_date.all_month,
+            '07/2024'.to_date.all_month,
+            '06/2024'.to_date.all_month,
+            '05/2024'.to_date.all_month,
+            '04/2024'.to_date.all_month,
+            '03/2024'.to_date.all_month,
+            '02/2024'.to_date.all_month,
+            '01/2024'.to_date.all_month
           )
         end
       end
@@ -31,22 +31,22 @@ describe TimeDurationService::Months do
         travel_to('2025-05-20') do
           # May 2025 is not finished yet, so we get Jan-Apr 2025 + all of 2024
           is_expected.to contain_exactly(
-            ('01/04/2025'.to_date)..('30/04/2025'.to_date),
-            ('01/03/2025'.to_date)..('31/03/2025'.to_date),
-            ('01/02/2025'.to_date)..('28/02/2025'.to_date),
-            ('01/01/2025'.to_date)..('31/01/2025'.to_date),
-            ('01/12/2024'.to_date)..('31/12/2024'.to_date),
-            ('01/11/2024'.to_date)..('30/11/2024'.to_date),
-            ('01/10/2024'.to_date)..('31/10/2024'.to_date),
-            ('01/09/2024'.to_date)..('30/09/2024'.to_date),
-            ('01/08/2024'.to_date)..('31/08/2024'.to_date),
-            ('01/07/2024'.to_date)..('31/07/2024'.to_date),
-            ('01/06/2024'.to_date)..('30/06/2024'.to_date),
-            ('01/05/2024'.to_date)..('31/05/2024'.to_date),
-            ('01/04/2024'.to_date)..('30/04/2024'.to_date),
-            ('01/03/2024'.to_date)..('31/03/2024'.to_date),
-            ('01/02/2024'.to_date)..('29/02/2024'.to_date),
-            ('01/01/2024'.to_date)..('31/01/2024'.to_date)
+            '04/2025'.to_date.all_month,
+            '03/2025'.to_date.all_month,
+            '02/2025'.to_date.all_month,
+            '01/2025'.to_date.all_month,
+            '12/2024'.to_date.all_month,
+            '11/2024'.to_date.all_month,
+            '10/2024'.to_date.all_month,
+            '09/2024'.to_date.all_month,
+            '08/2024'.to_date.all_month,
+            '07/2024'.to_date.all_month,
+            '06/2024'.to_date.all_month,
+            '05/2024'.to_date.all_month,
+            '04/2024'.to_date.all_month,
+            '03/2024'.to_date.all_month,
+            '02/2024'.to_date.all_month,
+            '01/2024'.to_date.all_month
           )
         end
       end
@@ -57,29 +57,29 @@ describe TimeDurationService::Months do
         travel_to('2025-12-20') do
           # December 2025 is not finished yet, so we get Jan-Nov 2025 + all of 2024
           is_expected.to contain_exactly(
-            ('01/11/2025'.to_date)..('30/11/2025'.to_date),
-            ('01/10/2025'.to_date)..('31/10/2025'.to_date),
-            ('01/09/2025'.to_date)..('30/09/2025'.to_date),
-            ('01/08/2025'.to_date)..('31/08/2025'.to_date),
-            ('01/07/2025'.to_date)..('31/07/2025'.to_date),
-            ('01/06/2025'.to_date)..('30/06/2025'.to_date),
-            ('01/05/2025'.to_date)..('31/05/2025'.to_date),
-            ('01/04/2025'.to_date)..('30/04/2025'.to_date),
-            ('01/03/2025'.to_date)..('31/03/2025'.to_date),
-            ('01/02/2025'.to_date)..('28/02/2025'.to_date),
-            ('01/01/2025'.to_date)..('31/01/2025'.to_date),
-            ('01/12/2024'.to_date)..('31/12/2024'.to_date),
-            ('01/11/2024'.to_date)..('30/11/2024'.to_date),
-            ('01/10/2024'.to_date)..('31/10/2024'.to_date),
-            ('01/09/2024'.to_date)..('30/09/2024'.to_date),
-            ('01/08/2024'.to_date)..('31/08/2024'.to_date),
-            ('01/07/2024'.to_date)..('31/07/2024'.to_date),
-            ('01/06/2024'.to_date)..('30/06/2024'.to_date),
-            ('01/05/2024'.to_date)..('31/05/2024'.to_date),
-            ('01/04/2024'.to_date)..('30/04/2024'.to_date),
-            ('01/03/2024'.to_date)..('31/03/2024'.to_date),
-            ('01/02/2024'.to_date)..('29/02/2024'.to_date),
-            ('01/01/2024'.to_date)..('31/01/2024'.to_date)
+            '11/2025'.to_date.all_month,
+            '10/2025'.to_date.all_month,
+            '09/2025'.to_date.all_month,
+            '08/2025'.to_date.all_month,
+            '07/2025'.to_date.all_month,
+            '06/2025'.to_date.all_month,
+            '05/2025'.to_date.all_month,
+            '04/2025'.to_date.all_month,
+            '03/2025'.to_date.all_month,
+            '02/2025'.to_date.all_month,
+            '01/2025'.to_date.all_month,
+            '12/2024'.to_date.all_month,
+            '11/2024'.to_date.all_month,
+            '10/2024'.to_date.all_month,
+            '09/2024'.to_date.all_month,
+            '08/2024'.to_date.all_month,
+            '07/2024'.to_date.all_month,
+            '06/2024'.to_date.all_month,
+            '05/2024'.to_date.all_month,
+            '04/2024'.to_date.all_month,
+            '03/2024'.to_date.all_month,
+            '02/2024'.to_date.all_month,
+            '01/2024'.to_date.all_month
           )
         end
       end

--- a/spec/services/time_duration_service/quarters_spec.rb
+++ b/spec/services/time_duration_service/quarters_spec.rb
@@ -6,7 +6,16 @@ describe TimeDurationService::Quarters do
     context '1rst quarter' do
       it do
         travel_to('2025-01-20') do
-          is_expected.to contain_exactly(('Tue, 01 Oct 2024'.to_date)..('Tue, 31 Dec 2024'.to_date), ('Mon, 01 Jul 2024'.to_date)..('Mon, 30 Sep 2024'.to_date), ('Mon, 01 Apr 2024'.to_date)..('Sun, 30 Jun 2024'.to_date), ('Mon, 01 Jan 2024'.to_date)..('Sun, 31 Mar 2024'.to_date), ('Sun, 01 Oct 2023'.to_date)..('Sun, 31 Dec 2023'.to_date), ('Sat, 01 Jul 2023'.to_date)..('Sat, 30 Sep 2023'.to_date), ('Sat, 01 Apr 2023'.to_date)..('Fri, 30 Jun 2023'.to_date), ('Sun, 01 Jan 2023'.to_date)..('Fri, 31 Mar 2023'.to_date))
+          is_expected.to contain_exactly(
+            '10/2024'.to_date.all_quarter,
+                           '07/2024'.to_date.all_quarter,
+                           '04/2024'.to_date.all_quarter,
+                           '01/2024'.to_date.all_quarter,
+                           '10/2023'.to_date.all_quarter,
+                           '07/2023'.to_date.all_quarter,
+                           '04/2023'.to_date.all_quarter,
+                           '01/2023'.to_date.all_quarter
+          )
         end
       end
     end
@@ -14,7 +23,13 @@ describe TimeDurationService::Quarters do
     context '2nd quarter' do
       it do
         travel_to('2025-05-20') do
-          is_expected.to contain_exactly(('Mon, 01 Jan 2024'.to_date)..('Sun, 31 Mar 2024'.to_date), ('Mon, 01 Apr 2024'.to_date)..('Sun, 30 Jun 2024'.to_date), ('Mon, 01 Jul 2024'.to_date)..('Mon, 30 Sep 2024'.to_date), ('Tue, 01 Oct 2024'.to_date)..('Tue, 31 Dec 2024'.to_date), ('Wed, 01 Jan 2025'.to_date)..('Mon, 31 Mar 2025'.to_date))
+          is_expected.to contain_exactly(
+            '01/2025'.to_date.all_quarter,
+                           '10/2024'.to_date.all_quarter,
+                           '07/2024'.to_date.all_quarter,
+                           '04/2024'.to_date.all_quarter,
+                           '01/2024'.to_date.all_quarter
+          )
         end
       end
     end
@@ -22,7 +37,14 @@ describe TimeDurationService::Quarters do
     context '3rd quarter' do
       it do
         travel_to('2025-08-20') do
-          is_expected.to contain_exactly(('Mon, 01 Jan 2024'.to_date)..('Sun, 31 Mar 2024'.to_date), ('Mon, 01 Apr 2024'.to_date)..('Sun, 30 Jun 2024'.to_date), ('Mon, 01 Jul 2024'.to_date)..('Mon, 30 Sep 2024'.to_date), ('Tue, 01 Oct 2024'.to_date)..('Tue, 31 Dec 2024'.to_date), ('Wed, 01 Jan 2025'.to_date)..('Mon, 31 Mar 2025'.to_date), ('Tue, 01 Apr 2025'.to_date)..('Mon, 30 Jun 2025'.to_date))
+          is_expected.to contain_exactly(
+            '04/2025'.to_date.all_quarter,
+                           '01/2025'.to_date.all_quarter,
+                           '10/2024'.to_date.all_quarter,
+                           '07/2024'.to_date.all_quarter,
+                           '04/2024'.to_date.all_quarter,
+                           '01/2024'.to_date.all_quarter
+          )
         end
       end
     end
@@ -30,7 +52,15 @@ describe TimeDurationService::Quarters do
     context 'last quarter' do
       it do
         travel_to('2025-11-20') do
-          is_expected.to contain_exactly(('Mon, 01 Jan 2024'.to_date)..('Sun, 31 Mar 2024'.to_date), ('Mon, 01 Apr 2024'.to_date)..('Sun, 30 Jun 2024'.to_date), ('Mon, 01 Jul 2024'.to_date)..('Mon, 30 Sep 2024'.to_date), ('Tue, 01 Oct 2024'.to_date)..('Tue, 31 Dec 2024'.to_date), ('Wed, 01 Jan 2025'.to_date)..('Mon, 31 Mar 2025'.to_date), ('Tue, 01 Apr 2025'.to_date)..('Mon, 30 Jun 2025'.to_date), ('Wed, 01 Jul 2025'.to_date)..('Tue, 30 Sep 2025'.to_date))
+          is_expected.to contain_exactly(
+            '07/2025'.to_date.all_quarter,
+                           '04/2025'.to_date.all_quarter,
+                           '01/2025'.to_date.all_quarter,
+                           '10/2024'.to_date.all_quarter,
+                           '07/2024'.to_date.all_quarter,
+                           '04/2024'.to_date.all_quarter,
+                           '01/2024'.to_date.all_quarter
+          )
         end
       end
     end

--- a/spec/services/time_duration_service/years_spec.rb
+++ b/spec/services/time_duration_service/years_spec.rb
@@ -6,7 +6,7 @@ describe TimeDurationService::Years do
     context '1rst quarter' do
       it do
         travel_to('2025-01-20') do
-          is_expected.to contain_exactly(('01/01/2024'.to_date)..('31/12/2024'.to_date), ('01/01/2023'.to_date)..('31/12/2023'.to_date))
+          is_expected.to contain_exactly('01/2024'.to_date.all_year, '01/2023'.to_date.all_year)
         end
       end
     end
@@ -14,7 +14,7 @@ describe TimeDurationService::Years do
     context '2nd quarter' do
       it do
         travel_to('2025-04-20') do
-          is_expected.to contain_exactly(('01/01/2024'.to_date)..('31/12/2024'.to_date))
+          is_expected.to contain_exactly('01/2024'.to_date.all_year)
         end
       end
     end


### PR DESCRIPTION
Autant utiliser les méthodes faciles de Rails.

Ce sont les premières touches pour #4297, et c’est en passant pour #4141.