### PR TITLE
Permet aux admins de générer les fichiers stats à la demande

### DIFF
--- a/app/admin/antenne.rb
+++ b/app/admin/antenne.rb
@@ -1,6 +1,8 @@
 ActiveAdmin.register Antenne do
   menu parent: :experts, priority: 1
 
+  include OnDemandActivityReports
+
   controller do
     include SoftDeletable::ActiveAdminResourceController
     include TerritorialZonesSearchable
@@ -97,9 +99,6 @@ ActiveAdmin.register Antenne do
         if a.managers.any?
           div admin_link_to(a, :managers, list: true)
         end
-      end
-      row(:stats) do |a|
-        div link_to I18n.t('active_admin.antennes.stats_reports'),reports_path(antenne_id: a.id)
       end
     end
 
@@ -217,6 +216,14 @@ ActiveAdmin.register Antenne do
     end
 
     f.actions
+  end
+
+  sidebar I18n.t('active_admin.reports.title'), only: [:show, :edit] do
+    div link_to t('active_admin.reports.view_reports_app_page'), reports_path(antenne_id: resource.id)
+    hr
+    activity_report_sidebar_contents(ActivityReports::AntenneStats.new(resource))
+    hr
+    activity_report_sidebar_contents(ActivityReports::AntenneMatches.new(resource))
   end
 
   ## Actions

--- a/app/admin/concerns/on_demand_activity_reports.rb
+++ b/app/admin/concerns/on_demand_activity_reports.rb
@@ -1,0 +1,70 @@
+module OnDemandActivityReports
+  def self.included(dsl)
+    ## Using `.send` because the ResourceDSL methods are (wrongly) private
+    # See https://github.com/activeadmin/activeadmin/issues/3673#issuecomment-291267819
+    dsl.send(:member_action, :generate_activity_report, method: :post) do
+      generator = {
+        cooperation: ActivityReports::CooperationStats,
+        matches: ActivityReports::AntenneMatches,
+        solicitations: ActivityReports::CooperationSolicitations,
+        stats: ActivityReports::AntenneStats,
+      }[params.expect(:type).to_sym]
+      generator.new(resource).enqueue
+      redirect_back_or_to collection_path, notice: t('active_admin.reports.job_started')
+    end
+  end
+
+  module ActivityReportsSidebarHelpers
+    def activity_report_sidebar_contents(generator)
+      div do
+        h4 t(generator.report_type, scope: "reports.type")
+        if generator.missing_reports_periods.any?
+          div t("active_admin.reports.missing_reports", count: generator.missing_reports_periods.count)
+        end
+        if generator.existing_reports_periods.any?
+          div t("active_admin.reports.latest_report_period", period: TimeDurationService.period_name(generator.existing_reports_periods.last))
+        end
+
+        job_status = generator.job_status
+        button_text = if job_status[:run_at].present?
+          t("active_admin.reports.job_running")
+        elsif job_status[:enqueued_at].present?
+          t("active_admin.reports.job_enqueued")
+        else
+          t('active_admin.reports.start_job_now')
+        end
+        button_title = if job_status[:run_at].present?
+          t("active_admin.reports.job_running_at", date: l(job_status[:run_at]))
+        elsif job_status[:enqueued_at].present?
+          t("active_admin.reports.job_enqueued_at", date: l(job_status[:enqueued_at]))
+        else
+          ""
+        end
+        enabled = generator.missing_reports_periods.any? && job_status.blank?
+        div button_to button_text,
+                      { action: :generate_activity_report, type: generator.report_type },
+                      data: { confirm: activity_report_start_job_confirmation_message(generator) },
+                      disabled: !enabled,
+                      title: button_title
+      end
+    end
+
+    def activity_report_start_job_confirmation_message(generator)
+      lines = [t("active_admin.reports.start_job_now_message.warning")]
+
+      if generator.missing_reports_periods.any?
+        lines << t("active_admin.reports.start_job_now_message.missing_reports", count: generator.missing_reports_periods.count)
+        lines += generator.missing_reports_periods.map{ "- #{TimeDurationService.period_name(it)}" }
+      end
+
+      if generator.expired_reports.any?
+        lines << t("active_admin.reports.start_job_now_message.expireds_reports", count: generator.expired_reports.count)
+        lines += generator.expired_reports.map{ "- #{it}" }
+      end
+
+      lines.join("\n")
+    end
+  end
+
+  Arbre::Element.include ActivityReportsSidebarHelpers
+end

--- a/app/admin/cooperation.rb
+++ b/app/admin/cooperation.rb
@@ -2,6 +2,7 @@ ActiveAdmin.register Cooperation do
   menu parent: :themes, priority: 3
 
   include AdminArchivable
+  include OnDemandActivityReports
 
   includes :institution, :cooperation_themes, :landings, :logo
 
@@ -60,12 +61,11 @@ ActiveAdmin.register Cooperation do
       row(:managers) do |c|
         div admin_link_to(c, :managers, list: true)
       end
-      row(:stats) do |c|
-        div link_to I18n.t('active_admin.cooperations.activity_reports'),reports_conseiller_cooperations_path(cooperation_id: c.id)
-      end
     end
   end
 
+  ## Form
+  #
   permit_params :name,
                 :logo_id, :mtm_campaign, :root_url, :display_url, :display_matches_stats, :wants_solicitations_export,
                 :external, :institution_id, landing_ids: []
@@ -95,5 +95,13 @@ ActiveAdmin.register Cooperation do
     end
 
     f.actions
+  end
+
+  sidebar I18n.t('active_admin.reports.title'), only: [:show, :edit] do
+    div link_to t('active_admin.reports.view_reports_app_page'), reports_conseiller_cooperations_path(cooperation_id: resource.id)
+    hr
+    activity_report_sidebar_contents(ActivityReports::CooperationStats.new(resource))
+    hr
+    activity_report_sidebar_contents(ActivityReports::CooperationSolicitations.new(resource))
   end
 end

--- a/app/services/activity_reports/antenne_matches.rb
+++ b/app/services/activity_reports/antenne_matches.rb
@@ -20,8 +20,4 @@ class ActivityReports::AntenneMatches < ActivityReports::GeneratorBase
   def report_type = :matches
 
   def reports_periods = TimeDurationService::Months.new.call
-
-  def build_filename(period)
-    I18n.t("activity_report_service.#{report_type}_file_name", month: period.first.month, year: period.first.year, item: @item.name.parameterize)
-  end
 end

--- a/app/services/activity_reports/generator_base.rb
+++ b/app/services/activity_reports/generator_base.rb
@@ -82,6 +82,9 @@ class ActivityReports::GeneratorBase < ApplicationJob
   def destroy_expired_reports = expired_reports.destroy_all
 
   def build_filename(period)
-    I18n.t("activity_report_service.#{report_type}_file_name", number: TimeDurationService::Quarters.new.find_quarter_for_month(period.first.month), year: period.first.year, item: @item.name.parameterize)
+    prefix = I18n.t(report_type, scope: "reports.filename_prefix")
+    item_name = @item.name.parameterize
+    period_name = TimeDurationService.period_name(period)
+    "#{prefix}-#{item_name}-#{period_name}.xlsx"
   end
 end

--- a/app/services/activity_reports/generator_base.rb
+++ b/app/services/activity_reports/generator_base.rb
@@ -21,6 +21,8 @@ class ActivityReports::GeneratorBase < ApplicationJob
     @item = arguments.first
   end
 
+  def job_status = SidekiqJob.status_for(self.class, @item)
+
   def perform(item = nil)
     @item ||= item
 

--- a/app/services/time_duration_service.rb
+++ b/app/services/time_duration_service.rb
@@ -1,0 +1,11 @@
+module TimeDurationService
+  def self.period_name(period)
+    if period.begin.month == period.end.month && period.begin == period.begin.beginning_of_month && period.end == period.end.end_of_month
+      "#{period.begin.year}-#{period.begin.month}"
+    elsif period.begin.quarter == period.end.quarter && period.begin == period.begin.beginning_of_quarter && period.end == period.end.end_of_quarter
+      "#{period.begin.year}T#{period.begin.quarter}"
+    else
+      "#{I18n.l(period.begin)}-#{I18n.l(period.end)}"
+    end
+  end
+end

--- a/config/i18n-tasks.yml
+++ b/config/i18n-tasks.yml
@@ -129,6 +129,7 @@ ignore_unused:
   - 'sitemap.*'
   - 'natures_entreprise.*'
   - 'reports.filename_prefix.*'
+  - 'reports.type.*'
 # - '{devise,kaminari,will_paginate}.*'
 # - 'simple_form.{yes,no}'
 # - 'simple_form.{placeholders,hints,labels}.*'

--- a/config/i18n-tasks.yml
+++ b/config/i18n-tasks.yml
@@ -128,6 +128,7 @@ ignore_unused:
   - 'equipe.*'
   - 'sitemap.*'
   - 'natures_entreprise.*'
+  - 'reports.filename_prefix.*'
 # - '{devise,kaminari,will_paginate}.*'
 # - 'simple_form.{yes,no}'
 # - 'simple_form.{placeholders,hints,labels}.*'

--- a/config/locales/models.fr.yml
+++ b/config/locales/models.fr.yml
@@ -8,15 +8,12 @@ fr:
       no_territorial_zones: Cette antenne ne possède pas de territoire
     antennes:
       deleted: Antennes supprimées avec succès
-      stats_reports: Rapports statistiques
       territorial_antennes: "%{count} antennes liées : "
     company_satisfaction:
       share: Partager
       share_confirmation: Etes-vous sûr de vouloir partager ce commentaire aux conseillers qui ont aidé l'entreprise ?
       shared: Le commentaire a bien été partagé
       shared_with: 'Partagé avec :'
-    cooperations:
-      activity_reports: Rapports d'activité
     expert:
       delete: Supprimer l’expert (sans ses utilisateurs)
       delete_confirmation:
@@ -66,6 +63,27 @@ fr:
       normalize_values: Normaliser les données
       normalize_values_done: Données normalisées
     regional_theme: Thème régional
+    reports:
+      job_enqueued: Génération en attente
+      job_enqueued_at: Génération lancée le %{date}
+      job_running: Génération en cours
+      job_running_at: Génération lancée le %{date}
+      job_started: Fichiers en cours de génération
+      latest_report_period: 'Dernier rapport : %{period}'
+      missing_reports:
+        one: "%{count} rapport à générer"
+        other: "%{count} rapports à générer"
+      start_job_now: Générer maintenant
+      start_job_now_message:
+        expireds_reports:
+          one: "%{count} ancien rapport sera supprimé :"
+          other: "%{count} anciens rapports seront générés :"
+        missing_reports:
+          one: "%{count} rapport sera généré :"
+          other: "%{count} rapports seront générés :"
+        warning: Attention, si le rapport est généré à l’avance, les données seront tronquées.
+      title: Rapports d’activité
+      view_reports_app_page: Afficher les rapports
     save_and_edit: Sauvegarder et revenir à l’édition
     scopes:
       acquisition: Acquisition

--- a/config/locales/views.fr.yml
+++ b/config/locales/views.fr.yml
@@ -45,11 +45,6 @@ fr:
     solicitations:
       diagnosis_in_progress: " (En cours)"
       id: Sollicitation %{id}
-  activity_report_service:
-    cooperation_file_name: rapport-activite-%{item}-%{year}T%{number}.xlsx
-    matches_file_name: export-mises-en-relation-%{item}-%{year}-%{month}.xlsx
-    solicitations_file_name: sollicitations-%{item}-%{year}T%{number}.xlsx
-    stats_file_name: export-stats-%{item}-%{year}T%{number}.xlsx
   admin:
     reassign_matches:
       reassign_matches:
@@ -812,6 +807,11 @@ fr:
   reminders_actions:
     processed_need: Besoin de l’entreprise %{company} traité
   reports:
+    filename_prefix:
+      cooperation: rapport-activite
+      matches: export-mises-en-relation
+      solicitations: sollicitations
+      stats: export-stats
     matches:
       download: Télécharger le fichier mises en relation %{date}
       file_infos: XLSX - %{weight} ko

--- a/config/locales/views.fr.yml
+++ b/config/locales/views.fr.yml
@@ -828,6 +828,11 @@ fr:
       interval: "%{start_month} à %{end_month} %{year}"
       no_export_available: Vos fichiers statistiques trimestriels ne sont pas encore disponibles pour cette antenne. Nous vous informons par mail dès qu’ils sont à télécharger sur votre compte utilisateur.
       title: Statistiques trimestrielles %{antenne}
+    type:
+      cooperation: Rapports de coopération
+      matches: Export des mises en relation
+      solicitations: Export des sollicitations
+      stats: Rapport d’antenne
   republique_francaise_html: République <br /> Française
   shared:
     breadcrumb:

--- a/lib/sidekiq_job.rb
+++ b/lib/sidekiq_job.rb
@@ -1,0 +1,44 @@
+# frozen_string_literal: true
+
+module SidekiqJob
+  ## This is way more code that should be needed to get the current status of an ActiveJob running in Sidekiq.
+  # @param job_class a subclass of ActiveJob::Base
+  # @param record a subclass of ActiveRecord::Base
+  # obtain the current status of a job started like this job_class.perform_later(record)
+  # @return Hash with the following optional keys:
+  #   - :queued_at if the job has been queued
+  #   - :run_at if the job has been started
+  #   if no job matching the parameters is found, returns an empty hash.
+  #
+  # Unfortunately, the mechanism here is mostly untestable, unless we actually use Sidekiq and redis in our tests.
+  def self.status_for(job_class, item)
+    work = Sidekiq::WorkSet.new
+      .map{ |_process_id, _thread_id, work| work }
+      .find do |work|
+      job = work.job
+      hash = job.args.first
+      hash["job_class"] == job_class.to_s && hash.dig("arguments", 0, "_aj_globalid") == item.to_gid.uri.to_s
+    end
+
+    if work.present?
+      return {
+        enqueued_at: work.job.enqueued_at,
+        run_at: work.run_at
+      }
+    end
+
+    queue = Sidekiq::Queue.all.find{ it.name == job_class.queue_name }
+    job = queue.find do |job|
+      hash = job.args.first
+      hash["job_class"] == job_class.to_s && hash.dig("arguments", 0, "_aj_globalid") == item.to_gid.uri.to_s
+    end
+
+    if job.present?
+      return {
+        enqueued_at: job.enqueued_at,
+      }
+    end
+
+    return {}
+  end
+end

--- a/spec/services/activity_reports/antenne_matches_spec.rb
+++ b/spec/services/activity_reports/antenne_matches_spec.rb
@@ -1,7 +1,7 @@
 require 'rails_helper'
 describe ActivityReports::AntenneMatches do
   describe '#perform' do
-    let(:antenne) { create :antenne }
+    let(:antenne) { create :antenne, name: "Commune de Paris" }
     let(:generator) { described_class.new(antenne) }
 
     around { |example| travel_to('10/07/2025'.to_date, &example) }
@@ -35,6 +35,7 @@ describe ActivityReports::AntenneMatches do
       expect((old_reports_ids - new_reports.ids).size).to eq 6
       expect(new_reports.first.period).to eq Date.new(2024,1).all_month
       expect(new_reports.last.period).to eq Date.new(2025,6).all_month
+      expect(new_reports.last.file.filename.to_s).to eq 'export-mises-en-relation-commune-de-paris-2025-6.xlsx'
     end
   end
 end

--- a/spec/services/activity_reports/antenne_stats_spec.rb
+++ b/spec/services/activity_reports/antenne_stats_spec.rb
@@ -1,7 +1,7 @@
 require 'rails_helper'
 describe ActivityReports::AntenneStats do
   describe '#perform' do
-    let(:antenne) { create :antenne }
+    let(:antenne) { create :antenne, name: "Commune de Paris" }
     let(:generator) { described_class.new(antenne) }
 
     around { |example| travel_to('10/07/2025'.to_date, &example) }
@@ -30,6 +30,7 @@ describe ActivityReports::AntenneStats do
       expect((old_reports_ids - new_reports.ids).size).to eq 2
       expect(new_reports.first.period).to eq '01/2024'.to_date.all_quarter
       expect(new_reports.last.period).to eq '04/2025'.to_date.all_quarter
+      expect(new_reports.last.file.filename.to_s).to eq 'export-stats-commune-de-paris-2025T2.xlsx'
     end
   end
 end

--- a/spec/services/activity_reports/cooperation_solicitations_spec.rb
+++ b/spec/services/activity_reports/cooperation_solicitations_spec.rb
@@ -1,7 +1,7 @@
 require 'rails_helper'
 describe ActivityReports::CooperationSolicitations do
   describe '#perform' do
-    let(:cooperation) { create :cooperation }
+    let(:cooperation) { create :cooperation, name: "Commune de Paris" }
     let(:generator) { described_class.new(cooperation) }
 
     around { |example| travel_to('10/07/2025'.to_date, &example) }
@@ -30,6 +30,7 @@ describe ActivityReports::CooperationSolicitations do
       expect((old_reports_ids - new_reports.ids).size).to eq 2
       expect(new_reports.first.period).to eq '01/2024'.to_date.all_quarter
       expect(new_reports.last.period).to eq '04/2025'.to_date.all_quarter
+      expect(new_reports.last.file.filename.to_s).to eq 'sollicitations-commune-de-paris-2025T2.xlsx'
     end
   end
 end

--- a/spec/services/activity_reports/cooperation_stats_spec.rb
+++ b/spec/services/activity_reports/cooperation_stats_spec.rb
@@ -1,7 +1,7 @@
 require 'rails_helper'
 describe ActivityReports::CooperationStats do
   describe '#perform' do
-    let(:cooperation) { create :cooperation }
+    let(:cooperation) { create :cooperation, name: "Commune de Paris" }
     let(:generator) { described_class.new(cooperation) }
 
     around { |example| travel_to('10/07/2025'.to_date, &example) }
@@ -30,6 +30,7 @@ describe ActivityReports::CooperationStats do
       expect((old_reports_ids - new_reports.ids).size).to eq 2
       expect(new_reports.first.period).to eq '01/2024'.to_date.all_quarter
       expect(new_reports.last.period).to eq '04/2025'.to_date.all_quarter
+      expect(new_reports.last.file.filename.to_s).to eq 'rapport-activite-commune-de-paris-2025T2.xlsx'
     end
   end
 end

--- a/spec/services/time_duration_service_spec.rb
+++ b/spec/services/time_duration_service_spec.rb
@@ -1,0 +1,11 @@
+require 'rails_helper'
+
+describe TimeDurationService do
+  describe '#period_name' do
+    it do
+      expect(described_class.period_name(('01/07/2024'.to_date)..('31/07/2024'.to_date))).to eq '2024-7'
+      expect(described_class.period_name(('01/2024'.to_date)..('31/03/2024'.to_date))).to eq '2024T1'
+      expect(described_class.period_name(('07/03/2024'.to_date)..('08/04/2024'.to_date))).to eq '07/03/2024-08/04/2024'
+    end
+  end
+end


### PR DESCRIPTION
fixes #4207 

- Merger d’abord #4494 et #4495

Ça ressemble à ça, dans l’ordre:

|||
|-|-|
|Clic sur le bouton “Générer maintenant”|<img width="480" height="232" alt="Capture d’écran 2026-06-01 à 17 50 29" src="https://github.com/user-attachments/assets/63d62cde-e249-4563-97da-a299f8dce7bb" />|
|Pendant que le job est en attente|<img width="287" height="322" alt="Capture d’écran 2026-06-01 à 17 49 52" src="https://github.com/user-attachments/assets/fc3b67cd-06a7-418e-81c3-e8a03d4394dd" />|
|Pendant l’exécution du job|<img width="262" height="281" alt="Capture d’écran 2026-06-01 à 17 50 43" src="https://github.com/user-attachments/assets/5a75368c-5903-4456-b0a2-606be7ad37d7" />|
|Pendant l’exécution du job|<img width="268" height="280" alt="Capture d’écran 2026-06-01 à 17 50 53" src="https://github.com/user-attachments/assets/f16df2b2-d5f4-4fd3-b0ba-abbdc30f4417" />|
|Après l’exécution, bouton désactivé|<img width="271" height="286" alt="Capture d’écran 2026-06-01 à 17 51 46" src="https://github.com/user-attachments/assets/905614ac-77d5-438a-85ed-472aa23126db" />|

Pour l’instant, je n’ai pas modifié l’affichage dans l’application elle-même, c’est déjà suffisamment de code.