### PR TITLE
Potential fix for code scanning alert no. 14: Code injection

### DIFF
--- a/app/controllers/concerns/stats_utilities.rb
+++ b/app/controllers/concerns/stats_utilities.rb
@@ -1,6 +1,18 @@
 module StatsUtilities
   extend ActiveSupport::Concern
 
+  ALLOWED_CHART_NAMES = %w[
+    solicitations_completed solicitations_diagnoses needs_positioning needs_done needs_done_no_help
+    needs_done_not_reachable needs_not_for_me needs_taking_care needs_taken_care_in_three_days
+    needs_taken_care_in_five_days needs_helped_in_five_days needs_themes_all needs_subjects_all
+    needs_exchange_with_expert needs_themes_not_from_external_cooperation
+    needs_themes_from_external_cooperation needs_subjects_not_from_external_cooperation
+    needs_subjects_from_external_cooperation needs_transmitted matches_positioning
+    matches_taking_care matches_done matches_done_no_help matches_done_not_reachable
+    matches_not_for_me matches_not_positioning matches_taken_care_in_three_days
+    matches_taken_care_in_five_days companies_by_employees companies_by_naf_code
+  ].freeze
+
   included do
     helper_method :stats_filter_params
   end
@@ -17,10 +29,12 @@ module StatsUtilities
   private
 
   def constantize_chart_name(name)
+    raise NameError, 'Invalid chart name' unless ALLOWED_CHART_NAMES.include?(name)
+
     name_splitted = name.split('_')
     category = name_splitted.first.capitalize
     graph = name_splitted[1..].map(&:capitalize).join
-    Stats.const_get(category).const_get(graph)
+    Stats.const_get(category, false).const_get(graph, false)
   end
 
   def stats_params


### PR DESCRIPTION
Potential fix for [https://github.com/betagouv/conseillers-entreprises/security/code-scanning/14](https://github.com/betagouv/conseillers-entreprises/security/code-scanning/14)

General fix: never perform reflective lookup from raw/untrusted strings without strict validation at the sink. Add centralized validation in `StatsUtilities` so all controllers benefit, including current and future ones.

Best fix here (without changing functionality): in `app/controllers/concerns/stats_utilities.rb`, define a frozen allowlist of supported chart names (the union used by current controllers), validate `name` against it in `invoke_stats`/`constantize_chart_name`, and use `const_get(..., false)` to avoid ancestor lookup surprises. If invalid, raise `NameError` (or `ArgumentError`) so bad input is rejected before constantization. This keeps existing behavior for valid chart names and addresses all reported variants in one place.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
