### PR TITLE
Gérer les réponses API en erreur dans la recherche d'entreprises en texte 

### DIFF
--- a/app/services/api_consumption/models/base.rb
+++ b/app/services/api_consumption/models/base.rb
@@ -9,7 +9,8 @@ module ApiConsumption::Models
 
     def initialize(params = {})
       return if params.blank?
-      params = params&.with_indifferent_access # accepter les strings et les sym, pour faciliter l'usage
+      return unless params.respond_to?(:with_indifferent_access)
+      params = params.with_indifferent_access # accepter les strings et les sym, pour faciliter l'usage
       self.class.fields.each do |key|
         dynamically_create_attr_accessor(key, params[key])
       end

--- a/app/services/search_facility/base.rb
+++ b/app/services/search_facility/base.rb
@@ -32,6 +32,9 @@ module SearchFacility
     def from_full_text
       begin
         response = Api::RechercheEntreprises::Search::Fulltext::Base.new(@query).call
+        # En cas d'erreur non bloquante, l'API renvoie un Hash { errors: ... }
+        # au lieu de la liste d'établissements attendue.
+        return { items: [], error: I18n.t('api_requests.generic_error') } unless response.is_a?(Array)
         items = response.map do |entreprise_params|
           next if entreprise_params.blank?
           ApiConsumption::Models::FacilityAutocomplete::ApiRechercheEntreprises.new(entreprise_params)

--- a/spec/services/api_consumption/models/facility_autocomplete/api_recherche_entreprises_spec.rb
+++ b/spec/services/api_consumption/models/facility_autocomplete/api_recherche_entreprises_spec.rb
@@ -12,6 +12,16 @@ RSpec.describe ApiConsumption::Models::FacilityAutocomplete::ApiRechercheEntrepr
       end
     end
 
+    context 'with an array instead of a hash' do
+      # Reproduces the production NoMethodError: when the API returns an error
+      # The model must not crash on a non-hash input
+      let(:params) { [:errors, { standard_api_errors: {} }] }
+
+      it 'fails silently' do
+        expect{ api_model }.not_to raise_error
+      end
+    end
+
     context 'with params' do
       let(:params) { JSON.parse(file_fixture('api_recherche_entreprises_entreprise_request_data.json').read) }
 

--- a/spec/services/search_facility/diffusable_spec.rb
+++ b/spec/services/search_facility/diffusable_spec.rb
@@ -74,5 +74,24 @@ RSpec.describe SearchFacility::Diffusable do
         expect(data[0]["nombre_etablissements_ouverts"]).to eq(2)
       end
     end
+
+    context 'from_fulltext when the API returns a minor error' do
+      # Reproduces the production crash: "undefined method 'with_indifferent_access' for an instance of Array"
+      # Api::Base#call return an error Hash instead of an Array. from_full_text
+      # must handle it gracefully instead of raising NoMethodError.
+      let(:api_url) { "https://recherche-entreprises.api.gouv.fr/search?mtm_campaign=conseillers-entreprises&q=#{query}" }
+      let(:query) { 'octo technology' }
+      let(:result) { described_class.new(search_params).from_full_text_or_siren }
+
+      before do
+        stub_request(:get, api_url).to_return(status: 502, body: '{}')
+      end
+
+      it 'does not raise and returns no items' do
+        expect{ result }.not_to raise_error
+        expect(result[:items]).to eq([])
+        expect(result[:error]).to be_present
+      end
+    end
   end
 end


### PR DESCRIPTION
Cause : `Api::Base#call` a deux types de retour. En succès il renvoie un `Array` d'établissements et en erreur non bloquante renvoie un `Hash { errors: {...} }`.  `from_full_text` supposait toujours un `Array` et faisait `response.map`. 

Correction : On renvoie un array vide plus une erreur si jamais l'api renvoie une erreur
on fait un return dans le initialize pour sécuriser aussi de ce côté-là au cas où

closes #4515 