### PR TITLE
Afficher l’évolution en pourcentage relatif

### DIFF
--- a/app/services/xlsx_export/cooperation_worksheet_generator/base.rb
+++ b/app/services/xlsx_export/cooperation_worksheet_generator/base.rb
@@ -80,6 +80,7 @@ module XlsxExport
         @right_header = s.add_style bg_color: 'eadecd', b: true, alignment: { horizontal: :right, wrap_text: true }, border: { color: 'AAAAAA', style: :thin }
         @label        = s.add_style alignment: { indent: 1 }
         @rate         = s.add_style format_code: '#0.0%'
+        @evolution    = s.add_style format_code: '+#0.0%;-#0.0%;#0.0%'
         @yellow       = s.add_style bg_color: 'FFEB84', type: :dxf
         @pink         = s.add_style bg_color: 'EAD1DC', type: :dxf
         @orange       = s.add_style bg_color: 'F79646', type: :dxf

--- a/app/services/xlsx_export/cooperation_worksheet_generator/provenance.rb
+++ b/app/services/xlsx_export/cooperation_worksheet_generator/provenance.rb
@@ -36,6 +36,7 @@ module XlsxExport
           reference_period = @start_date.years_ago(1)..@end_date.years_ago(1)
           reference = base_solicitations.where(provenance_detail: provenance_detail).rewhere(completed_at: reference_period)
           evolution = calculate_rate(solicitations.size, reference)
+          evolution = evolution - 1.0 if evolution.present? # relative rate
 
           body_row = [
             provenance_detail,
@@ -94,7 +95,7 @@ module XlsxExport
       end
 
       def provenance_row_style
-        row_style = [@label, nil, @rate, nil, @rate, nil, @rate, nil, @rate, @rate]
+        row_style = [@label, nil, @evolution, nil, @rate, nil, @rate, nil, @rate, @rate]
         STATUS.each{ |status| row_style << @count; row_style << @rate }
         row_style
       end

--- a/spec/services/xlsx_export/cooperation_exporter_spec.rb
+++ b/spec/services/xlsx_export/cooperation_exporter_spec.rb
@@ -137,15 +137,17 @@ RSpec.describe XlsxExport::CooperationExporter do
     end
 
     describe 'Provenance worksheet' do
-      let!(:solicitation_with_provenance) do
-        create(:solicitation,
-          landing: landing,
-          landing_subject: landing_subject,
+      before do
+        create_list(:solicitation, 3,
+          landing: landing, landing_subject: landing_subject, status: :processed,
           completed_at: Date.new(2025, 2, 15),
-          status: :processed,
+          provenance_detail: 'Partner Website')
+
+        create_list(:solicitation, 2,
+          landing: landing, landing_subject: landing_subject, status: :processed,
+          completed_at: Date.new(2024, 2, 15), # one year before
           provenance_detail: 'Partner Website')
       end
-      let!(:diagnosis) { create(:diagnosis_completed, solicitation: solicitation_with_provenance, created_at: Date.new(2025, 2, 16)) }
 
       it 'includes provenance worksheet when provenance details exist' do
         provenance_sheet = package.workbook.worksheets.find { |ws| ws.name == I18n.t('cooperation_stats_exporter.provenance.tab') }
@@ -158,11 +160,19 @@ RSpec.describe XlsxExport::CooperationExporter do
 
         header_row = provenance_sheet.rows.first.cells.map(&:value)
 
-        expect(header_row).to include(I18n.t('cooperation_stats_exporter.provenance.provenance_detail'))
-        expect(header_row).to include(I18n.t('cooperation_stats_exporter.provenance.solicitations_count'))
-        expect(header_row).to include(I18n.t('cooperation_stats_exporter.provenance.abandonned_count'))
-        expect(header_row).to include(I18n.t('cooperation_stats_exporter.provenance.matched_count'))
-        expect(header_row).to include(I18n.t('cooperation_stats_exporter.provenance.done_count'))
+        expect(header_row[0]).to eq "Provenance"
+        expect(header_row[1]).to eq "Nb sollicitations"
+        expect(header_row[2]).to eq "Évolution par rapport à l’année précédente"
+      end
+
+      it 'has correct values' do
+        provenance_sheet = package.workbook.worksheets.find { |ws| ws.name == I18n.t('cooperation_stats_exporter.provenance.tab') }
+
+        values_row = provenance_sheet.rows.last.cells.map(&:value)
+
+        expect(values_row[0]).to eq "Partner Website"
+        expect(values_row[1]).to eq 3
+        expect(values_row[2]).to eq 1.5
       end
     end
 

--- a/spec/services/xlsx_export/cooperation_exporter_spec.rb
+++ b/spec/services/xlsx_export/cooperation_exporter_spec.rb
@@ -172,7 +172,7 @@ RSpec.describe XlsxExport::CooperationExporter do
 
         expect(values_row[0]).to eq "Partner Website"
         expect(values_row[1]).to eq 3
-        expect(values_row[2]).to eq 1.5
+        expect(values_row[2]).to eq 0.5
       end
     end
 


### PR DESCRIPTION
fixes #4517 

| Avant | Après |
|-|-|
|<img width="494" height="124" alt="image" src="https://github.com/user-attachments/assets/dda0b4f9-d83e-4c76-bbdb-9801512099e4" /> | <img width="523" height="138" alt="Capture d’écran 2026-06-16 à 17 06 58" src="https://github.com/user-attachments/assets/fb083109-e0cc-4d3a-aa36-96a8eef954b7" /> |