### PR TITLE
Remove unused js

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -12,7 +12,6 @@ gem 'openssl'
 
 # Assets
 gem 'haml-rails'
-gem 'jquery-rails'
 gem 'dartsass-sprockets'
 gem 'terser'
 gem 'premailer-rails'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -791,7 +791,6 @@ DEPENDENCIES
   i18n-tasks
   ip_anonymizer
   jbuilder
-  jquery-rails
   jsbundling-rails
   kaminari
   letter_opener_web

--- a/app/javascript/application.js
+++ b/app/javascript/application.js
@@ -1,7 +1,6 @@
 import "@hotwired/turbo-rails";
 
 require("@rails/ujs").start();
-require("jquery");
 
 import "./shared/";
 import "./application/";

--- a/app/javascript/application.js
+++ b/app/javascript/application.js
@@ -1,4 +1,3 @@
-import "whatwg-fetch";
 import "@hotwired/turbo-rails";
 
 require("@rails/ujs").start();

--- a/app/javascript/gouvfr-nomodule.js
+++ b/app/javascript/gouvfr-nomodule.js
@@ -1,1 +1,0 @@
-import "@gouvfr/dsfr/dist/dsfr/dsfr.nomodule.min.js";

--- a/app/javascript/pages.js
+++ b/app/javascript/pages.js
@@ -1,7 +1,6 @@
 import "@hotwired/turbo-rails";
 
 require("@rails/ujs").start();
-require("jquery");
 
 import "./shared/";
 import "./pages/";

--- a/app/javascript/pages.js
+++ b/app/javascript/pages.js
@@ -1,4 +1,3 @@
-import "whatwg-fetch";
 import "@hotwired/turbo-rails";
 
 require("@rails/ujs").start();

--- a/app/javascript/shared/index.js
+++ b/app/javascript/shared/index.js
@@ -1,4 +1,3 @@
 import './controllers'
-import './polyfills'
 import './utils'
 import './checkboxes_require_one'

--- a/app/javascript/shared/polyfills.js
+++ b/app/javascript/shared/polyfills.js
@@ -1,7 +1,0 @@
-// Polyfill Element.matches()
-// https://developer.mozilla.org/en-US/docs/Web/API/Element/matches
-if (!Element.prototype.matches) {
-  Element.prototype.matches =
-    Element.prototype.msMatchesSelector ||
-    Element.prototype.webkitMatchesSelector;
-}

--- a/app/views/application/_head.html.haml
+++ b/app/views/application/_head.html.haml
@@ -14,7 +14,6 @@
   = stylesheet_link_tag 'application', media: 'all', data: { 'turbo-track': 'reload' }
   = badges_css_tag
   = javascript_include_tag 'gouvfr-module', type: 'module', data: { 'turbo-track': 'reload' }, nonce: true
-  = javascript_include_tag 'gouvfr-nomodule', type: 'text/javascript', nomodule: '', as: 'script', data: { 'turbo-track': 'reload' }, nonce: true
   = javascript_include_tag 'application', data: { 'turbo-track': 'reload' }, type: "module", nonce: true
 
   = render 'favicon'

--- a/app/views/layouts/pages.html.haml
+++ b/app/views/layouts/pages.html.haml
@@ -18,7 +18,6 @@
     = stylesheet_link_tag '@gouvfr/dsfr/dist/utility/icons/icons-communication/icons-communication.min', data: { 'turbo-track': 'reload' }
     = stylesheet_link_tag 'pages', data: { 'turbo-track': 'reload' }
     = javascript_include_tag 'gouvfr-module', type: 'module', data: { 'turbo-track': 'reload' }, nonce: true
-    = javascript_include_tag 'gouvfr-nomodule', type: 'text/javascript', nomodule: '', data: { 'turbo-track': 'reload' }, nonce: true
     = javascript_include_tag 'pages', data: { 'turbo-track': 'reload' }, type: "module", nonce: true
     - if in_iframe?
       %meta{ name: 'robots', content: 'noindex' }

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -20,8 +20,6 @@ module.exports = defineConfig([{
     languageOptions: {
         globals: {
             ...globals.browser,
-            ...globals.jquery,
-            $: true,
             require: true,
             _paq: true,
             Highcharts: true,

--- a/package.json
+++ b/package.json
@@ -12,8 +12,7 @@
     "mjml": ">4.15.3",
     "remixicon": "^4.2.0",
     "slim-select": "^2.9.2",
-    "stimulus": ">2.0.0",
-    "whatwg-fetch": "^3.5.0"
+    "stimulus": ">2.0.0"
   },
   "devDependencies": {
     "eslint": ">=7.14.0",

--- a/package.json
+++ b/package.json
@@ -8,7 +8,6 @@
     "@hotwired/turbo-rails": "^8.0.4",
     "@rails/ujs": "^6.0.3-4",
     "accessible-autocomplete": "^2.0.3",
-    "jquery": "^3.5.1",
     "mjml": ">4.15.3",
     "remixicon": "^4.2.0",
     "slim-select": "^2.9.2",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2277,11 +2277,6 @@ whatwg-encoding@^3.1.1:
   dependencies:
     iconv-lite "0.6.3"
 
-whatwg-fetch@^3.5.0:
-  version "3.6.20"
-  resolved "https://registry.yarnpkg.com/whatwg-fetch/-/whatwg-fetch-3.6.20.tgz#580ce6d791facec91d37c72890995a0b48d31c70"
-  integrity sha512-EqhiFU6daOA8kpjOWTL0olhVOF3i7OrFzSYiGsEMB8GcXS+RrzauAERX65xMeNWVqxA6HXH2m69Z9LaKKdisfg==
-
 whatwg-mimetype@^4.0.0:
   version "4.0.0"
   resolved "https://registry.yarnpkg.com/whatwg-mimetype/-/whatwg-mimetype-4.0.0.tgz#bc1bf94a985dc50388d54a9258ac405c3ca2fc0a"

--- a/yarn.lock
+++ b/yarn.lock
@@ -1196,11 +1196,6 @@ jackspeak@^4.1.1:
   dependencies:
     "@isaacs/cliui" "^9.0.0"
 
-jquery@^3.5.1:
-  version "3.7.1"
-  resolved "https://registry.yarnpkg.com/jquery/-/jquery-3.7.1.tgz#083ef98927c9a6a74d05a6af02806566d16274de"
-  integrity sha512-m4avr8yL8kmFN8psrbFFFmB/If14iN5o9nw/NgnnM+kybDJpRsAynV2BsfpTYrTRysYUdADVD7CkUUizgkpLfg==
-
 js-beautify@^1.15.4:
   version "1.15.4"
   resolved "https://registry.yarnpkg.com/js-beautify/-/js-beautify-1.15.4.tgz#f579f977ed4c930cef73af8f98f3f0a608acd51e"


### PR DESCRIPTION
Followup #4520. Suppression de:
- jquery: je crois que ce n’est plus utilisé nulle part dans le code, je n’y vois aucune référence, et tout à l’air de marcher?
- whatwg-fetch: [On ne supporte plus IE](https://caniuse.com/fetch)
- gouvfr-nomodule: [Idem](https://caniuse.com/es6-module)
- polyfill pour Element.prototype.matches, [idem](https://caniuse.com/mdn-api_element_matches)