### PR TITLE
Évite de réutiliser les facility avec siret vide

### DIFF
--- a/app/services/diagnosis_creation/create_or_update_diagnosis.rb
+++ b/app/services/diagnosis_creation/create_or_update_diagnosis.rb
@@ -9,7 +9,7 @@ module DiagnosisCreation
     def call
       begin
         Diagnosis.transaction do
-          if @params[:facility_attributes].include? :siret
+          if @params.dig(:facility_attributes, :siret).present?
             set_facility
           end
 

--- a/app/views/conseiller/diagnoses/new.haml
+++ b/app/views/conseiller/diagnoses/new.haml
@@ -16,7 +16,9 @@
       - if @diagnosis.solicitation.present?
         = form.hidden_field :solicitation_id
       = form.fields_for :facility do |facility_form|
-        = facility_form.hidden_field :siret, value: params[:siret] || @diagnosis.solicitation&.siret
+        - siret = params[:siret] || @diagnosis.solicitation&.siret
+        - if siret.present?
+          = facility_form.hidden_field :siret, value: siret
         .fr-fieldset__element
           = facility_form.fields_for :company do |company_form|
             = company_form.label :name, t('.name'), class: 'fr-label'

--- a/spec/services/diagnosis_creation/create_or_update_diagnosis_spec.rb
+++ b/spec/services/diagnosis_creation/create_or_update_diagnosis_spec.rb
@@ -64,6 +64,21 @@ describe DiagnosisCreation::CreateOrUpdateDiagnosis do
             expect(create_or_update_diagnosis[:errors]).to eq({ major_api_error: { "api-apientreprise-entreprise-base" => "some error message" } })
           end
         end
+
+        context 'when the SIRET is blank' do
+          let(:siret) { '' }
+          let!(:intermediary_result) { DiagnosisCreation::CreateOrUpdateFacilityAndCompany.new(siret, fallback_insee_code: "12345") }
+
+          before do
+            create(:facility, siret: '')
+            create(:company, siren: '')
+          end
+
+          it 'does not reuse a previously created facility with a blank SIRET' do
+            expect(create_or_update_diagnosis[:diagnosis].facility).to be_new_record
+          end
+        end
+
       end
 
       context 'with manual facility info' do


### PR DESCRIPTION
fixes #4523

C’est pas le fix le plus élégant. Je pense vraiment qu’il faut qu’on se penche sur la gestion d’erreurs à la création des Diagnoses.