### PR TITLE
Fix DB config

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -36,8 +36,6 @@ pickle-email-*.html
 # unless supporting rvm < 1.11.0 or doing something fancy, ignore this:
 .rvmrc
 
-/config/database.yml
-
 # Ignore all logfiles and tempfiles.
 /log/*
 /tmp/*

--- a/config/database.yml
+++ b/config/database.yml
@@ -20,4 +20,4 @@ test:
 
 production:
   <<: *default
-  database: place-des-entreprises-production
+  url: <%= ENV['DATABASE_URL'] %>

--- a/config/database.yml
+++ b/config/database.yml
@@ -2,7 +2,8 @@ default: &default
   adapter: postgresql
   encoding: unicode
   pool: 5
-  timeout: 5000
+  variables:
+    statement_timeout: 30000
 
 development:
   <<: *default


### PR DESCRIPTION
Premier et second points de #4510:

- corriger les incohérences de configuration, d’abord sans changer le comportement.
- ajouter statement_timeout à 30s, pour éviter que les requêtes trop longues ne squattent PG indéfiniment.
