### PR TITLE
Afficher la date de transmission dans la page des besoins

### DIFF
--- a/app/controllers/needs_controller.rb
+++ b/app/controllers/needs_controller.rb
@@ -57,6 +57,7 @@ class NeedsController < ApplicationController
     else
       @origin = params[:origin]
       @matches = @need.matches.sent.order(:created_at)
+      @match_for_current_user = @need.matches.find_by(expert: current_user.experts)
       @facility = @need.facility
 
       @facility_needs = policy_scope(@facility.needs)

--- a/app/policies/need_policy.rb
+++ b/app/policies/need_policy.rb
@@ -23,10 +23,6 @@ class NeedPolicy < ApplicationPolicy
       (@user.is_manager? && (@record.expert_antennes.any? { |antenne| @user.supervised_antennes.include?(antenne) }))
   end
 
-  def show_need_actions?
-    @record.matches.find_by(expert: @user.experts).present?
-  end
-
   def add_match?
     admin?
   end

--- a/app/views/needs/show.html.haml
+++ b/app/views/needs/show.html.haml
@@ -11,6 +11,9 @@
         %h1.fr-h3.fr-mb-2v= @need.subject
         %p
           %time.date{ datetime: @need.solicited_at }= t('needs.dates.solicited_at', date: l(@need.solicited_at, format: :long_sentence))
+          - if @match_for_current_user.present?
+            %br
+              %time.date{ datetime: @need.solicited_at }= t('needs.dates.match_sent_at', date: l(@match_for_current_user.sent_at, format: :long_sentence))
         = need_general_context(@need)
         - display_partner_url = (@need.solicitation&.cooperation&.display_url && PartnerOrigin.partner_url(@need.solicitation).present?)
         - if @need.subject_answers.any? || display_partner_url
@@ -87,11 +90,11 @@
             - else
               = t('.blank_advisor')
 
-- if policy(@need).show_need_actions?
+- if @match_for_current_user.present?
   .light-blue-bg
     .fr-container.fr-p-2w.fr-pb-8w
       %h2.fr-h3.fr-my-4w= t('.my_intervention')
-      = render 'match_actions', match: @need.matches.find_by(expert: current_user.experts)
+      = render 'match_actions', match: @match_for_current_user
 
 .lighter-blue-bg
   .fr-container.fr-p-2w#all-experts

--- a/config/locales/views.fr.yml
+++ b/config/locales/views.fr.yml
@@ -579,7 +579,7 @@ fr:
       closed_at: Clôture
       see_expert_inbox: Voir la boîte de réception de l’expert
       see_match_info: Voir plus d'infos sur la MER
-      sent_at: Envoi
+      sent_at: Transmission
       taken_care_of_at: Prise en charge
   monitoring:
     antennes:
@@ -629,7 +629,7 @@ fr:
       quo_active: Boite de réception
       taking_care: Prise en charge
     dates:
-      match_sent_at: Envoyé le %{date}
+      match_sent_at: Transmis le %{date}
       solicited_at: Déposé le %{date}
       solicited_at_day: Besoin du %{date}
     empty_placeholder:

--- a/spec/policies/need_policy_spec.rb
+++ b/spec/policies/need_policy_spec.rb
@@ -82,32 +82,6 @@ RSpec.describe NeedPolicy, type: :policy do
     end
   end
 
-  permissions :show_need_actions? do
-    context "user belongs to need experts" do
-      let(:user) { create :user, experts: [need.experts.first] }
-
-      it { is_expected.to permit(user, need) }
-    end
-
-    context "user in the same antenne" do
-      let(:user) { create :user, antenne: need.experts.first.antenne }
-
-      it { is_expected.not_to permit(user, need) }
-    end
-
-    context "denies access if user is admin" do
-      let(:user) { create :user, :admin }
-
-      it { is_expected.not_to permit(user, need) }
-    end
-
-    context "denies access if user is another user" do
-      let(:user) { create :user, antenne: create(:antenne) }
-
-      it { is_expected.not_to permit(user, need) }
-    end
-  end
-
   permissions :add_match? do
     let!(:need) { create :need_with_matches }
 

--- a/spec/views/needs/show.html.haml_spec.rb
+++ b/spec/views/needs/show.html.haml_spec.rb
@@ -2,29 +2,27 @@ require 'rails_helper'
 
 RSpec.describe 'needs/show' do
   login_user
-  let(:expert) { create :expert, users: [current_user] }
   let(:need) { create :need_with_matches, status: :quo }
-  let(:matches) { need.matches }
-  let!(:taken_care_match) { create :match, need: need, status: :taking_care }
 
   let(:assignments) do
     enable_pundit(view, current_user)
     assign(:need, need)
     assign(:facility, need.facility)
-    assign(:matches, matches)
+    assign(:matches, need.matches)
+    assign(:match_for_current_user, match_for_current_user)
     assign(:facility_needs, Need.none)
     assign(:contact_needs, Need.none)
     render
   end
 
   context 'for expert user' do
-    let!(:a_match) { create :match, expert: expert, need: need }
+    let(:match_for_current_user) { need.matches.first }
 
     describe 'display page' do
       before { assignments }
 
       it('displays subject title') { expect(rendered).to have_css('h1', text: need.subject.label) }
-      it('display other experts matches') { expect(rendered).to have_css('#all-experts', text: matches.first.expert.full_name) }
+      it('display other experts matches') { expect(rendered).to have_css('#all-experts', text: need.matches.first.expert.full_name) }
       it('display new feedback form') { expect(rendered).to have_css('.feedbacks-form', text: I18n.t('feedbacks.form.title')) }
       it('have form for additional experts') { expect(render).to have_no_css('.additional-experts', count: 1) }
       it('has form for close matches') { expect(render).to have_no_css(".details--dropdown", count: 1) }
@@ -52,7 +50,7 @@ RSpec.describe 'needs/show' do
 
     describe 'status taking_care' do
       before do
-        a_match.update status: :taking_care
+        match_for_current_user.update status: :taking_care
         assignments
       end
 
@@ -62,7 +60,7 @@ RSpec.describe 'needs/show' do
 
     describe 'status done' do
       before do
-        a_match.update status: :done
+        match_for_current_user.update status: :done
         assignments
       end
 
@@ -71,7 +69,7 @@ RSpec.describe 'needs/show' do
 
     describe 'status done_not_reachable' do
       before do
-        a_match.update status: :done_not_reachable
+        match_for_current_user.update status: :done_not_reachable
         assignments
       end
 
@@ -80,7 +78,7 @@ RSpec.describe 'needs/show' do
 
     describe 'status done_no_help' do
       before do
-        a_match.update status: :done_no_help
+        match_for_current_user.update status: :done_no_help
         assignments
       end
 
@@ -89,7 +87,7 @@ RSpec.describe 'needs/show' do
 
     describe 'status not_for_me' do
       before do
-        a_match.update status: :not_for_me
+        match_for_current_user.update status: :not_for_me
         assignments
       end
 
@@ -98,6 +96,8 @@ RSpec.describe 'needs/show' do
   end
 
   context 'for admin' do
+    let(:match_for_current_user) { nil }
+
     before do
       current_user.user_rights.create(category: 'admin')
       assignments
@@ -106,6 +106,6 @@ RSpec.describe 'needs/show' do
     it('displays subject title') { expect(rendered).to match(need.subject.label) }
     it('not displays action for match') { expect(render).to have_no_css('#match-actions') }
     it('has form for additional experts') { expect(render).to have_css('.additional-experts', count: 1) }
-    it('has form for close matches') { expect(render).to have_css(".details--dropdown", count: 2) }
+    it('has form for close matches') { expect(render).to have_css(".details--dropdown", count: 1) }
   end
 end


### PR DESCRIPTION
fixes #4547

<img width="545" height="125" alt="image" src="https://github.com/user-attachments/assets/e5402c96-b6b3-42b8-aa95-5ceb7b91460f" />

C’est maintenant similaire à ce qu’on faisait déjà dans la boite de réception, pour le même conseiller:

<img width="554" height="142" alt="image" src="https://github.com/user-attachments/assets/fee2438f-02b2-46eb-98fa-49423fba6ca0" />

Au passage:
- changement du wording, “Transmis” plutôt que “Envoyé”.
- retrait d’une méthode de policy: `#show_need_actions?` ne correspond pas à une autorisation d’effectuer une `action`, mais à un contexte d’affichage.