### PR TITLE
Renomme l’onglet “Retours” en “Satisfaction”

### DIFF
--- a/config/locales/views.fr.yml
+++ b/config/locales/views.fr.yml
@@ -354,8 +354,8 @@ fr:
         mark_all_as_seen: Tout marquer comme "vu"
         no_results: Aucun résultat
         select_all: Sélectionner tous les retours de la page
-        short_title: Retours
-        title: Retours des entreprises aidées
+        short_title: Satisfaction
+        title: Satisfaction des entreprises aidées
       need_card:
         comment_date: Retour de %{author}, le %{date}
         process: Marquer comme "vu"


### PR DESCRIPTION
fixes #4551

| Avant | Après |
|-|-|
| <img width="577" height="220" alt="image" src="https://github.com/user-attachments/assets/fef0f584-a90e-4d8f-9b8b-4e3b576def0d" /> | <img width="577" height="233" alt="image" src="https://github.com/user-attachments/assets/1cc1d567-dfdd-473c-929a-e4700e12cfd6" /> |

Le reste du texte parle de retours, mais ça reste pertinent (par exemple dans la phrase “Toute réutilisation de ces retours nécessite…”