### PR TITLE
Ajout d'un dev shell Nix

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -1,0 +1,27 @@
+{
+  "nodes": {
+    "nixpkgs": {
+      "locked": {
+        "lastModified": 1782118813,
+        "narHash": "sha256-BnbXO5s5EhV89lLXMAGCzPdEN5a6vNqvMk71obeTEUw=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "b3c092d3c36d91e2f61f3dfb39a159f180a56659",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixpkgs-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "root": {
+      "inputs": {
+        "nixpkgs": "nixpkgs"
+      }
+    }
+  },
+  "root": "root",
+  "version": 7
+}

--- a/flake.nix
+++ b/flake.nix
@@ -1,0 +1,27 @@
+{
+  description = "conseillers-entreprises dev shell";
+
+  inputs.nixpkgs.url = "github:NixOS/nixpkgs/nixpkgs-unstable";
+
+  outputs =
+    { nixpkgs, ... }:
+    let
+      pkgs = nixpkgs.legacyPackages.aarch64-darwin;
+    in
+    {
+      devShells.aarch64-darwin.default = pkgs.mkShell {
+        # pkg-config's setup hook auto-populates PKG_CONFIG_PATH from buildInputs,
+        # so native gems (pg, openssl, ffi) compile without manual flag exports.
+        nativeBuildInputs = [ pkgs.pkg-config ];
+
+        buildInputs = with pkgs; [
+          postgresql_17 # libpq headers/.pc + psql client
+          postgresql_17.pg_config # pg gem looks up pg_config first (separate output)
+          redis
+          openssl
+          libyaml # psych / native gems
+          libffi # ffi gem
+        ];
+      };
+    };
+}


### PR DESCRIPTION
J'ai migré mon ordinateur de Brew vers Nix, ça implique d'ajouter ces fichiers sinon Nix ne prend pas en compte les fichiers non ajouté à Git.

Ces deux fichiers fournissent un environnement de développement reproductible via Nix flakes, pour installer les bibliothèques système nécessaires à la compilation des gems natives.

`flake.nix` définit le dev shell. Il déclare les dépendances système. Il n'y a pas Ruby et Node parce que j'ai choisi de les laissés gérés par Mise pour le moment.

`flake.lock` verrouille les versions exactes de nixpkgs utilisées par flake.nix. Il garantit que tout le monde obtient les mêmes versions de paquets, comme un Gemfile.lock.