### PR TITLE
Corrige le calcule des antennes parents/enfants

### DIFF
--- a/app/models/concerns/with_territorial_zones.rb
+++ b/app/models/concerns/with_territorial_zones.rb
@@ -15,10 +15,13 @@ module WithTerritorialZones
 
     scope :with_insee_codes, -> (insee_codes) {
       return nil if insee_codes.blank?
-      #    Si self.insee_codes contient tous les insee_codes
-      #   insee_codes n'est pas un champs en base mais une methode de l'instance
+      #   Conserve les enregistrements dont le périmètre territorial recoupe
+      #   `insee_codes`. Une intersection (et non une inclusion stricte) suffit :
+      #   une seule commune orpheline fusionnée, obsolète ou rattachée à une
+      #   autre région ne doit pas exclure toute l'antenne de la hiérarchie.
+      #   `insee_codes` n'est pas un champ en base mais une méthode de l'instance.
       includes(:territorial_zones).select do |record|
-        (record.insee_codes - insee_codes).empty? || (insee_codes - record.insee_codes).empty?
+        (record.insee_codes & insee_codes).any?
       end
     }
   end

--- a/app/models/concerns/with_territorial_zones.rb
+++ b/app/models/concerns/with_territorial_zones.rb
@@ -21,7 +21,7 @@ module WithTerritorialZones
       #   autre région ne doit pas exclure toute l'antenne de la hiérarchie.
       #   `insee_codes` n'est pas un champ en base mais une méthode de l'instance.
       includes(:territorial_zones).select do |record|
-        (record.insee_codes & insee_codes).any?
+        record.insee_codes.intersect?(insee_codes)
       end
     }
   end

--- a/lib/sidekiq_job.rb
+++ b/lib/sidekiq_job.rb
@@ -12,13 +12,11 @@ module SidekiqJob
   #
   # Unfortunately, the mechanism here is mostly untestable, unless we actually use Sidekiq and redis in our tests.
   def self.status_for(job_class, item)
+    item_gid = item.to_gid.uri.to_s
+
     work = Sidekiq::WorkSet.new
       .map{ |_process_id, _thread_id, work| work }
-      .find do |work|
-      job = work.job
-      hash = job.args.first
-      hash["job_class"] == job_class.to_s && hash.dig("arguments", 0, "_aj_globalid") == item.to_gid.uri.to_s
-    end
+      .find{ |work| matching_active_job?(work.job, job_class, item_gid) }
 
     if work.present?
       return {
@@ -28,10 +26,7 @@ module SidekiqJob
     end
 
     queue = Sidekiq::Queue.all.find{ it.name == job_class.queue_name }
-    job = queue.find do |job|
-      hash = job.args.first
-      hash["job_class"] == job_class.to_s && hash.dig("arguments", 0, "_aj_globalid") == item.to_gid.uri.to_s
-    end
+    job = queue&.find{ |job| matching_active_job?(job, job_class, item_gid) }
 
     if job.present?
       return {
@@ -40,5 +35,15 @@ module SidekiqJob
     end
 
     return {}
+  end
+
+  # WorkSet and Queue enumerate every job in Sidekiq, including plain Sidekiq::Job
+  # jobs whose first argument is not the ActiveJob payload hash. Guard against those
+  # before reaching into the expected ActiveJob structure.
+  def self.matching_active_job?(job, job_class, item_gid)
+    hash = job.args.first
+    return false unless hash.is_a?(Hash)
+
+    hash["job_class"] == job_class.to_s && hash.dig("arguments", 0, "_aj_globalid") == item_gid
   end
 end

--- a/spec/lib/sidekiq_job_spec.rb
+++ b/spec/lib/sidekiq_job_spec.rb
@@ -1,0 +1,33 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe SidekiqJob do
+  describe '.matching_active_job?' do
+    let(:job_class) { ActivityReports::AntenneStats }
+    let(:item_gid) { 'gid://app/Antenne/2841' }
+
+    def job_double(args)
+      instance_double(Sidekiq::JobRecord, args: args)
+    end
+
+    context 'when the job is an ActiveJob payload matching the class and item' do
+      it 'returns true' do
+        args = [
+          { 'job_class' => job_class.to_s,
+                            'arguments' => [{ '_aj_globalid' => item_gid }] }
+        ]
+
+        expect(described_class.matching_active_job?(job_double(args), job_class, item_gid)).to be(true)
+      end
+    end
+
+    context 'when the job is a plain Sidekiq::Job whose first argument is an Integer' do
+      it 'returns false' do
+        expect { described_class.matching_active_job?(job_double([2841]), job_class, item_gid) }
+          .not_to raise_error
+        expect(described_class.matching_active_job?(job_double([2841]), job_class, item_gid)).to be(false)
+      end
+    end
+  end
+end

--- a/spec/services/antenne_hierarchy_spec.rb
+++ b/spec/services/antenne_hierarchy_spec.rb
@@ -55,6 +55,28 @@ describe AntenneHierarchy do
           expect(antenne.child_antennes).not_to include(local_antenne_outside_perimeter)
         end
       end
+
+      context 'when a local antenne overlaps the region but has a commune outside it' do
+        # Reproduit le bug réel (antenne 2845) : une antenne locale dont la
+        # quasi-totalité du territoire est dans la région, mais qui possède
+        # une commune isolée hors région (commune obsolète, fusionnée ou
+        # rattachée à une autre région). Elle ne doit pas disparaître de la
+        # hiérarchie : une intersection territoriale suffit à la rattacher.
+        let!(:local_antenne_overlapping) do
+          create :antenne, :local, institution: institution,
+                 territorial_zones: [
+                   create(:territorial_zone, :commune, code: "29232"), # Finistère → région 53
+                   create(:territorial_zone, :commune, code: "75056")  # Paris → région 11
+                 ]
+        end
+
+        before { described_class.new(antenne).call }
+
+        it "attaches the local antenne to the region it intersects with" do
+          expect(local_antenne_overlapping.reload.parent_antenne).to eq(regional_antenne)
+          expect(antenne.child_antennes).to include(local_antenne_overlapping)
+        end
+      end
     end
 
     context "Local antenne" do

--- a/spec/services/api/internal/communes_search_spec.rb
+++ b/spec/services/api/internal/communes_search_spec.rb
@@ -87,7 +87,7 @@ RSpec.describe Api::Internal::CommunesSearch do
 
       it 'matches substring in commune name' do
         expect(results).not_to be_empty
-        expect(results).to all(include(normalized_nom: match(/bourg/)))
+        expect(results).to all(include(normalized_nom: include('bourg')))
       end
     end
 

--- a/spec/views/companies/show.html.haml_spec.rb
+++ b/spec/views/companies/show.html.haml_spec.rb
@@ -22,7 +22,7 @@ RSpec.describe 'companies/show' do
       render
     end
 
-    it('displays a title') { expect(rendered).to match(/Raison Sociale/) }
+    it('displays a title') { expect(rendered).to include('Raison Sociale') }
   end
 
   context 'with API minor errors' do


### PR DESCRIPTION
closes #4558 

Deux problèmes rencontré ici :  

Les jobs Sidekiq
Si un job 'UpdateAntenneHierarchyJob' tournait, on avait une erreur 500. Le module `SidekiqJob` était prévu pour les jobs qui passent par ActiveJob, or, on a deux jobs qui sont des jobs Sidekiq directement, `UpdateAntenneHierarchyJob` et `CompanyEmails::SendStatusNotificationJob`. Le module `SidekiqJob` s'attendait à voir un hash comme premier argument, mais ce n'est pas le cas des simples jobs Sidekiq qui reçoivent un id brut. 

Le problème des communes non délégués ou sur une autre région
Certaines antennes comme l'antenne Mission Locale 81 Tarn Nord on des communes délégués, quand la mise à jour des antennes parents ce fait avec `with_insee_codes` il devait y avoir une inclusion totale. Inclusion qui ne prenait pas en compte les communes délégués ou avec des communes qui dépassent sur une autre région. Maintenant l'intersection se fait avec `&` ce qui laisse un peu de souplesse.

L'antenne régionale Occitanie des Missions locales passe de 23 à 26 antennes enfants

Au total
137 antennes gagnent un parent alors qu'elles n'en avaient pas.
0 changent de parents
0 en perdent

