### PR TITLE
Permettre aux sponsors d’accéder aux stats des antennes

### DIFF
--- a/app/assets/stylesheets/components/forms.sass
+++ b/app/assets/stylesheets/components/forms.sass
@@ -14,3 +14,10 @@ form
 .ss-content .ss-list .ss-option:not(.ss-disabled).ss-selected,
 .ss-content .ss-list .ss-option:hover
   background-color: base.$blue
+
+.ss-main.fr-select
+  margin-top: .5rem
+  padding: .5rem .5rem .5rem .5rem
+  border-radius: .25rem .25rem 0 0
+  background-color: var(--background-contrast-grey)
+  background-image: none

--- a/app/controllers/concerns/search_filters.rb
+++ b/app/controllers/concerns/search_filters.rb
@@ -40,7 +40,7 @@ module SearchFilters
   end
 
   def base_antennes
-    @base_antennes ||= BuildAntennesCollection.new(current_user).for_manager
+    @base_antennes ||= BuildAntennesCollection.new(current_user).for_manager_or_sponsor
   end
 
   def base_regions

--- a/app/controllers/reports_controller.rb
+++ b/app/controllers/reports_controller.rb
@@ -8,20 +8,19 @@ class ReportsController < ApplicationController
   layout 'side_menu', only: [:stats, :matches]
 
   def index
+    authorize :report
     redirect_to action: :stats, antenne_id: params[:antenne_id]
   end
 
-  def stats
-    authorize :report
-  end
+  def stats; end
 
   def matches
-    authorize :report
     @grouped_reports = @antenne.matches_reports.order(start_date: :desc).group_by{ |r| r.start_date.year }
   end
 
   def download
-    report = authorize ActivityReport.find(params.expect(:id)), policy_class: ReportPolicy
+    report = ActivityReport.find(params.expect(:id))
+    authorize report, "#{report.category}?", policy_class: ReportPolicy
 
     send_data report.file.download, type: "application/xlsx", filename: report.file.filename.to_s
   end
@@ -30,6 +29,10 @@ class ReportsController < ApplicationController
 
   def retrieve_antenne
     @antenne = Antenne.find(params.expect(:antenne_id))
+
+    report = @antenne.activity_reports.new(category: action_name)
+    authorize report, policy_class: ReportPolicy
+
     initialize_filters([:antennes])
   end
 

--- a/app/controllers/reports_controller.rb
+++ b/app/controllers/reports_controller.rb
@@ -8,7 +8,7 @@ class ReportsController < ApplicationController
   layout 'side_menu', only: [:stats, :matches]
 
   def index
-    authorize :report
+    authorize :activity_report
     redirect_to action: :stats, antenne_id: params[:antenne_id]
   end
 
@@ -20,7 +20,7 @@ class ReportsController < ApplicationController
 
   def download
     report = ActivityReport.find(params.expect(:id))
-    authorize report, "#{report.category}?", policy_class: ReportPolicy
+    authorize report, "#{report.category}?"
 
     send_data report.file.download, type: "application/xlsx", filename: report.file.filename.to_s
   end
@@ -31,7 +31,7 @@ class ReportsController < ApplicationController
     @antenne = Antenne.find(params.expect(:antenne_id))
 
     report = @antenne.activity_reports.new(category: action_name)
-    authorize report, policy_class: ReportPolicy
+    authorize report
 
     initialize_filters([:antennes])
   end

--- a/app/controllers/reports_controller.rb
+++ b/app/controllers/reports_controller.rb
@@ -28,7 +28,7 @@ class ReportsController < ApplicationController
     @antenne = if params[:antenne_id].present?
       Antenne.find(params.expect(:antenne_id))
     else
-      current_user.managed_antennes.by_higher_territorial_level.first
+      current_user.managed_antennes.by_higher_territorial_level.first || current_user.sponsored_institutions.first&.antennes&.first
     end
     authorize @antenne, policy_class: ReportPolicy
     initialize_filters([:antennes])

--- a/app/controllers/reports_controller.rb
+++ b/app/controllers/reports_controller.rb
@@ -19,12 +19,7 @@ class ReportsController < ApplicationController
   def download
     report = ActivityReport.find(params.expect(:id))
     authorize report, policy_class: ReportPolicy
-    respond_to do |format|
-      format.html
-      format.xlsx do
-        send_data report.file.download, type: "application/xlsx", filename: report.file.filename.to_s
-      end
-    end
+    send_data report.file.download, type: "application/xlsx", filename: report.file.filename.to_s
   end
 
   private

--- a/app/controllers/reports_controller.rb
+++ b/app/controllers/reports_controller.rb
@@ -18,7 +18,8 @@ class ReportsController < ApplicationController
 
   def download
     report = ActivityReport.find(params.expect(:id))
-    authorize report, policy_class: ReportPolicy
+    authorize report.antenne, "#{report.category}?", policy_class: ReportPolicy # report.category is 'matches' or 'stats' which maps to the ReportPolicy query names.
+
     send_data report.file.download, type: "application/xlsx", filename: report.file.filename.to_s
   end
 

--- a/app/controllers/reports_controller.rb
+++ b/app/controllers/reports_controller.rb
@@ -37,7 +37,6 @@ class ReportsController < ApplicationController
     end
     authorize @antenne, policy_class: ReportPolicy
     initialize_filters([:antennes])
-    @antennes_for_select = BuildAntennesCollection.new(current_user).for_manager
   end
 
   def retrieve_quarters

--- a/app/controllers/reports_controller.rb
+++ b/app/controllers/reports_controller.rb
@@ -11,15 +11,17 @@ class ReportsController < ApplicationController
     redirect_to action: :stats, antenne_id: params[:antenne_id]
   end
 
-  def stats; end
+  def stats
+    authorize :report
+  end
 
   def matches
+    authorize :report
     @grouped_reports = @antenne.matches_reports.order(start_date: :desc).group_by{ |r| r.start_date.year }
   end
 
   def download
-    report = ActivityReport.find(params.expect(:id))
-    authorize report.antenne, "#{report.category}?", policy_class: ReportPolicy # report.category is 'matches' or 'stats' which maps to the ReportPolicy query names.
+    report = authorize ActivityReport.find(params.expect(:id)), policy_class: ReportPolicy
 
     send_data report.file.download, type: "application/xlsx", filename: report.file.filename.to_s
   end
@@ -28,7 +30,6 @@ class ReportsController < ApplicationController
 
   def retrieve_antenne
     @antenne = Antenne.find(params.expect(:antenne_id))
-    authorize @antenne, policy_class: ReportPolicy
     initialize_filters([:antennes])
   end
 

--- a/app/controllers/reports_controller.rb
+++ b/app/controllers/reports_controller.rb
@@ -1,6 +1,7 @@
 class ReportsController < ApplicationController
   include SearchFilters
 
+  before_action :default_antenne_id, only: [:stats, :matches]
   before_action :retrieve_antenne, only: [:stats, :matches]
   before_action :retrieve_quarters, only: [:stats]
 
@@ -26,11 +27,7 @@ class ReportsController < ApplicationController
   private
 
   def retrieve_antenne
-    @antenne = if params[:antenne_id].present?
-      Antenne.find(params.expect(:antenne_id))
-    else
-      current_user.managed_antennes.by_higher_territorial_level.first || current_user.sponsored_institutions.first&.antennes&.first
-    end
+    @antenne = Antenne.find(params.expect(:antenne_id))
     authorize @antenne, policy_class: ReportPolicy
     initialize_filters([:antennes])
   end

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -48,4 +48,9 @@ module ApplicationHelper
 
     honeypot_html + timestamp_html
   end
+
+  # Format a hash of i18n key/values as data attributes to pass to a stimulus controller
+  def i18n_stimulus_values(controller, scope)
+    I18n.t(scope).transform_keys { |key| "data-#{controller.dasherize}-#{key.to_s.dasherize}-value" }
+  end
 end

--- a/app/javascript/application/controllers/index.js
+++ b/app/javascript/application/controllers/index.js
@@ -10,8 +10,6 @@ import CoverageController from "./coverage_controller"
 stimulus_app.register("coverage", CoverageController)
 import DiagnosisNeedsStepController from "./diagnosis_needs_step_controller"
 stimulus_app.register("diagnosis-needs-step", DiagnosisNeedsStepController)
-import DirectSubmitController from "./direct_submit_controller"
-stimulus_app.register("direct-submit", DirectSubmitController)
 import ExpertAutocompleteController from "./expert_autocomplete_controller"
 stimulus_app.register("expert-autocomplete", ExpertAutocompleteController)
 import FeedbackFormController from "./feedback_form_controller"

--- a/app/javascript/shared/controllers/direct_submit_controller.js
+++ b/app/javascript/shared/controllers/direct_submit_controller.js
@@ -2,7 +2,7 @@ import { Controller } from "stimulus";
 
 export default class extends Controller {
 
-  submit() {
-    this.element.submit()
+  submit(event) {
+    event.target.form.requestSubmit()
   }
 }

--- a/app/javascript/shared/controllers/index.js
+++ b/app/javascript/shared/controllers/index.js
@@ -6,6 +6,8 @@ import FiltersController from "./filters_controller"
 stimulus_app.register("filters", FiltersController)
 import InseeCodeController from "./insee_code_controller"
 stimulus_app.register("insee-code", InseeCodeController)
+import SlimSelectController from "./slim_select_controller"
+stimulus_app.register("slim-select", SlimSelectController)
 import StatsChartsController from "./stats_charts_controller"
 stimulus_app.register("stats-charts", StatsChartsController)
 

--- a/app/javascript/shared/controllers/index.js
+++ b/app/javascript/shared/controllers/index.js
@@ -2,6 +2,8 @@ import { stimulus_app } from "../stimulus_app"
 
 import BatchCheckController from "./batch_check_controller"
 stimulus_app.register("batch-check", BatchCheckController)
+import DirectSubmitController from "./direct_submit_controller"
+stimulus_app.register("direct-submit", DirectSubmitController)
 import FiltersController from "./filters_controller"
 stimulus_app.register("filters", FiltersController)
 import InseeCodeController from "./insee_code_controller"

--- a/app/javascript/shared/controllers/slim_select_controller.js
+++ b/app/javascript/shared/controllers/slim_select_controller.js
@@ -1,0 +1,18 @@
+import { Controller } from "stimulus";
+import SlimSelect from 'slim-select';
+
+export default class extends Controller {
+  connect() {
+    this.placeholderTextValue ||= 'Sélectionner'
+
+    new SlimSelect({
+      select: this.element,
+      settings: {
+        searchPlaceholder: 'Rechercher',
+        searchText: 'Pas de résultat',
+        searchingText: 'Recherche…',
+        placeholderText: 'Sélectionner',
+      }
+    })
+  }
+}

--- a/app/javascript/shared/controllers/slim_select_controller.js
+++ b/app/javascript/shared/controllers/slim_select_controller.js
@@ -2,16 +2,16 @@ import { Controller } from "stimulus";
 import SlimSelect from 'slim-select';
 
 export default class extends Controller {
-  connect() {
-    this.placeholderTextValue ||= 'Sélectionner'
+  static values = {searchPlaceholder: String, searchText: String, searchingText: String, placeholderText: String}
 
+  connect() {
     new SlimSelect({
       select: this.element,
       settings: {
-        searchPlaceholder: 'Rechercher',
-        searchText: 'Pas de résultat',
-        searchingText: 'Recherche…',
-        placeholderText: 'Sélectionner',
+        searchPlaceholder: this.searchPlaceholderValue,
+        searchText: this.searchTextValue,
+        searchingText: this.searchingTextValue,
+        placeholderText: this.placeholderTextValue,
       }
     })
   }

--- a/app/models/activity_report.rb
+++ b/app/models/activity_report.rb
@@ -26,6 +26,10 @@ class ActivityReport < ApplicationRecord
   belongs_to :antenne, -> { where(activity_reports: { reportable_type: 'Antenne' }) },
              foreign_key: 'reportable_id', inverse_of: :activity_reports, optional: true
 
+  def cooperation = (reportable if reportable_type == 'Cooperation')
+
+  def antenne = (reportable if reportable_type == 'Antenne')
+
   has_one_attached :file
 
   def period

--- a/app/policies/activity_report_policy.rb
+++ b/app/policies/activity_report_policy.rb
@@ -1,4 +1,4 @@
-class ReportPolicy < ApplicationPolicy
+class ActivityReportPolicy < ApplicationPolicy
   def index?
     @user&.is_admin? || @user&.is_manager? || @user&.is_sponsor?
   end

--- a/app/policies/activity_report_policy.rb
+++ b/app/policies/activity_report_policy.rb
@@ -11,10 +11,20 @@ class ActivityReportPolicy < ApplicationPolicy
     @user&.is_admin? || in_supervised_antennes?(@record.antenne)
   end
 
+  def cooperation?
+    @user&.is_admin? || in_managed_cooperation?(@record.cooperation) || in_sponsored_institutions?(@record.cooperation.institution)
+  end
+
+  alias solicitations? cooperation?
+
   private
 
   def in_supervised_antennes?(antenne)
     @user&.supervised_antennes&.include?(antenne)
+  end
+
+  def in_managed_cooperation?(cooperation)
+    @user&.managed_cooperations&.include?(cooperation)
   end
 
   def in_sponsored_institutions?(institution)

--- a/app/policies/report_policy.rb
+++ b/app/policies/report_policy.rb
@@ -1,10 +1,10 @@
 class ReportPolicy < ApplicationPolicy
   def index?
-    @user&.is_admin? || @user&.is_manager?
+    @user&.is_admin? || @user&.is_manager? || @user&.is_sponsor?
   end
 
   def stats?
-    @user&.is_admin? || in_supervised_antennes?(@record)
+    @user&.is_admin? || in_supervised_antennes?(@record) || in_sponsored_institutions?(@record)
   end
 
   def matches? = stats?
@@ -17,5 +17,9 @@ class ReportPolicy < ApplicationPolicy
 
   def in_supervised_antennes?(reportable)
     reportable.is_a?(Antenne) && @user&.supervised_antennes&.include?(reportable)
+  end
+
+  def in_sponsored_institutions?(reportable)
+    reportable.is_a?(Antenne) && @user&.sponsored_institutions&.include?(reportable.institution)
   end
 end

--- a/app/policies/report_policy.rb
+++ b/app/policies/report_policy.rb
@@ -1,6 +1,6 @@
 class ReportPolicy < ApplicationPolicy
   def index?
-    @user&.is_admin? || in_supervised_antennes?(@record) || @user&.is_manager?
+    @user&.is_admin? || @user&.is_manager?
   end
 
   def stats?

--- a/app/policies/report_policy.rb
+++ b/app/policies/report_policy.rb
@@ -1,25 +1,34 @@
 class ReportPolicy < ApplicationPolicy
-  # @record is not an ActivityReport, but an Antenne (or more generally a reportable)
-
   def index?
     @user&.is_admin? || @user&.is_manager? || @user&.is_sponsor?
   end
 
   def stats?
-    @user&.is_admin? || in_supervised_antennes?(@record) || in_sponsored_institutions?(@record)
+    @user&.is_admin? || @user&.is_manager? || @user&.is_sponsor?
   end
 
   def matches?
-    @user&.is_admin? || in_supervised_antennes?(@record)
+    @user&.is_admin? || @user&.is_manager?
+  end
+
+  def download?
+    case @record.category
+    when 'stats'
+      @user&.is_admin? || in_supervised_antennes?(@record.antenne) || in_sponsored_institutions?(@record.antenne.institution)
+    when 'matches'
+      @user&.is_admin? || in_supervised_antennes?(@record.antenne)
+    else
+      false
+    end
   end
 
   private
 
-  def in_supervised_antennes?(reportable)
-    reportable.is_a?(Antenne) && @user&.supervised_antennes&.include?(reportable)
+  def in_supervised_antennes?(antenne)
+    @user&.supervised_antennes&.include?(antenne)
   end
 
-  def in_sponsored_institutions?(reportable)
-    reportable.is_a?(Antenne) && @user&.sponsored_institutions&.include?(reportable.institution)
+  def in_sponsored_institutions?(institution)
+    @user&.sponsored_institutions&.include?(institution)
   end
 end

--- a/app/policies/report_policy.rb
+++ b/app/policies/report_policy.rb
@@ -7,7 +7,9 @@ class ReportPolicy < ApplicationPolicy
     @user&.is_admin? || in_supervised_antennes?(@record) || in_sponsored_institutions?(@record)
   end
 
-  def matches? = stats?
+  def matches?
+    @user&.is_admin? || in_supervised_antennes?(@record)
+  end
 
   def download?
     @user.is_admin? || in_supervised_antennes?(@record.reportable)

--- a/app/policies/report_policy.rb
+++ b/app/policies/report_policy.rb
@@ -16,7 +16,6 @@ class ReportPolicy < ApplicationPolicy
   private
 
   def in_supervised_antennes?(reportable)
-    reportable.is_a?(Antenne) &&
-    (@user.is_manager? && @user&.supervised_antennes&.include?(reportable))
+    reportable.is_a?(Antenne) && @user&.supervised_antennes&.include?(reportable)
   end
 end

--- a/app/policies/report_policy.rb
+++ b/app/policies/report_policy.rb
@@ -10,7 +10,7 @@ class ReportPolicy < ApplicationPolicy
   def matches? = stats?
 
   def download?
-    @user.is_admin? || in_supervised_antennes?(@record.reportable) || @record.reportable.managers.include?(@user)
+    @user.is_admin? || in_supervised_antennes?(@record.reportable)
   end
 
   private

--- a/app/policies/report_policy.rb
+++ b/app/policies/report_policy.rb
@@ -1,4 +1,6 @@
 class ReportPolicy < ApplicationPolicy
+  # @record is not an ActivityReport, but an Antenne (or more generally a reportable)
+
   def index?
     @user&.is_admin? || @user&.is_manager? || @user&.is_sponsor?
   end
@@ -9,10 +11,6 @@ class ReportPolicy < ApplicationPolicy
 
   def matches?
     @user&.is_admin? || in_supervised_antennes?(@record)
-  end
-
-  def download?
-    @user.is_admin? || in_supervised_antennes?(@record.reportable)
   end
 
   private

--- a/app/policies/report_policy.rb
+++ b/app/policies/report_policy.rb
@@ -4,22 +4,11 @@ class ReportPolicy < ApplicationPolicy
   end
 
   def stats?
-    @user&.is_admin? || @user&.is_manager? || @user&.is_sponsor?
+    @user&.is_admin? || in_supervised_antennes?(@record.antenne) || in_sponsored_institutions?(@record.antenne.institution)
   end
 
   def matches?
-    @user&.is_admin? || @user&.is_manager?
-  end
-
-  def download?
-    case @record.category
-    when 'stats'
-      @user&.is_admin? || in_supervised_antennes?(@record.antenne) || in_sponsored_institutions?(@record.antenne.institution)
-    when 'matches'
-      @user&.is_admin? || in_supervised_antennes?(@record.antenne)
-    else
-      false
-    end
+    @user&.is_admin? || in_supervised_antennes?(@record.antenne)
   end
 
   private

--- a/app/services/build_antennes_collection.rb
+++ b/app/services/build_antennes_collection.rb
@@ -57,6 +57,7 @@ class BuildAntennesCollection
     user.managed_antennes.territorial_level_national.each do |antenne|
       antennes_ids << Antenne.where(institution: antenne.institution, territorial_level: :regional).not_deleted.ids
     end
+    antennes_ids << Antenne.where(institution: user.sponsored_institutions).not_deleted.ids
     Antenne.where(id: antennes_ids.flatten)
   end
 end

--- a/app/services/build_antennes_collection.rb
+++ b/app/services/build_antennes_collection.rb
@@ -7,6 +7,8 @@ class BuildAntennesCollection
   def for_manager_or_sponsor
     manager_antennes = manager_antennes_included_regionals
     antennes_collection = antennes_collection_hash(Antenne.not_deleted, manager_antennes)
+    sponsor_antennes = Antenne.where(institution: user.sponsored_institutions).territorial_level_national.not_deleted
+    antennes_collection += sponsor_antennes.map { |a| { name: a.name, id: a.id, territorial_level: Antenne::TERRITORIAL_ORDER[a.territorial_level.to_sym] } }
     add_locals_antennes(antennes_collection, manager_antennes)
   end
 
@@ -57,7 +59,6 @@ class BuildAntennesCollection
     user.managed_antennes.territorial_level_national.each do |antenne|
       antennes_ids << Antenne.where(institution: antenne.institution, territorial_level: :regional).not_deleted.ids
     end
-    antennes_ids << Antenne.where(institution: user.sponsored_institutions).not_deleted.ids
     Antenne.where(id: antennes_ids.flatten)
   end
 end

--- a/app/services/build_antennes_collection.rb
+++ b/app/services/build_antennes_collection.rb
@@ -4,7 +4,7 @@ class BuildAntennesCollection
     @item = item
   end
 
-  def for_manager
+  def for_manager_or_sponsor
     manager_antennes = manager_antennes_included_regionals
     antennes_collection = antennes_collection_hash(Antenne.not_deleted, manager_antennes)
     add_locals_antennes(antennes_collection, manager_antennes)

--- a/app/views/application/navbar/_app.html.haml
+++ b/app/views/application/navbar/_app.html.haml
@@ -15,7 +15,7 @@
           %span.count-notification.count-notification--green.fr-tag.fr-tag--sm.fr-ml-1w#counter-unseen-nav= current_user.shared_satisfactions.unseen.size
   - if policy([:manager, :stats]).index?
     = navbar_item manager_stats_path, t('.stats'), 'ri-line-chart-line'
-  - if policy(:report).index?
+  - if policy(:activity_report).index?
     = navbar_item reports_path, t('.reports'), 'ri-file-text-line'
   - if policy(:cooperation).index?
     %li.fr-nav__item

--- a/app/views/conseiller/sitemap/sitemap.html.haml
+++ b/app/views/conseiller/sitemap/sitemap.html.haml
@@ -18,7 +18,7 @@
     - if policy([:manager, :needs]).index?
       %li
         = link_to current_user.managed_antennes.many? ? t('application.navbar.antennes_needs') : t('application.navbar.antenne_needs'), manager_needs_path
-    - if policy(:report).index?
+    - if policy(:activity_report).index?
       %li
         = link_to t('application.navbar.app.reports'), reports_path
 

--- a/app/views/reports/_menu.html.haml
+++ b/app/views/reports/_menu.html.haml
@@ -5,7 +5,7 @@
 %ul.fr-sidemenu__list
   - [:stats, :matches].each do |key|
     - report = antenne.activity_reports.new(category: key)
-    - if ReportPolicy.new(current_user, report).send("#{key}?")
+    - if policy(report).send("#{key}?")
       %li.fr-sidemenu__item.item-with-tag
         - url = polymorphic_path([key, :reports].compact, antenne_id: antenne.id)
         = active_link_to(url, class: 'fr-sidemenu__link', class_active: 'fr-sidemenu__item--active') do

--- a/app/views/reports/_menu.html.haml
+++ b/app/views/reports/_menu.html.haml
@@ -2,7 +2,8 @@
   /besoins(/antenne)/:collection_name
 %ul.fr-sidemenu__list
   - [:stats, :matches].each do |key|
-    %li.fr-sidemenu__item.item-with-tag
-      - url = polymorphic_path([key, :reports].compact, antenne_id: antenne_id)
-      = active_link_to(url, class: 'fr-sidemenu__link', class_active: 'fr-sidemenu__item--active') do
-        = t(key, scope: 'reports.sidemenu')
+    - if policy(:report).send("#{key}?")
+      %li.fr-sidemenu__item.item-with-tag
+        - url = polymorphic_path([key, :reports].compact, antenne_id: antenne_id)
+        = active_link_to(url, class: 'fr-sidemenu__link', class_active: 'fr-sidemenu__item--active') do
+          = t(key, scope: 'reports.sidemenu')

--- a/app/views/reports/_menu.html.haml
+++ b/app/views/reports/_menu.html.haml
@@ -1,9 +1,12 @@
--# Dynamically build the path for each of the collections. Paths look like this:
+-# locals: (antenne:)
+
+  Dynamically build the path for each of the collections. Paths look like this:
   /besoins(/antenne)/:collection_name
 %ul.fr-sidemenu__list
   - [:stats, :matches].each do |key|
-    - if policy(:report).send("#{key}?")
+    - report = antenne.activity_reports.new(category: key)
+    - if ReportPolicy.new(current_user, report).send("#{key}?")
       %li.fr-sidemenu__item.item-with-tag
-        - url = polymorphic_path([key, :reports].compact, antenne_id: antenne_id)
+        - url = polymorphic_path([key, :reports].compact, antenne_id: antenne.id)
         = active_link_to(url, class: 'fr-sidemenu__link', class_active: 'fr-sidemenu__item--active') do
           = t(key, scope: 'reports.sidemenu')

--- a/app/views/reports/_search.haml
+++ b/app/views/reports/_search.haml
@@ -2,7 +2,8 @@
   .fr-grid-row.fr-grid-row--gutters
     .fr-col
       = f.label :antenne_id, t('filters.select_antenne'), class: 'fr-label'
-      = f.select :antenne_id, options_for_select(filters[:antennes].pluck(:name, :id), selected: antenne.id), {}, class: "fr-select fr-mb-2v"
+      - options = options_for_select(filters[:antennes].pluck(:name, :id), selected: antenne.id)
+      = f.select :antenne_id, options, {}, class: "fr-select fr-mb-2v", data: { controller: "slim-select" }
 
   .fr-grid-row.fr-grid-row--gutters
     .fr-col-12.fr-col-md-6.fr-col-offset-md-6.text-right

--- a/app/views/reports/_search.haml
+++ b/app/views/reports/_search.haml
@@ -4,12 +4,7 @@
       = f.label :antenne_id, t('filters.select_antenne'), class: 'fr-label'
       - options = options_for_select(filters[:antennes].pluck(:name, :id), selected: antenne.id)
       = f.select :antenne_id, options, {}, class: "fr-select fr-mb-2v",
-        data: { controller: "slim-select direct-submit",
-          slim_select_search_placeholder_value: t("helpers.slim_select.search_placeholder"),
-          slim_select_search_text_value: t("helpers.slim_select.search_text"),
-          slim_select_searching_text_value: t("helpers.slim_select.searching_text"),
-          slim_select_placeholder_text_value: t("helpers.slim_select.placeholder_text"),
-         action: "direct-submit#submit" }
+        data: { controller: "slim-select direct-submit", action: "direct-submit#submit" }, **i18n_stimulus_values("slim-select", "helpers.slim_select")
 
   .fr-grid-row.fr-grid-row--gutters
     .fr-col-12.fr-col-md-6.fr-col-offset-md-6.text-right

--- a/app/views/reports/_search.haml
+++ b/app/views/reports/_search.haml
@@ -3,7 +3,13 @@
     .fr-col
       = f.label :antenne_id, t('filters.select_antenne'), class: 'fr-label'
       - options = options_for_select(filters[:antennes].pluck(:name, :id), selected: antenne.id)
-      = f.select :antenne_id, options, {}, class: "fr-select fr-mb-2v", data: { controller: "slim-select direct-submit", action: "direct-submit#submit" }
+      = f.select :antenne_id, options, {}, class: "fr-select fr-mb-2v",
+        data: { controller: "slim-select direct-submit",
+          slim_select_search_placeholder_value: t("helpers.slim_select.search_placeholder"),
+          slim_select_search_text_value: t("helpers.slim_select.search_text"),
+          slim_select_searching_text_value: t("helpers.slim_select.searching_text"),
+          slim_select_placeholder_text_value: t("helpers.slim_select.placeholder_text"),
+         action: "direct-submit#submit" }
 
   .fr-grid-row.fr-grid-row--gutters
     .fr-col-12.fr-col-md-6.fr-col-offset-md-6.text-right

--- a/app/views/reports/_search.haml
+++ b/app/views/reports/_search.haml
@@ -3,7 +3,7 @@
     .fr-col
       = f.label :antenne_id, t('filters.select_antenne'), class: 'fr-label'
       - options = options_for_select(filters[:antennes].pluck(:name, :id), selected: antenne.id)
-      = f.select :antenne_id, options, {}, class: "fr-select fr-mb-2v", data: { controller: "slim-select" }
+      = f.select :antenne_id, options, {}, class: "fr-select fr-mb-2v", data: { controller: "slim-select direct-submit", action: "direct-submit#submit" }
 
   .fr-grid-row.fr-grid-row--gutters
     .fr-col-12.fr-col-md-6.fr-col-offset-md-6.text-right

--- a/app/views/reports/matches.html.haml
+++ b/app/views/reports/matches.html.haml
@@ -1,7 +1,7 @@
 - title = t('.title', antenne: @antenne.name)
 - meta title: title
 - content_for :header, render('header', base: t('application.navbar.app.reports'), title: title)
-- content_for :menu, render('menu', antenne_id: @antenne.id)
+- content_for :menu, render('menu', antenne: @antenne)
 - content_for :search, render('search', filters: @filters, antenne: @antenne)
 
 - if @grouped_reports.present?

--- a/app/views/reports/stats.html.haml
+++ b/app/views/reports/stats.html.haml
@@ -1,7 +1,7 @@
 - title = t('.title', antenne: @antenne.name)
 - meta title: title
 - content_for :header, render('header', base: t('application.navbar.app.reports'), title: title)
-- content_for :menu, render('menu', antenne_id: @antenne.id)
+- content_for :menu, render('menu', antenne: @antenne)
 - content_for :search, render('search', filters: @filters, antenne: @antenne)
 
 - if @quarters.present?

--- a/config/locales/fr.yml
+++ b/config/locales/fr.yml
@@ -206,6 +206,11 @@ fr:
   helpers:
     select:
       prompt: Veuillez sélectionner
+    slim_select:
+      placeholder_text: Sélectionner
+      search_placeholder: Rechercher
+      search_text: Pas de résultat
+      searching_text: Recherche…
     submit:
       create: Créer un(e) %{model}
       submit: Enregistrer ce(tte) %{model}

--- a/spec/policies/activity_report_policy_spec.rb
+++ b/spec/policies/activity_report_policy_spec.rb
@@ -1,6 +1,6 @@
 require 'rails_helper'
 
-RSpec.describe ReportPolicy, :aggregate_failures, type: :policy do
+RSpec.describe ActivityReportPolicy, :aggregate_failures, type: :policy do
   subject { described_class }
 
   let(:antenne) { create :antenne }

--- a/spec/policies/report_policy_spec.rb
+++ b/spec/policies/report_policy_spec.rb
@@ -16,6 +16,12 @@ RSpec.describe ReportPolicy, type: :policy do
       it { is_expected.to permit(user) }
     end
 
+    context "grants access if user is a sponsor" do
+      let(:user) { create :user, :sponsor }
+
+      it { is_expected.to permit(user) }
+    end
+
     context "denies access if user is another user" do
       let(:user) { create :user }
 
@@ -34,6 +40,12 @@ RSpec.describe ReportPolicy, type: :policy do
 
     context "grants access if antenne is in user managed antennes" do
       let(:user) { create :user, :manager, managed_antennes: [antenne] }
+
+      it { is_expected.to permit(user, antenne) }
+    end
+
+    context "grants access if user is a sponsor" do
+      let(:user) { create :user, :sponsor, sponsored_institutions: [antenne.institution] }
 
       it { is_expected.to permit(user, antenne) }
     end

--- a/spec/policies/report_policy_spec.rb
+++ b/spec/policies/report_policy_spec.rb
@@ -10,7 +10,10 @@ RSpec.describe ReportPolicy, :aggregate_failures, type: :policy do
   let(:sponsor) { create :user, :sponsor, sponsored_institutions: [antenne.institution] }
   let(:other_user) { create :user }
 
-  permissions :index? do
+  let(:matches_report) { create :activity_report, :category_matches, reportable: antenne }
+  let(:stats_report) { create :activity_report, :category_stats, reportable: antenne }
+
+  permissions :index?, :stats? do
     it "grants access to admins, managers and sponsors" do
       is_expected.to permit(admin)
       is_expected.to permit(manager)
@@ -19,21 +22,32 @@ RSpec.describe ReportPolicy, :aggregate_failures, type: :policy do
     end
   end
 
-  permissions :stats? do
-    it "grants access to admins, managers and sponsors of the antenne" do
-      is_expected.to permit(admin, antenne)
-      is_expected.to permit(manager, antenne)
-      is_expected.to permit(sponsor, antenne)
+  permissions :matches? do
+    it "grants access to admins and managers of the antenne" do
+      is_expected.to permit(admin)
+      is_expected.to permit(manager)
+      is_expected.not_to permit(sponsor)
       is_expected.not_to permit(other_user)
     end
   end
 
-  permissions :matches? do
-    it "grants access to admins and managers of the antenne" do
-      is_expected.to permit(admin, antenne)
-      is_expected.to permit(manager, antenne)
-      is_expected.not_to permit(sponsor, antenne)
-      is_expected.not_to permit(other_user, antenne)
+  permissions :download? do
+    context "matches report" do
+      it "grants access to admins, managers of the antenne" do
+        is_expected.to permit(admin, matches_report)
+        is_expected.to permit(manager, matches_report)
+        is_expected.not_to permit(sponsor, matches_report)
+        is_expected.not_to permit(other_user, matches_report)
+      end
+    end
+
+    context "stats report" do
+      it "grants access to admins, managers and sponsors of the antenne" do
+        is_expected.to permit(admin, stats_report)
+        is_expected.to permit(manager, stats_report)
+        is_expected.to permit(sponsor, stats_report)
+        is_expected.not_to permit(other_user, stats_report)
+      end
     end
   end
 end

--- a/spec/policies/report_policy_spec.rb
+++ b/spec/policies/report_policy_spec.rb
@@ -1,88 +1,39 @@
 require 'rails_helper'
 
-RSpec.describe ReportPolicy, type: :policy do
+RSpec.describe ReportPolicy, :aggregate_failures, type: :policy do
   subject { described_class }
 
+  let(:antenne) { create :antenne }
+
+  let(:admin) { create :user, :admin }
+  let(:manager) { create :user, :manager, managed_antennes: [antenne] }
+  let(:sponsor) { create :user, :sponsor, sponsored_institutions: [antenne.institution] }
+  let(:other_user) { create :user }
+
   permissions :index? do
-    context "grants access if user is an admin" do
-      let(:user) { create :user, :admin }
-
-      it { is_expected.to permit(user) }
-    end
-
-    context "grants access if user is a manager" do
-      let(:user) { create :user, :manager }
-
-      it { is_expected.to permit(user) }
-    end
-
-    context "grants access if user is a sponsor" do
-      let(:user) { create :user, :sponsor }
-
-      it { is_expected.to permit(user) }
-    end
-
-    context "denies access if user is another user" do
-      let(:user) { create :user }
-
-      it { is_expected.not_to permit(user) }
+    it "grants access to admins, managers and sponsors" do
+      is_expected.to permit(admin)
+      is_expected.to permit(manager)
+      is_expected.to permit(sponsor)
+      is_expected.not_to permit(other_user)
     end
   end
 
   permissions :stats? do
-    let(:antenne) { create :antenne }
-
-    context "grant access if user is an admin" do
-      let(:user) { create :user, :admin }
-
-      it { is_expected.to permit(user, antenne) }
-    end
-
-    context "grants access if antenne is in user managed antennes" do
-      let(:user) { create :user, :manager, managed_antennes: [antenne] }
-
-      it { is_expected.to permit(user, antenne) }
-    end
-
-    context "grants access if user is a sponsor" do
-      let(:user) { create :user, :sponsor, sponsored_institutions: [antenne.institution] }
-
-      it { is_expected.to permit(user, antenne) }
-    end
-
-    context "denies access if user is another user" do
-      let(:user) { create :user }
-
-      it { is_expected.not_to permit(user, antenne) }
+    it "grants access to admins, managers and sponsors of the antenne" do
+      is_expected.to permit(admin, antenne)
+      is_expected.to permit(manager, antenne)
+      is_expected.to permit(sponsor, antenne)
+      is_expected.not_to permit(other_user)
     end
   end
 
   permissions :matches? do
-    let(:antenne) { create :antenne }
-
-    context "grant access if user is an admin" do
-      let(:user) { create :user, :admin }
-
-      it { is_expected.to permit(user, antenne) }
-    end
-
-    context "grants access if antenne is in user managed antennes" do
-      let(:user) { create :user, :manager, managed_antennes: [antenne] }
-
-      it { is_expected.to permit(user, antenne) }
-    end
-
-    context "denies access if user is a sponsor" do
-      let(:user) { create :user, :sponsor, sponsored_institutions: [antenne.institution] }
-
-      it { is_expected.not_to permit(user) }
-    end
-
-
-    context "denies access if user is another user" do
-      let(:user) { create :user }
-
-      it { is_expected.not_to permit(user, antenne) }
+    it "grants access to admins and managers of the antenne" do
+      is_expected.to permit(admin, antenne)
+      is_expected.to permit(manager, antenne)
+      is_expected.not_to permit(sponsor, antenne)
+      is_expected.not_to permit(other_user, antenne)
     end
   end
 end

--- a/spec/policies/report_policy_spec.rb
+++ b/spec/policies/report_policy_spec.rb
@@ -85,4 +85,33 @@ RSpec.describe ReportPolicy, type: :policy do
       it { is_expected.not_to permit(user, activity_report) }
     end
   end
+
+  permissions :matches? do
+    let(:antenne) { create :antenne }
+
+    context "grant access if user is an admin" do
+      let(:user) { create :user, :admin }
+
+      it { is_expected.to permit(user, antenne) }
+    end
+
+    context "grants access if antenne is in user managed antennes" do
+      let(:user) { create :user, :manager, managed_antennes: [antenne] }
+
+      it { is_expected.to permit(user, antenne) }
+    end
+
+    context "denies access if user is a sponsor" do
+      let(:user) { create :user, :sponsor, sponsored_institutions: [antenne.institution] }
+
+      it { is_expected.not_to permit(user) }
+    end
+
+
+    context "denies access if user is another user" do
+      let(:user) { create :user }
+
+      it { is_expected.not_to permit(user, antenne) }
+    end
+  end
 end

--- a/spec/policies/report_policy_spec.rb
+++ b/spec/policies/report_policy_spec.rb
@@ -13,7 +13,7 @@ RSpec.describe ReportPolicy, :aggregate_failures, type: :policy do
   let(:matches_report) { create :activity_report, :category_matches, reportable: antenne }
   let(:stats_report) { create :activity_report, :category_stats, reportable: antenne }
 
-  permissions :index?, :stats? do
+  permissions :index? do
     it "grants access to admins, managers and sponsors" do
       is_expected.to permit(admin)
       is_expected.to permit(manager)
@@ -22,32 +22,21 @@ RSpec.describe ReportPolicy, :aggregate_failures, type: :policy do
     end
   end
 
-  permissions :matches? do
-    it "grants access to admins and managers of the antenne" do
-      is_expected.to permit(admin)
-      is_expected.to permit(manager)
-      is_expected.not_to permit(sponsor)
-      is_expected.not_to permit(other_user)
+  permissions :stats? do
+    it "grants access to admins, managers and sponsors of the antenne" do
+      is_expected.to permit(admin, stats_report)
+      is_expected.to permit(manager, stats_report)
+      is_expected.to permit(sponsor, stats_report)
+      is_expected.not_to permit(other_user, stats_report)
     end
   end
 
-  permissions :download? do
-    context "matches report" do
-      it "grants access to admins, managers of the antenne" do
-        is_expected.to permit(admin, matches_report)
-        is_expected.to permit(manager, matches_report)
-        is_expected.not_to permit(sponsor, matches_report)
-        is_expected.not_to permit(other_user, matches_report)
-      end
-    end
-
-    context "stats report" do
-      it "grants access to admins, managers and sponsors of the antenne" do
-        is_expected.to permit(admin, stats_report)
-        is_expected.to permit(manager, stats_report)
-        is_expected.to permit(sponsor, stats_report)
-        is_expected.not_to permit(other_user, stats_report)
-      end
+  permissions :matches? do
+    it "grants access to admins and managers of the antenne" do
+      is_expected.to permit(admin, matches_report)
+      is_expected.to permit(manager, matches_report)
+      is_expected.not_to permit(sponsor, matches_report)
+      is_expected.not_to permit(other_user, matches_report)
     end
   end
 end

--- a/spec/policies/report_policy_spec.rb
+++ b/spec/policies/report_policy_spec.rb
@@ -57,35 +57,6 @@ RSpec.describe ReportPolicy, type: :policy do
     end
   end
 
-  permissions :download? do
-    let(:antenne) { create :antenne }
-    let!(:activity_report) { create :activity_report, :category_matches, reportable: antenne }
-
-    context "grant access if user is an admin" do
-      let(:user) { create :user, :admin }
-
-      it { is_expected.to permit(user, activity_report) }
-    end
-
-    context "grants access if user is a region manager for his antenne report" do
-      let(:user) { create :user, :manager, antenne: antenne }
-
-      it { is_expected.to permit(user, activity_report) }
-    end
-
-    context "denies access if user is a region manager for another antenne report" do
-      let(:user) { create :user, :manager, antenne: create(:antenne) }
-
-      it { is_expected.not_to permit(user, activity_report) }
-    end
-
-    context "denies access if user is another user" do
-      let(:user) { create :user, antenne: antenne }
-
-      it { is_expected.not_to permit(user, activity_report) }
-    end
-  end
-
   permissions :matches? do
     let(:antenne) { create :antenne }
 

--- a/spec/services/build_antennes_collection_spec.rb
+++ b/spec/services/build_antennes_collection_spec.rb
@@ -123,8 +123,7 @@ describe BuildAntennesCollection do
         let!(:expert_subject_national) { create :expert_subject, expert: national_expert }
 
         it do
-          is_expected.to contain_exactly({ name: national_antenne.name, id: "#{national_antenne.id}-aggregate", territorial_level: 0 },
-                                         { name: local_antenne.name, id: local_antenne.id, territorial_level: 2 })
+          is_expected.to contain_exactly({ name: national_antenne.name, id: national_antenne.id, territorial_level: 0 })
         end
       end
 
@@ -134,8 +133,7 @@ describe BuildAntennesCollection do
         let!(:expert_subject) { create :expert_subject, expert: expert }
 
         it do
-          is_expected.to contain_exactly({ name: national_antenne.name, id: "#{national_antenne.id}-aggregate", territorial_level: 0 },
-                                         { name: local_antenne.name, id: local_antenne.id, territorial_level: 2 })
+          is_expected.to contain_exactly({ name: national_antenne.name, id: national_antenne.id, territorial_level: 0 })
         end
       end
 
@@ -147,10 +145,7 @@ describe BuildAntennesCollection do
 
         it do
           is_expected.to contain_exactly(
-            { name: national_antenne.name, id: "#{national_antenne.id}-aggregate", territorial_level: 0 },
-                           { name: regional_antenne.name, id: regional_antenne.id.to_s, territorial_level: 1 },
-                           { name: "#{regional_antenne.name}#{I18n.t('helpers.stats_helper.with_locales')}", id: "#{regional_antenne.id}-aggregate", territorial_level: 1 },
-                           { name: local_antenne.name, id: local_antenne.id, territorial_level: 2 }
+            { name: national_antenne.name, id: national_antenne.id, territorial_level: 0 }
           )
         end
       end

--- a/spec/services/build_antennes_collection_spec.rb
+++ b/spec/services/build_antennes_collection_spec.rb
@@ -1,11 +1,11 @@
 require 'rails_helper'
 
 describe BuildAntennesCollection do
-  describe "for_manager" do
+  describe "for_manager_or_sponsor" do
     let(:current_user) { create :user }
     let(:institution) { create :institution }
 
-    subject { described_class.new(current_user).for_manager }
+    subject { described_class.new(current_user).for_manager_or_sponsor }
 
     context 'Regional antenne' do
       let(:regional_antenne) { create :antenne, :regional, institution: institution }

--- a/spec/services/build_antennes_collection_spec.rb
+++ b/spec/services/build_antennes_collection_spec.rb
@@ -102,5 +102,58 @@ describe BuildAntennesCollection do
         end
       end
     end
+
+    context 'Sponsored antenne' do
+      let(:national_antenne) { create :antenne, :national, institution: institution }
+
+      before { current_user.sponsored_institutions << [national_antenne.institution] }
+
+      context 'Antenne national sans antennes locales' do
+        let!(:expert) { create :expert_with_users, antenne: national_antenne }
+        let!(:expert_subject) { create :expert_subject, expert: expert }
+
+        it { is_expected.to contain_exactly({ name: national_antenne.name, id: national_antenne.id, territorial_level: 0 }) }
+      end
+
+      context 'Antenne national avec des experts avec des antennes locales' do
+        let!(:local_antenne) { create :antenne, :local, institution: institution }
+        let!(:local_expert) { create :expert_with_users, antenne: local_antenne }
+        let!(:national_expert) { create :expert_with_users, antenne: national_antenne }
+        let!(:expert_subject_local) { create :expert_subject, expert: local_expert }
+        let!(:expert_subject_national) { create :expert_subject, expert: national_expert }
+
+        it do
+          is_expected.to contain_exactly({ name: national_antenne.name, id: "#{national_antenne.id}-aggregate", territorial_level: 0 },
+                                         { name: local_antenne.name, id: local_antenne.id, territorial_level: 2 })
+        end
+      end
+
+      context 'Antenne national sans expert avec des antennes locales' do
+        let!(:local_antenne) { create :antenne, :local, institution: institution }
+        let!(:expert) { create :expert_with_users, antenne: local_antenne }
+        let!(:expert_subject) { create :expert_subject, expert: expert }
+
+        it do
+          is_expected.to contain_exactly({ name: national_antenne.name, id: "#{national_antenne.id}-aggregate", territorial_level: 0 },
+                                         { name: local_antenne.name, id: local_antenne.id, territorial_level: 2 })
+        end
+      end
+
+      context "Antenne national sans expert avec des antennes regionales qui ont des antennes locales" do
+        let!(:local_antenne) { create :antenne, :local, institution: institution, parent_antenne: regional_antenne }
+        let!(:regional_antenne) { create :antenne, :regional, institution: institution, parent_antenne: national_antenne }
+        let!(:expert) { create :expert_with_users, antenne: local_antenne }
+        let!(:expert_subject) { create :expert_subject, expert: expert }
+
+        it do
+          is_expected.to contain_exactly(
+            { name: national_antenne.name, id: "#{national_antenne.id}-aggregate", territorial_level: 0 },
+                           { name: regional_antenne.name, id: regional_antenne.id.to_s, territorial_level: 1 },
+                           { name: "#{regional_antenne.name}#{I18n.t('helpers.stats_helper.with_locales')}", id: "#{regional_antenne.id}-aggregate", territorial_level: 1 },
+                           { name: local_antenne.name, id: local_antenne.id, territorial_level: 2 }
+          )
+        end
+      end
+    end
   end
 end


### PR DESCRIPTION
fixes #4553

Ça ressemble à ça, il y a un champ de recherche:

<img width="1332" height="581" alt="image" src="https://github.com/user-attachments/assets/7e9a5c3f-9cd0-4c04-8108-4a72b981557a" />

- J’utilise slim-select pour la sélection d’Antennes, parce que la liste peut être longue.
- J’ai aussi mis un commit (et revert) d’une version expérimentale d’une page d’index séparée, mais ça me semble moins bien.

WIP, il reste à:
- [x] Changer la page dès qu’on clique sur l’Antenne dans le select, sans cliquer sur `Rechercher`.
- [x] ajouter quelques cas de tests unitaires aux méthodes de recherche et de policy que j’ai modifiées
- [x] réusiner ReportPolicy? J’ai un peu simplifié, mais elle est bizarre, parce que son `@record` n’est pas un report (mais un reportable) sauf dans la méthode `#download?`
  - [x] Qui d’ailleurs ne fait pas de différence de permission selon le type de report, alors qu’on ne veut donner accès qu’aux `stats`, pas aux `matches`.
- [x] Essayer d’utiliser `SearchFilter#default_antenne_id` pour obtenir l’antenne par défaut dans `ReportController#retrieve_antenne`, ça semblerait plus cohérent.
- [x] ~~Voir si je veux nettoyer `BuildAntennesCollection` en passant, c’est bizarre ce truc qui prend soit une `Institution`, soit un `User` comme paramètre.~~