### PR TITLE
Permettre à plus de comptes d’accéder aux stats des coopérations

### DIFF
--- a/app/admin/cooperation.rb
+++ b/app/admin/cooperation.rb
@@ -98,7 +98,7 @@ ActiveAdmin.register Cooperation do
   end
 
   sidebar I18n.t('active_admin.reports.title'), only: [:show, :edit] do
-    div link_to t('active_admin.reports.view_reports_app_page'), reports_conseiller_cooperations_path(cooperation_id: resource.id)
+    div link_to t('active_admin.reports.view_reports_app_page'), reports_conseiller_cooperation_path(resource)
     hr
     activity_report_sidebar_contents(ActivityReports::CooperationStats.new(resource))
     hr

--- a/app/admin/cooperation.rb
+++ b/app/admin/cooperation.rb
@@ -59,7 +59,8 @@ ActiveAdmin.register Cooperation do
         div admin_link_to(c, :landings, list: true)
       end
       row(:managers) do |c|
-        div admin_link_to(c, :managers, list: true)
+        name_proc = -> (manager) { manager.institution == c.institution ? manager : "#{manager} (#{manager.institution})" }
+        div admin_link_to(c, :managers, list: true, name: name_proc)
       end
     end
   end

--- a/app/admin/helpers/admin_link_to.rb
+++ b/app/admin/helpers/admin_link_to.rb
@@ -3,10 +3,28 @@ module Admin
     ## Additional helpers for the objects links and attributes within /admin
     #
     module AdminLinkTo
+      # link to objects in admin. Examples:
+      # - simple link: `admin_link_to user123`
+      # - to-one relation: `admin_link_to user123, :institution`
+      # - to-many relation, display the count of items and link to the table: `admin_link_to user123, :feedbacks`
+      # - to-many relation, one link per item: `admin_link_to user123, :feedbacks, list: true`
+      # The :name option can be used to customize the text of the link.
+      # - admin_link_to user123, "static text"
+      # - admin_link_to user123, -> (user) { user.full_name }
       def admin_link_to(object, association = nil, options = {})
+        name_proc = if options[:name].present?
+          if options[:name].respond_to?(:call)
+            options[:name]
+          else
+            proc { options[:name] }
+          end
+        else
+          proc { |object| object }
+        end
+
         if association.nil?
           return nil if object.nil?
-          return link_to(object, polymorphic_path([:admin, object]))
+          return link_to(name_proc.call(object), polymorphic_path([:admin, object]))
         end
 
         klass = object.class
@@ -16,7 +34,7 @@ module Admin
           if options[:list] # List of objects
             foreign_objects = object.send(association)
             if foreign_objects.present?
-              links = foreign_objects.map { |foreign_object| link_to(foreign_object, polymorphic_path([:admin, foreign_object])) }
+              links = foreign_objects.map { |foreign_object| link_to(name_proc.call(foreign_object), polymorphic_path([:admin, foreign_object])) }
               links.join('<br/>').html_safe
             else
               empty_result(options)
@@ -47,7 +65,7 @@ module Admin
         else # `has_one` association
           foreign_object = object.send(association)
           if foreign_object.present?
-            link_to(foreign_object, polymorphic_path([:admin, foreign_object]))
+            link_to(name_proc.call(foreign_object), polymorphic_path([:admin, foreign_object]))
           else
             empty_result(options)
           end

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -13,7 +13,7 @@ class ApplicationController < SharedController
     if user.sign_in_count == 1
       tutoriels_path
     elsif user.is_only_cooperation_manager?
-      needs_conseiller_cooperations_path
+      conseiller_cooperations_path
     elsif user.is_manager?
       manager_needs_path
     elsif user.is_sponsor?

--- a/app/controllers/conseiller/cooperations_controller.rb
+++ b/app/controllers/conseiller/cooperations_controller.rb
@@ -67,12 +67,8 @@ class Conseiller::CooperationsController < ApplicationController
   private
 
   def retrieve_cooperation
-    @cooperation = if params[:cooperation_id].present?
-      Cooperation.find_by(id: params[:cooperation_id])
-    else
-      current_user.managed_cooperation
-    end
-    authorize @cooperation, :manage?
+    @cooperation = Cooperation.find(params.expect(:id))
+    authorize @cooperation
   end
 
   def init_filters

--- a/app/controllers/conseiller/cooperations_controller.rb
+++ b/app/controllers/conseiller/cooperations_controller.rb
@@ -1,7 +1,7 @@
 class Conseiller::CooperationsController < ApplicationController
   include StatsUtilities
 
-  layout 'side_menu', only: %i[reports solicitations]
+  layout 'side_menu'
 
   before_action :retrieve_cooperation, only: %i[needs matches reports solicitations load_filter_options provenance_detail_autocomplete]
   before_action :init_filters, only: %i[needs matches load_filter_options]
@@ -18,6 +18,10 @@ class Conseiller::CooperationsController < ApplicationController
       matches_taken_care_in_three_days matches_taken_care_in_five_days
     ]
   }
+
+  def index
+    redirect_to needs_conseiller_cooperation_path(policy_scope(Cooperation).first)
+  end
 
   def needs
     set_stats_params(cooperation_id: @cooperation.id)

--- a/app/controllers/conseiller/cooperations_controller.rb
+++ b/app/controllers/conseiller/cooperations_controller.rb
@@ -4,7 +4,7 @@ class Conseiller::CooperationsController < ApplicationController
   layout 'side_menu'
 
   before_action :retrieve_cooperation, only: %i[needs matches reports solicitations load_filter_options provenance_detail_autocomplete]
-  before_action :init_filters, only: %i[needs matches load_filter_options]
+  before_action :init_filters, only: %i[load_filter_options]
 
   CHART_NAMES = {
     needs: %w[
@@ -24,13 +24,14 @@ class Conseiller::CooperationsController < ApplicationController
   end
 
   def needs
+    init_filters
     set_stats_params(cooperation_id: @cooperation.id)
     @charts_names = CHART_NAMES[:needs]
   end
 
   def matches
-    # On filtre les MER de l'institution
-    set_stats_params(cooperation_id: @cooperation.id, institution_id: @cooperation.institution.id)
+    init_filters(institutions: [@cooperation.institution, current_user.institution])
+    set_stats_params(cooperation_id: @cooperation.id)
     @charts_names = CHART_NAMES[:matches]
   end
 
@@ -71,7 +72,7 @@ class Conseiller::CooperationsController < ApplicationController
     authorize @cooperation
   end
 
-  def init_filters
+  def init_filters(institutions: nil)
     themes = @cooperation.themes.select(:id, :label).order(:label)
     subjects = @cooperation.subjects.not_archived.order(:label)
 
@@ -82,6 +83,7 @@ class Conseiller::CooperationsController < ApplicationController
     @filters = {
       themes: themes.uniq,
       subjects: subjects.uniq,
+      institutions: institutions&.uniq,
       regions: RegionOrderingService.call
     }
   end

--- a/app/helpers/cooperations_helper.rb
+++ b/app/helpers/cooperations_helper.rb
@@ -1,0 +1,16 @@
+module CooperationsHelper
+  # Build a `select` tag with the viewable cooperations
+  # Each option uses direct-submit-controller to automatically switch to its url.
+  def managed_cooperations_select_menu(current_cooperation)
+    cooperations = policy_scope(Cooperation)
+    return if cooperations.size < 2
+
+    options = cooperations.map do |cooperation|
+      action = policy(cooperation).send("#{action_name}?") ? action_name : "needs"
+      path = polymorphic_path([action.to_sym, :conseiller, cooperation])
+      [cooperation.name, cooperation.id, { data: { 'direct-submit-url': path } }]
+    end
+
+    select_tag("", options_for_select(options, current_cooperation.id), class: 'fr-select fr-mb-2v', data: { controller: "direct-submit", action: "direct-submit#submit" })
+  end
+end

--- a/app/javascript/shared/controllers/direct_submit_controller.js
+++ b/app/javascript/shared/controllers/direct_submit_controller.js
@@ -1,8 +1,12 @@
 import { Controller } from "stimulus";
+import { Turbo } from "@hotwired/turbo-rails"
 
 export default class extends Controller {
-
   submit(event) {
-    event.target.form.requestSubmit()
+    if (event.target.form) {
+      event.target.form.requestSubmit()
+    } else if (event.target?.selectedOptions?.item(0)?.dataset?.directSubmitUrl !== undefined) {
+      Turbo.visit(event.target.selectedOptions.item(0).dataset.directSubmitUrl)
+    }
   }
 }

--- a/app/mailers/user_mailer.rb
+++ b/app/mailers/user_mailer.rb
@@ -29,7 +29,7 @@ class UserMailer < ApplicationMailer
 
   def cooperation_activity_report
     @support_user = User.cooperations_referent.first
-    @cooperation = @user.managed_cooperation
+    @cooperation = params[:cooperation]
     return false if @support_user.nil? || @cooperation.nil?
     @cooperation_logo_name = @cooperation.logo&.filename
 

--- a/app/models/cooperation.rb
+++ b/app/models/cooperation.rb
@@ -86,7 +86,7 @@ class Cooperation < ApplicationRecord
   end
 
   def with_provenance_details?
-    self.solicitations.pluck(:provenance_detail).compact_blank.uniq.any?
+    solicitations.where.not(provenance_detail: nil).exists?
   end
 
   def support_user

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -122,7 +122,6 @@ class User < ApplicationRecord
   validates :full_name, presence: true, unless: :deleted?
   validates :job, presence: true
   validate :password_complexity
-  validates :user_rights_cooperation_manager, length: { maximum: 1, too_long: I18n.t('errors.only_one_cooperation') }
   validates_associated :experts, on: :import
 
   ## "Through" Associations
@@ -298,10 +297,6 @@ class User < ApplicationRecord
     return existing if existing.present?
 
     self.experts.create!(self.user_expert_shared_attributes)
-  end
-
-  def managed_cooperation
-    self.managed_cooperations&.first
   end
 
   ## Rights

--- a/app/policies/cooperation_policy.rb
+++ b/app/policies/cooperation_policy.rb
@@ -15,4 +15,14 @@ class CooperationPolicy < ApplicationPolicy
 
   alias load_filter_options? needs?
   alias provenance_detail_autocomplete? needs?
+
+  class Scope < Scope
+    def resolve
+      if user.is_admin?
+        super
+      else
+        super.merge(user.managed_cooperations)
+      end
+    end
+  end
 end

--- a/app/policies/cooperation_policy.rb
+++ b/app/policies/cooperation_policy.rb
@@ -1,8 +1,18 @@
 class CooperationPolicy < ApplicationPolicy
   def index? = @user&.is_admin? || @user&.is_cooperation_manager?
 
-  def manage?
-    @user&.is_admin? ||
-    (@user&.is_cooperation_manager? && @user.managed_cooperations.include?(@record))
+  def needs?
+    @user&.is_admin? || @user&.managed_cooperations&.include?(@record)
   end
+
+  def matches? = (@user&.is_admin? || @user&.managed_cooperations&.include?(@record)) && @record.display_matches_stats?
+
+  def reports?
+    @user&.is_admin? || @user&.managed_cooperations&.include?(@record)
+  end
+
+  def solicitations? = (@user&.is_admin? || @user&.managed_cooperations&.include?(@record)) && @record.wants_solicitations_export?
+
+  alias load_filter_options? needs?
+  alias provenance_detail_autocomplete? needs?
 end

--- a/app/services/activity_reports/notify_cooperation_managers.rb
+++ b/app/services/activity_reports/notify_cooperation_managers.rb
@@ -6,8 +6,11 @@ module ActivityReports
 
     def call
       @managers.each do |user|
-        next unless user.managed_cooperations.map { |cooperation| cooperation.activity_reports.find_by(start_date: 3.months.ago.beginning_of_month) }.any?
-        UserMailer.with(user: user).cooperation_activity_report.deliver_later
+        user.managed_cooperations.each do |cooperation|
+          recent_reports = cooperation.activity_reports.find_by(start_date: 3.months.ago.beginning_of_month)
+          next if recent_reports.blank?
+          UserMailer.with(user: user, cooperation: cooperation).cooperation_activity_report.deliver_later
+        end
       end
     end
   end

--- a/app/views/application/navbar/_admin.html.haml
+++ b/app/views/application/navbar/_admin.html.haml
@@ -7,7 +7,8 @@
 
 %ul.fr-nav__list
   %li.fr-nav__item.fr-nav__item--align-right
-    %button.fr-nav__btn{ 'aria-controls': "fr-nav-item-account", 'aria-expanded': "false" }
+    - controller_names = %w[institutions badges csv_exports cooperations invitations]
+    %button.fr-nav__btn{ aria: { controls: "fr-nav-item-account", current: controller_name.in?(controller_names), expanded: "false" } }
       = t('.tools')
     .fr-menu.fr-collapse#fr-nav-item-account
       %ul.fr-menu__list

--- a/app/views/application/navbar/_admin.html.haml
+++ b/app/views/application/navbar/_admin.html.haml
@@ -15,4 +15,5 @@
         = navbar_item institutions_path, t('.annuaire'), 'ri-government-line'
         = navbar_item badges_path, t('.badges'), 'ri-price-tag-3-line'
         = navbar_item conseiller_csv_exports_path, t('.csv_exports'), 'ri-folder-download-line'
+        = navbar_item conseiller_cooperations_path, t('.cooperation'), 'ri-shake-hands-line'
         = navbar_item new_user_invitation_path, t('.invite'), 'ri-user-add-line'

--- a/app/views/application/navbar/_app.html.haml
+++ b/app/views/application/navbar/_app.html.haml
@@ -18,16 +18,7 @@
   - if policy(:activity_report).index?
     = navbar_item reports_path, t('.reports'), 'ri-file-text-line'
   - if policy(:cooperation).index?
-    %li.fr-nav__item
-      %button.fr-nav__btn{ aria: { controls: "nav-cooperation", current: controller_name == 'cooperations', expanded: "false" } }
-        %span.ri-shake-hands-line.fr-mr-1w{ 'aria-hidden': 'true' }
-        = t('.cooperation')
-      .fr-collapse.fr-menu#nav-cooperation
-        %ul.fr-menu__list
-          = navbar_item needs_conseiller_cooperations_path, t('.cooperation_needs')
-          - if current_user.managed_cooperations.any?{ it.display_matches_stats? }
-            = navbar_item matches_conseiller_cooperations_path, t('.cooperation_matches')
-          = navbar_item reports_conseiller_cooperations_path, t('.cooperation_reports')
+    = navbar_item conseiller_cooperations_path, t('.cooperation'), 'ri-shake-hands-line'
 
 %ul.fr-nav__list
   - if display_questionnaire_navbar_item?

--- a/app/views/conseiller/cooperations/_menu.html.haml
+++ b/app/views/conseiller/cooperations/_menu.html.haml
@@ -1,9 +1,11 @@
--# Dynamically build the path for each of the collections. Paths look like this:
-  /cooperations(/cooperation)/:collection_name
+-# locals: (cooperation:)
+
+-# Dynamically build the path for each of the tabs. Paths look like this:
+  /conseiller/cooperations/(:cooperation)/:section
 %ul.fr-sidemenu__list
-  - sections = Cooperation.find(cooperation_id).wants_solicitations_export? ? [:reports, :solicitations] : [:reports]
-  - sections.each do |key|
-    %li.fr-sidemenu__item.item-with-tag
-      - url = polymorphic_path([key, :conseiller, :cooperations].compact, cooperation_id: cooperation_id)
-      = active_link_to(url, class: 'fr-sidemenu__link', class_active: 'fr-sidemenu__item--active') do
-        = t(key, scope: 'conseiller.cooperations.sidemenu')
+  - %i[needs matches reports solicitations].each do |key|
+    - if policy(cooperation).send("#{key}?")
+      %li.fr-sidemenu__item.item-with-tag
+        - url = polymorphic_path([key, :conseiller, cooperation].compact)
+        = active_link_to(url, class: 'fr-sidemenu__link', class_active: 'fr-sidemenu__item--active') do
+          = t(key, scope: 'conseiller.cooperations.sidemenu')

--- a/app/views/conseiller/cooperations/_menu.html.haml
+++ b/app/views/conseiller/cooperations/_menu.html.haml
@@ -1,5 +1,9 @@
 -# locals: (cooperation:)
 
+  Cooperation selection, for users that can access several cooperations:
+  (switch to another cooperation, on the same page than the current)
+= managed_cooperations_select_menu(cooperation)
+
 -# Dynamically build the path for each of the tabs. Paths look like this:
   /conseiller/cooperations/(:cooperation)/:section
 %ul.fr-sidemenu__list

--- a/app/views/conseiller/cooperations/_stats_filters.haml
+++ b/app/views/conseiller/cooperations/_stats_filters.haml
@@ -1,6 +1,14 @@
 = form_with url: request.url, method: :get, local: true do |f|
   .fr-grid-row.fr-grid-row--gutters.fr-mb-3w#stats-params{ data: { controller: 'filters', url: load_filter_options_conseiller_cooperation_path(cooperation) } }
 
+    - if filters[:institutions].present?
+      .fr-col-12
+        .fr-select-group
+          = f.label :institution_id, class: 'fr-label' do
+            = t('activerecord.models.institution.one')
+          = f.collection_select :institution_id, filters[:institutions], :id, :name, { selected: params[:institution_id],
+          include_blank: t('all.feminine') }, class: "fr-select"
+
     .fr-col-12.fr-col-md-4
       .fr-input-group
         = f.label :start_date, t('stats.stats_params.start_date'), class: 'fr-label'
@@ -37,7 +45,6 @@
             = f.hidden_field :provenance_detail, 'data-autocomplete-target': 'hidden'
             %input.fr-input{ 'data-autocomplete-target': 'input', type: 'text', value: params[:provenance_detail].presence }
             %ul.list-group{ 'data-autocomplete-target': 'results' }
-
 
     .fr-col-12
       .fr-input-group

--- a/app/views/conseiller/cooperations/_stats_filters.haml
+++ b/app/views/conseiller/cooperations/_stats_filters.haml
@@ -1,5 +1,5 @@
 = form_with url: request.url, method: :get, local: true do |f|
-  .fr-grid-row.fr-grid-row--gutters.fr-mb-3w#stats-params{ data: { controller: 'filters', url: load_filter_options_conseiller_cooperations_path } }
+  .fr-grid-row.fr-grid-row--gutters.fr-mb-3w#stats-params{ data: { controller: 'filters', url: load_filter_options_conseiller_cooperation_path(cooperation) } }
 
     .fr-col-12.fr-col-md-4
       .fr-input-group
@@ -32,7 +32,7 @@
             include_blank: t('all.feminine') }, class: "fr-select"
       - if cooperation.with_provenance_details?
         .fr-input-group.fr-pr-2v
-          .autocomplete-field{ 'data-autocomplete-url-value': "#{provenance_detail_autocomplete_conseiller_cooperations_path}", 'data-controller': 'autocomplete', 'data-autocomplete-min-length-value': 2 }
+          .autocomplete-field{ 'data-autocomplete-url-value': "#{provenance_detail_autocomplete_conseiller_cooperation_path(cooperation)}", 'data-controller': 'autocomplete', 'data-autocomplete-min-length-value': 2 }
             = f.label :provenance_detail, t('stats.stats_params.provenance_detail'), class: 'fr-label'
             = f.hidden_field :provenance_detail, 'data-autocomplete-target': 'hidden'
             %input.fr-input{ 'data-autocomplete-target': 'input', type: 'text', value: params[:provenance_detail].presence }

--- a/app/views/conseiller/cooperations/matches.html.haml
+++ b/app/views/conseiller/cooperations/matches.html.haml
@@ -1,15 +1,14 @@
-- title = t('.title', cooperation_name: @cooperation.name, institution_name: @cooperation.institution.name)
-- cooperation_title = t('conseiller.cooperations.title', name: @cooperation.name)
+- title = t('.title', cooperation_name: @cooperation.name)
 - meta title: title
 - content_for :head do
   - javascript_include_tag 'highcharts', data: { 'turbo-track': 'reload' }, nonce: 'true'
 
+- content_for :menu, render('menu', cooperation: @cooperation)
+
 .fr-container
   .fr-grid-row
     .fr-col
-      %h1.fr-h2
-        = title
-      = render 'shared/breadcrumb', pages: [{ title: cooperation_title, path: needs_conseiller_cooperations_path }], current_page: title
+      %h1.fr-h2= title
 
 .fr-container
   .fr-grid-row

--- a/app/views/conseiller/cooperations/needs.html.haml
+++ b/app/views/conseiller/cooperations/needs.html.haml
@@ -4,12 +4,12 @@
 - content_for :head do
   - javascript_include_tag 'highcharts', data: { 'turbo-track': 'reload' }, nonce: 'true'
 
+- content_for :menu, render('menu', cooperation: @cooperation)
+
 .fr-container
   .fr-grid-row
     .fr-col
-      %h1.fr-h2
-        = title
-      = render 'shared/breadcrumb', pages: [{ title: cooperation_title, path: needs_conseiller_cooperations_path }], current_page: title
+      %h1.fr-h2= title
 
 .fr-container
   .fr-grid-row

--- a/app/views/conseiller/cooperations/reports.haml
+++ b/app/views/conseiller/cooperations/reports.haml
@@ -1,7 +1,7 @@
 - title = t('.title', cooperation_name: @cooperation.name)
 - meta title: title
 
-- content_for :menu, render('menu', cooperation_id: @cooperation.id)
+- content_for :menu, render('menu', cooperation: @cooperation)
 
 .fr-container
   .fr-grid-row

--- a/app/views/mailers/user_mailer/cooperation_activity_report.mjml
+++ b/app/views/mailers/user_mailer/cooperation_activity_report.mjml
@@ -10,7 +10,7 @@
     </mj-text>
 
     <mj-button background-color="#000091" color="white" border-radius="0" font-weight="700">
-      <%= link_to t('.download_report'), reports_conseiller_cooperations_url, target: :blank, style: 'color: white; text-decoration: none' %>
+      <%= link_to t('.download_report'), reports_conseiller_cooperation_url(@cooperation), target: :blank, style: 'color: white; text-decoration: none' %>
     </mj-button>
 
     <mj-text>

--- a/config/locales/fr.yml
+++ b/config/locales/fr.yml
@@ -192,7 +192,6 @@ fr:
     missing_inherited_method: Méthode manquante dans la classe enfant
     one_territorial_referent_per_region: Un seul référent régional est autorisé par région
     one_user_for_referents: Un seul reférent est autorisé.
-    only_one_cooperation: Une seule coopération peut être attribuée au responsable de coopération. S'il faut modifier cette règle, demandez aux devs !
     page_title: Erreur - %{title}
     satisfaction_without_comment: Vous ne pouvez pas partager une satisfaction sans commentaire
     sponsor_without_institution: Une institution doit être attribuée à ce pilotage ministériel

--- a/config/locales/views.fr.yml
+++ b/config/locales/views.fr.yml
@@ -137,6 +137,7 @@ fr:
         admin: Administration
         annuaire: Annuaire
         badges: Tags
+        cooperation: Coopérations
         csv_exports: Exports csv
         invite: Inviter des utilisateurs
         tools: Outils
@@ -144,9 +145,6 @@ fr:
       antennes_needs: Besoins des antennes
       app:
         cooperation: Coopération
-        cooperation_matches: Pilotage par partenaire
-        cooperation_needs: Pilotage par besoin
-        cooperation_reports: Rapport d’activité
         questionnaire: Questionnaire de satisfaction
         reports: Export des données
         stats: Statistiques
@@ -265,7 +263,7 @@ fr:
   conseiller:
     cooperations:
       matches:
-        title: "%{cooperation_name} - Pilotage %{institution_name}"
+        title: "%{cooperation_name} - Pilotage par partenaire"
       needs:
         decalage_alert:
           description: Le total des besoins transmis peut à partir d’ici différer. Certains besoins ont été requalifiés par notre équipe pour être affectés au bon sujet.
@@ -280,6 +278,8 @@ fr:
         no_export_available: Votre rapport d’activité n’est pas encore disponible.
         title: "%{cooperation_name} - Rapport d’activité"
       sidemenu:
+        matches: Pilotage par partenaire
+        needs: Pilotage par besoin
         reports: Rapports d’activité
         solicitations: Export des sollicitations
       title: Coopération %{name}

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -127,15 +127,17 @@ Rails.application.routes.draw do
         patch :mark_as_seen
       end
     end
-    resources :cooperations, only: %i[], path: 'cooperation' do
-      collection do
+    resources :cooperations, only: %i[index] do
+      member do
         get :needs, path: 'pilotage-besoin'
         get :matches, path: 'pilotage-partenaire'
-        get :reports, path: 'rapports-activite'
-        get :solicitations, path: 'export-sollicitations'
-        get :load_data
         get :load_filter_options
         get :provenance_detail_autocomplete
+        get :reports, path: 'rapports-activite'
+        get :solicitations, path: 'export-sollicitations'
+      end
+      collection do
+        get :load_data
       end
     end
   end

--- a/spec/controllers/conseiller/cooperations_controller_spec.rb
+++ b/spec/controllers/conseiller/cooperations_controller_spec.rb
@@ -9,7 +9,7 @@ RSpec.describe Conseiller::CooperationsController do
 
   describe 'GET #needs' do
     it do
-      get :needs
+      get :needs, params: { id: cooperation.id }
       expect(response).to be_successful
       expect(assigns(:cooperation)).to eq(cooperation)
     end

--- a/spec/jobs/activity_reports/notify_antenne_managers_job_spec.rb
+++ b/spec/jobs/activity_reports/notify_antenne_managers_job_spec.rb
@@ -1,6 +1,0 @@
-require 'rails_helper'
-RSpec.describe ActivityReports::NotifyAntenneManagersJob do
-  describe 'enqueue a job' do
-    it { assert_enqueued_jobs(1) { described_class.perform_later } }
-  end
-end

--- a/spec/mailers/previews/user_mailer_preview.rb
+++ b/spec/mailers/previews/user_mailer_preview.rb
@@ -4,7 +4,8 @@ class UserMailerPreview < ActionMailer::Preview
   end
 
   def cooperation_activity_report
-    UserMailer.with(user: User.active.cooperation_managers.find_random).cooperation_activity_report
+    user = User.active.cooperation_managers.find_random
+    UserMailer.with(user: user, cooperation: user.managed_cooperations.find_random).cooperation_activity_report
   end
 
   def invite_to_demo

--- a/spec/policies/cooperation_policy_spec.rb
+++ b/spec/policies/cooperation_policy_spec.rb
@@ -1,75 +1,67 @@
 require 'rails_helper'
 
-RSpec.describe CooperationPolicy, type: :policy do
+RSpec.describe CooperationPolicy, :aggregate_failures, type: :policy do
   subject { described_class }
 
+  let(:cooperation) { create :cooperation }
+
+  let(:admin) { create :user, :admin }
+  let(:manager) { create :user, :cooperation_manager, managed_cooperations: [cooperation] }
+  let(:other_user) { create :user }
+
   permissions :index? do
-    context "grants access if user is a cooperation manager" do
-      let(:user) { create :user, :cooperation_manager }
-
-      it { is_expected.to permit(user) }
-    end
-
-    context "grants access if user is an admin" do
-      let(:user) { create :user, :admin }
-
-      it { is_expected.to permit(user) }
-    end
-
-    context "denies access if user is another user" do
-      let(:user) { create :user }
-
-      it { is_expected.not_to permit(user) }
+    it "grants access to admins and cooperation managers" do
+      is_expected.to permit(admin)
+      is_expected.to permit(manager)
+      is_expected.not_to permit(other_user)
     end
   end
 
-  permissions :index? do
-    let(:cooperation) { create :cooperation }
-
-    context "grants access if cooperation is in user managed cooperations" do
-      let(:user) { create :user, :cooperation_manager }
-
-      it { is_expected.to permit(user) }
-    end
-
-    context "grant access if user is an admin" do
-      let(:user) { create :user, :admin }
-
-      it { is_expected.to permit(user) }
-    end
-
-    context "denies access if user is another user" do
-      let(:user) { create :user }
-
-      it { is_expected.not_to permit(user) }
+  permissions :needs?, :reports? do
+    it "grants access to admins and managers of the cooperation" do
+      is_expected.to permit(admin, cooperation)
+      is_expected.to permit(manager, cooperation)
+      is_expected.not_to permit(other_user, cooperation)
     end
   end
 
-  permissions :manage? do
-    let(:cooperation) { create :cooperation }
-
-    context "grant access if user is an admin" do
-      let(:user) { create :user, :admin }
-
-      it { is_expected.to permit(user, cooperation) }
+  permissions :matches? do
+    context "the cooperation does not display matches stats" do
+      it "grants access to nobody" do
+        is_expected.not_to permit(admin, cooperation)
+        is_expected.not_to permit(manager, cooperation)
+        is_expected.not_to permit(other_user, cooperation)
+      end
     end
 
-    context "grants access if user manages this cooperation" do
-      let(:user) { create :user, :cooperation_manager, managed_cooperations: [cooperation] }
+    context "the cooperation displays matches stats" do
+      let(:cooperation) { create :cooperation, display_matches_stats: true }
 
-      it { is_expected.to permit(user, cooperation) }
+      it "grants access to admins and managers of the cooperation" do
+        is_expected.to permit(admin, cooperation)
+        is_expected.to permit(manager, cooperation)
+        is_expected.not_to permit(other_user, cooperation)
+      end
+    end
+  end
+
+  permissions :solicitations? do
+    context "the cooperation does not display solicitations stats" do
+      it "grants access to nobody" do
+        is_expected.not_to permit(admin, cooperation)
+        is_expected.not_to permit(manager, cooperation)
+        is_expected.not_to permit(other_user, cooperation)
+      end
     end
 
-    context "denies access if user manages another cooperation" do
-      let(:user) { create :user, :cooperation_manager }
+    context "the cooperation displays solicitations stats" do
+      let(:cooperation) { create :cooperation, wants_solicitations_export: true }
 
-      it { is_expected.not_to permit(user, cooperation) }
-    end
-
-    context "denies access if user is another user" do
-      let(:user) { create :user }
-
-      it { is_expected.not_to permit(user, cooperation) }
+      it "grants access to admins and managers of the cooperation" do
+        is_expected.to permit(admin, cooperation)
+        is_expected.to permit(manager, cooperation)
+        is_expected.not_to permit(other_user, cooperation)
+      end
     end
   end
 end

--- a/spec/views/conseiller/cooperations/needs.html.haml_spec.rb
+++ b/spec/views/conseiller/cooperations/needs.html.haml_spec.rb
@@ -1,6 +1,8 @@
 require 'rails_helper'
 
 RSpec.describe 'conseiller/cooperations/needs' do
+  login_user
+
   describe "index" do
     let(:cooperation) { create :cooperation }
     let(:need01) { create :need_with_matches, diagnosis: create(:diagnosis, solicitation: create(:solicitation, cooperation: cooperation)) }


### PR DESCRIPTION
⚠️ À merger après avoir mergé #4563 (et rebasé)

fixes #4562.

Les utilisateurs peuvent maintenant avoir plusieurs UserRight de type CooperationManager. Toutes les autres modifications découlent de ça. (Finalement, il n’y a pas de cas spécial pour les sponsors d’institution, il n’ont pas accès automatiquement aux stats des coopérations des institutions qu’ils sponsorisent.

Pour un manager de plusieurs coopérations, il y a maintenant ce petit menu.

<img width="733" height="434" alt="Capture d’écran 2026-07-16 à 13 54 35" src="https://github.com/user-attachments/assets/3f954e15-e4b4-4dda-8025-c1f7c8261caa" />
<img width="725" height="410" alt="Capture d’écran 2026-07-16 à 13 54 42" src="https://github.com/user-attachments/assets/33085a62-fc19-4c02-a86b-380c45fd5102" />


Autres choses faites:
- Modifié les routes de conseillers/coopérations pour que ça soit des routes de `member`, pas de `collection` auxquelles on passe un `:cooperation_id`.
- Modifié la navbar, pour mettre les sections plutôt dans le side_menu à gauche
- Repris CooperationPolicy pour pouvoir baser l’affichage de l’interface en fonction de la policy.
- Donné accès à /conseiller/cooperations aux admins directement depuis le menu Outils
- Modifié DirectSubmitController pour permettre de spécifier une URL de visite dans chaque option d’un `select`.
- Ajusté l’affichage des responsables de coopération dans l’admin pour indiquer ceux qui ne sont pas de la même institution que la coopération.
  <img width="697" height="118" alt="Capture d’écran 2026-07-16 à 13 56 54" src="https://github.com/user-attachments/assets/87826666-f698-4cb7-bb6a-6c59a327db42" />
- Ajouté un champ de sélection de l’institution pour la section pilotage-partenaire, qui permet de basculer le cas échéant entre l’institution de la coopération et l’institution de l’utilisateur.

