### PR TITLE
Ajoute des métadonnées pour les pages témoignages des conseillers

### DIFF
--- a/app/helpers/about_seo_helper.rb
+++ b/app/helpers/about_seo_helper.rb
@@ -36,7 +36,11 @@ module AboutSeoHelper
                       breadcrumb: true,
                       main_entity_id: "#{request.original_url}#article"
                     ))
-    add_page_schema(temoignage_article_schema(temoignage: temoignage, image: image))
+    add_page_schema(temoignage_article_schema(
+                      temoignage: temoignage,
+                      image: image,
+                      action_url: new_solicitation_url(landing_slug: 'accueil', landing_subject_slug: temoignage.landing_subject)
+                    ))
   end
 
   def setup_comment_ca_marche_seo_schemas(temoignages:)

--- a/app/helpers/about_seo_helper.rb
+++ b/app/helpers/about_seo_helper.rb
@@ -2,8 +2,8 @@ module AboutSeoHelper
   # Helpers pour simplifier la configuration des schémas SEO dans les pages "About"
 
   def setup_temoignages_index_seo(temoignages:)
-    title = t('about.temoignages_experts.index.meta_title')
-    description = t('about.temoignages_experts.index.meta_description')
+    title = t('about.temoignages_experts.index.title_long')
+    description = t('about.temoignages_experts.index.subtitle')
 
     meta(title: title, description: description)
     add_page_schema(page_schema(

--- a/app/helpers/about_seo_helper.rb
+++ b/app/helpers/about_seo_helper.rb
@@ -1,6 +1,23 @@
 module AboutSeoHelper
   # Helpers pour simplifier la configuration des schémas SEO dans les pages "About"
 
+  def setup_temoignage_show_seo(temoignage:, key:)
+    title = strip_tags(temoignage.title)
+    description = strip_tags(temoignage.subtitle)
+
+    meta(title: title, description: description)
+    add_page_schema(page_schema(
+                      title: title,
+                      description: description,
+                      breadcrumb: true,
+                      main_entity_id: "#{request.original_url}#article"
+                    ))
+    add_page_schema(temoignage_article_schema(
+                      temoignage: temoignage,
+                      image: image_url("temoignages_experts/#{key}.jpeg")
+                    ))
+  end
+
   def setup_comment_ca_marche_seo_schemas(temoignages:)
     title = t('about.comment_ca_marche.meta_title')
     description = t('about.comment_ca_marche.meta_description')

--- a/app/helpers/about_seo_helper.rb
+++ b/app/helpers/about_seo_helper.rb
@@ -1,6 +1,20 @@
 module AboutSeoHelper
   # Helpers pour simplifier la configuration des schémas SEO dans les pages "About"
 
+  def setup_temoignages_index_seo(temoignages:)
+    title = t('about.temoignages_experts.index.meta_title')
+    description = t('about.temoignages_experts.index.meta_description')
+
+    meta(title: title, description: description)
+    add_page_schema(page_schema(
+                      title: title,
+                      description: description,
+                      breadcrumb: true,
+                      main_entity_id: "#{request.original_url}#itemlist"
+                    ))
+    add_page_schema(temoignages_list_schema(temoignages: temoignages))
+  end
+
   def setup_temoignage_show_seo(temoignage:, key:)
     title = strip_tags(temoignage.title)
     description = strip_tags(temoignage.subtitle)

--- a/app/helpers/about_seo_helper.rb
+++ b/app/helpers/about_seo_helper.rb
@@ -18,18 +18,25 @@ module AboutSeoHelper
   def setup_temoignage_show_seo(temoignage:, key:)
     title = strip_tags(temoignage.title)
     description = strip_tags(temoignage.subtitle)
+    image = image_url("temoignages_experts/#{key}.jpeg")
 
-    meta(title: title, description: description)
+    set_og_image(image)
+    meta(
+      title: title,
+      description: description,
+      og: { type: 'article', title: title, description: description, image: { alt: temoignage.expert } },
+      article: {
+        published_time: temoignage.initial_publication_date.in_time_zone.iso8601,
+        modified_time: temoignage.publication_date.in_time_zone.iso8601
+      }
+    )
     add_page_schema(page_schema(
                       title: title,
                       description: description,
                       breadcrumb: true,
                       main_entity_id: "#{request.original_url}#article"
                     ))
-    add_page_schema(temoignage_article_schema(
-                      temoignage: temoignage,
-                      image: image_url("temoignages_experts/#{key}.jpeg")
-                    ))
+    add_page_schema(temoignage_article_schema(temoignage: temoignage, image: image))
   end
 
   def setup_comment_ca_marche_seo_schemas(temoignages:)

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -15,7 +15,8 @@ module ApplicationHelper
     capture do
       concat tag.link(href: canonical_url, rel: :canonical)
       concat tag.meta(property: 'og:url', content: canonical_url)
-      concat tag.meta(property: 'og:image', content: image_url('logo-ce.png'))
+      og_image = content_for?(:og_image) ? content_for(:og_image) : image_url('logo-ce.png')
+      concat tag.meta(property: 'og:image', content: og_image)
     end
   end
 

--- a/app/helpers/breadcrumbs_helper.rb
+++ b/app/helpers/breadcrumbs_helper.rb
@@ -19,9 +19,12 @@ module BreadcrumbsHelper
   end
 
   # Breadcrumbs used for other pages
-  # Ex : "Déposer une demande › Comment ça marche ?"
-  def breadcrumbs_page(title)
+  # Ex : "Accueil › Comment ça marche ?"
+  # Avec un parent optionnel (page intermédiaire cliquable) :
+  # Ex : "Accueil › Qui sont les conseillers ? › Sophie Neel"
+  def breadcrumbs_page(title, parent = nil)
     html = content_tag('li', link_to(t('breadcrumbs_helper.home_link.home'), root_path, class: 'fr-breadcrumb__link blue'))
+    html << content_tag('li', link_to(parent[:name], parent[:url], class: 'fr-breadcrumb__link blue')) if parent.present?
     html << content_tag('li', link_to(title, '#', class: 'fr-breadcrumb__link', 'aria-current': 'page'))
     html
   end
@@ -70,10 +73,10 @@ module BreadcrumbsHelper
     items
   end
 
-  def breadcrumbs_data_page(title)
-    [
-      { name: t('breadcrumbs_helper.home_link.home'), url: root_url },
-      { name: title, url: request.original_url }
-    ]
+  def breadcrumbs_data_page(title, parent = nil)
+    items = [{ name: t('breadcrumbs_helper.home_link.home'), url: root_url }]
+    items << { name: parent[:name], url: parent[:url] } if parent.present?
+    items << { name: title, url: request.original_url }
+    items
   end
 end

--- a/app/helpers/seo/content_schemas.rb
+++ b/app/helpers/seo/content_schemas.rb
@@ -115,6 +115,43 @@ module Seo
       }
     end
 
+    # Liste des témoignages (page index) : un ItemList dont chaque élément est un Article
+    # résumé. Les items partagent le même `@id` (`...#article`) que le nœud complet de la
+    # page de détail, pour que les moteurs fusionnent les deux en une seule entité.
+    def temoignages_list_schema(temoignages:)
+      return nil if temoignages.blank?
+
+      {
+        '@type': "ItemList",
+        '@id': "#{request.original_url}#itemlist",
+        numberOfItems: temoignages.size,
+        itemListOrder: "https://schema.org/ItemListOrderAscending",
+        itemListElement: temoignages.map.with_index do |(key, temoignage), index|
+          page_url = temoignages_expert_url(key)
+          {
+            '@type': "ListItem",
+            position: index + 1,
+            item: {
+              '@type': "Article",
+              '@id': "#{page_url}#article",
+              headline: strip_tags(temoignage.title),
+              url: page_url,
+              datePublished: temoignage.initial_publication_date.in_time_zone.iso8601,
+              author: { '@id': "#{root_url}#organization" },
+              about: {
+                '@type': "Person",
+                name: temoignage.expert,
+                worksFor: {
+                  '@type': "GovernmentOrganization",
+                  name: temoignage.institution
+                }
+              }
+            }
+          }
+        end
+      }
+    end
+
     def review_schema(author:, content:, index: 1)
       return nil if author.blank? || content.blank?
 

--- a/app/helpers/seo/content_schemas.rb
+++ b/app/helpers/seo/content_schemas.rb
@@ -88,7 +88,7 @@ module Seo
       return nil if temoignage.blank?
 
       page_url = request.original_url
-      {
+      schema = {
         '@type': "Article",
         '@id': "#{page_url}#article",
         headline: strip_tags(temoignage.title),
@@ -113,6 +113,13 @@ module Seo
         isPartOf: { '@id': "#{page_url}#webpage" },
         mainEntityOfPage: { '@id': "#{page_url}#webpage" }
       }
+
+      # Liens « Voir aussi » : ressources externes associées → `citation`.
+      return schema if temoignage.voir_aussi.blank?
+
+      schema.merge(citation: temoignage.voir_aussi.map do |link|
+        { '@type': "CreativeWork", name: link[:name], url: link[:url] }
+      end)
     end
 
     # Liste des témoignages (page index) : un ItemList dont chaque élément est un Article

--- a/app/helpers/seo/content_schemas.rb
+++ b/app/helpers/seo/content_schemas.rb
@@ -80,6 +80,41 @@ module Seo
       }
     end
 
+    # Témoignage d'un conseiller : interview éditoriale publiée par le service.
+    # Le conseiller est l'interviewé (le sujet), pas l'auteur : on l'expose donc en `about`
+    # comme un Person rattaché à son institution (GovernmentOrganization), et l'auteur est
+    # l'organisation éditrice. Ce n'est pas un avis d'utilisateur, d'où "Article" (et non "Review").
+    def temoignage_article_schema(temoignage:, image:)
+      return nil if temoignage.blank?
+
+      page_url = request.original_url
+      {
+        '@type': "Article",
+        '@id': "#{page_url}#article",
+        headline: strip_tags(temoignage.title),
+        description: strip_tags(temoignage.subtitle),
+        image: image,
+        datePublished: temoignage.initial_publication_date.in_time_zone.iso8601,
+        dateModified: temoignage.publication_date.in_time_zone.iso8601,
+        inLanguage: "fr-FR",
+        author: { '@id': "#{root_url}#organization" },
+        publisher: { '@id': "#{root_url}#organization" },
+        about: [
+          { '@id': "#{root_url}#service" },
+          {
+            '@type': "Person",
+            name: temoignage.expert,
+            worksFor: {
+              '@type': "GovernmentOrganization",
+              name: temoignage.institution
+            }
+          }
+        ],
+        isPartOf: { '@id': "#{page_url}#webpage" },
+        mainEntityOfPage: { '@id': "#{page_url}#webpage" }
+      }
+    end
+
     def review_schema(author:, content:, index: 1)
       return nil if author.blank? || content.blank?
 

--- a/app/helpers/seo/content_schemas.rb
+++ b/app/helpers/seo/content_schemas.rb
@@ -84,7 +84,7 @@ module Seo
     # Le conseiller est l'interviewé (le sujet), pas l'auteur : on l'expose donc en `about`
     # comme un Person rattaché à son institution (GovernmentOrganization), et l'auteur est
     # l'organisation éditrice. Ce n'est pas un avis d'utilisateur, d'où "Article" (et non "Review").
-    def temoignage_article_schema(temoignage:, image:)
+    def temoignage_article_schema(temoignage:, image:, action_url: nil)
       return nil if temoignage.blank?
 
       page_url = request.original_url
@@ -115,11 +115,22 @@ module Seo
       }
 
       # Liens « Voir aussi » : ressources externes associées → `citation`.
-      return schema if temoignage.voir_aussi.blank?
+      if temoignage.voir_aussi.present?
+        schema = schema.merge(citation: temoignage.voir_aussi.map do |link|
+          { '@type': "CreativeWork", name: link[:name], url: link[:url] }
+        end)
+      end
 
-      schema.merge(citation: temoignage.voir_aussi.map do |link|
-        { '@type': "CreativeWork", name: link[:name], url: link[:url] }
-      end)
+      # CTA « Échanger avec un conseiller »
+      if action_url.present?
+        schema = schema.merge(potentialAction: {
+          '@type': "CommunicateAction",
+          name: t('cta_button'),
+          target: { '@type': "EntryPoint", urlTemplate: action_url }
+        })
+      end
+
+      schema
     end
 
     # Liste des témoignages (page index) : un ItemList dont chaque élément est un Article

--- a/app/helpers/seo/content_schemas.rb
+++ b/app/helpers/seo/content_schemas.rb
@@ -136,6 +136,7 @@ module Seo
               '@id': "#{page_url}#article",
               headline: strip_tags(temoignage.title),
               url: page_url,
+              image: image_url("temoignages_experts/#{key}.jpeg"),
               datePublished: temoignage.initial_publication_date.in_time_zone.iso8601,
               author: { '@id': "#{root_url}#organization" },
               about: {

--- a/app/helpers/seo_helper.rb
+++ b/app/helpers/seo_helper.rb
@@ -37,6 +37,12 @@ module SeoHelper
     nil
   end
 
+  # Surcharge l'image Open Graph de la page (sinon le logo par défaut est utilisé dans `canonical_tags`).
+  def set_og_image(url)
+    content_for(:og_image, url)
+    nil
+  end
+
   def schema_org_tag(data)
     content_tag(:script, type: 'application/ld+json') do
       raw(data.to_json.gsub('</', '<\/"'))

--- a/app/views/about/temoignages_experts/index.html.haml
+++ b/app/views/about/temoignages_experts/index.html.haml
@@ -15,7 +15,7 @@
   .fr-grid-row.fr-grid-row--gutters.fr-my-7w
     - @temoignages.each do |key, temoignage|
       .fr-col-md-12
-        .fr-card.fr-card--sm.fr-enlarge-link.fr-card--horizontal.fr-card--horizontal-tier
+        %article.fr-card.fr-card--sm.fr-enlarge-link.fr-card--horizontal.fr-card--horizontal-tier
           .fr-card__body
             .fr-card__content
               %h2.fr-card__title

--- a/app/views/about/temoignages_experts/index.html.haml
+++ b/app/views/about/temoignages_experts/index.html.haml
@@ -1,3 +1,5 @@
+- setup_temoignages_index_seo(temoignages: @temoignages)
+
 .fr-container.fr-py-7w.fr-mt-3v
   .fr-grid-row
     .fr-col-12.fr-col-md-8

--- a/app/views/about/temoignages_experts/show.html.haml
+++ b/app/views/about/temoignages_experts/show.html.haml
@@ -2,7 +2,7 @@
 
 = render 'pages/breadcrumbs', title: @temoignage.expert, parent: { name: t('about.temoignages_experts.title'), url: temoignages_experts_url }
 
-.fr-container.fr-py-7w
+%article.fr-container.fr-py-7w
   .fr-grid-row.fr-grid-row--center
     .fr-col-12.fr-col-md-10.fr-col-lg-8
       %h1= @temoignage.title

--- a/app/views/about/temoignages_experts/show.html.haml
+++ b/app/views/about/temoignages_experts/show.html.haml
@@ -1,6 +1,6 @@
 - setup_temoignage_show_seo(temoignage: @temoignage, key: @key)
 
-= render 'pages/breadcrumbs', title: t('about.temoignages_experts.title')
+= render 'pages/breadcrumbs', title: @temoignage.expert, parent: { name: t('about.temoignages_experts.title'), url: temoignages_experts_url }
 
 .fr-container.fr-py-7w
   .fr-grid-row.fr-grid-row--center

--- a/app/views/about/temoignages_experts/show.html.haml
+++ b/app/views/about/temoignages_experts/show.html.haml
@@ -1,3 +1,5 @@
+- setup_temoignage_show_seo(temoignage: @temoignage, key: @key)
+
 = render 'pages/breadcrumbs', title: t('about.temoignages_experts.title')
 
 .fr-container.fr-py-7w

--- a/app/views/pages/_breadcrumbs.html.haml
+++ b/app/views/pages/_breadcrumbs.html.haml
@@ -1,12 +1,9 @@
--# locals: (landing: nil, landing_theme: nil, landing_subject: nil, title: nil, query_params: {})
+-# locals: (landing: nil, landing_theme: nil, landing_subject: nil, title: nil, parent: nil, query_params: {})
 :ruby
-  if defined?(landing)
-    landing_theme ||= nil
-    landing_subject ||= nil
-    title ||= nil
+  if landing.present?
     breadcrumb_items = breadcrumbs_data_landing({ landing: landing, landing_theme: landing_theme, landing_subject: landing_subject }, query_params, title)
   else
-    breadcrumb_items = breadcrumbs_data_page(title)
+    breadcrumb_items = breadcrumbs_data_page(title, parent)
   end
 
 - add_page_schema(breadcrumb_schema(breadcrumb_items))
@@ -18,7 +15,7 @@
         = t('.see_breadcrumb')
       .fr-collapse#breadcrumb-1
         %ol.fr-breadcrumb__list.breadcrumbs
-          - if defined? landing
+          - if landing.present?
             = raw breadcrumbs_landing({ landing: landing, landing_theme: landing_theme, landing_subject: landing_subject }, query_params, title)
           - else
-            = breadcrumbs_page(title)
+            = breadcrumbs_page(title, parent)

--- a/config/locales/views.fr.yml
+++ b/config/locales/views.fr.yml
@@ -27,6 +27,8 @@ fr:
       temoignage_alt: Photo de %{author}
     temoignages_experts:
       index:
+        meta_description: Découvrez comment les conseillers partenaires du service peuvent vous accompagner selon votre problématique. Partout en France, pour un projet ou une difficulté, nous mobilisons des conseillers engagés à vos côtés.
+        meta_title: Ils témoignent de leur engagement aux côtés des entreprises
         subtitle: Découvrez comment les conseillers partenaires du service peuvent vous accompagner selon votre problématique. Partout en France, pour un projet ou une difficulté, nous mobilisons des conseillers engagés à vos côtés.
         title_long: Ils témoignent de leur engagement aux côtés des entreprises.
       show:

--- a/config/locales/views.fr.yml
+++ b/config/locales/views.fr.yml
@@ -27,8 +27,6 @@ fr:
       temoignage_alt: Photo de %{author}
     temoignages_experts:
       index:
-        meta_description: Découvrez comment les conseillers partenaires du service peuvent vous accompagner selon votre problématique. Partout en France, pour un projet ou une difficulté, nous mobilisons des conseillers engagés à vos côtés.
-        meta_title: Ils témoignent de leur engagement aux côtés des entreprises
         subtitle: Découvrez comment les conseillers partenaires du service peuvent vous accompagner selon votre problématique. Partout en France, pour un projet ou une difficulté, nous mobilisons des conseillers engagés à vos côtés.
         title_long: Ils témoignent de leur engagement aux côtés des entreprises.
       show:

--- a/spec/helpers/breadcrumbs_helper_spec.rb
+++ b/spec/helpers/breadcrumbs_helper_spec.rb
@@ -118,4 +118,54 @@ describe BreadcrumbsHelper do
       end
     end
   end
+
+  describe 'breadcrumbs_page' do
+    context 'without a parent (flat about page)' do
+      subject { helper.breadcrumbs_page('Comment ça marche ?') }
+
+      it {
+        is_expected.to eq(
+          '<li><a class="fr-breadcrumb__link blue" href="/">Accueil</a></li>' \
+          '<li><a class="fr-breadcrumb__link" aria-current="page" href="#">Comment ça marche ?</a></li>'
+        )
+      }
+    end
+
+    context 'with a parent (nested page)' do
+      subject { helper.breadcrumbs_page('Dupond Dupont', { name: 'Qui sont les conseillers ?', url: '/temoignages' }) }
+
+      it 'inserts a clickable parent crumb between home and the current page' do
+        is_expected.to eq(
+          '<li><a class="fr-breadcrumb__link blue" href="/">Accueil</a></li>' \
+          '<li><a class="fr-breadcrumb__link blue" href="/temoignages">Qui sont les conseillers ?</a></li>' \
+          '<li><a class="fr-breadcrumb__link" aria-current="page" href="#">Dupond Dupont</a></li>'
+        )
+      end
+    end
+  end
+
+  describe 'breadcrumbs_data_page' do
+    context 'without a parent' do
+      subject { helper.send(:breadcrumbs_data_page, 'Comment ça marche ?') }
+
+      it {
+        is_expected.to eq([
+          { name: 'Accueil', url: helper.root_url },
+          { name: 'Comment ça marche ?', url: helper.request.original_url }
+        ])
+      }
+    end
+
+    context 'with a parent' do
+      subject { helper.send(:breadcrumbs_data_page, 'Dupond Dupont', { name: 'Qui sont les conseillers ?', url: 'http://test.host/temoignages' }) }
+
+      it 'includes home, the parent, then the current page' do
+        is_expected.to eq([
+          { name: 'Accueil', url: helper.root_url },
+          { name: 'Qui sont les conseillers ?', url: 'http://test.host/temoignages' },
+          { name: 'Dupond Dupont', url: helper.request.original_url }
+        ])
+      end
+    end
+  end
 end

--- a/spec/helpers/breadcrumbs_helper_spec.rb
+++ b/spec/helpers/breadcrumbs_helper_spec.rb
@@ -120,7 +120,7 @@ describe BreadcrumbsHelper do
   end
 
   describe 'breadcrumbs_page' do
-    context 'without a parent (flat about page)' do
+    context 'without a parent' do
       subject { helper.breadcrumbs_page('Comment ça marche ?') }
 
       it {
@@ -131,7 +131,7 @@ describe BreadcrumbsHelper do
       }
     end
 
-    context 'with a parent (nested page)' do
+    context 'with a parent' do
       subject { helper.breadcrumbs_page('Dupond Dupont', { name: 'Qui sont les conseillers ?', url: '/temoignages' }) }
 
       it 'inserts a clickable parent crumb between home and the current page' do

--- a/spec/helpers/seo_helper_spec.rb
+++ b/spec/helpers/seo_helper_spec.rb
@@ -49,6 +49,31 @@ describe SeoHelper do
     it 'is also about the shared government service node of the graph' do
       expect(schema[:about]).to include('@id': "#{helper.root_url}#service")
     end
+
+    it 'omits citation when there is no "voir aussi" link' do
+      expect(schema).not_to have_key(:citation)
+    end
+
+    context 'with "voir aussi" links' do
+      let(:temoignage) do
+        TemoignagesExperts::Temoignage.new(
+          title: 'T', subtitle: 'S', institution: 'Banque de France', expert: 'Dupond Dupont',
+          publication_date: Date.new(2026, 6, 11), initial_publication_date: Date.new(2024, 12, 5),
+          landing_subject: 'tresorerie', mtm_kwd: 'article-bdf',
+          voir_aussi: [
+            { name: 'Réagir aux premières difficultés', url: 'https://entreprendre.service-public.gouv.fr/vosdroits/N32550' },
+            { name: 'Éviter la cessation des paiements', url: 'https://entreprendre.service-public.gouv.fr/vosdroits/N32476' }
+          ]
+        )
+      end
+
+      it 'cites each "voir aussi" resource as a related CreativeWork' do
+        expect(schema[:citation]).to eq([
+          { '@type': 'CreativeWork', name: 'Réagir aux premières difficultés', url: 'https://entreprendre.service-public.gouv.fr/vosdroits/N32550' },
+          { '@type': 'CreativeWork', name: 'Éviter la cessation des paiements', url: 'https://entreprendre.service-public.gouv.fr/vosdroits/N32476' }
+        ])
+      end
+    end
   end
 
   describe '#temoignages_list_schema' do

--- a/spec/helpers/seo_helper_spec.rb
+++ b/spec/helpers/seo_helper_spec.rb
@@ -28,34 +28,12 @@ describe SeoHelper do
       )
     end
 
-    it 'exposes the initial and last publication dates as datetimes with the Paris timezone offset' do
-      expect(schema[:datePublished]).to eq('2024-12-05T00:00:00+01:00')
-      expect(schema[:dateModified]).to eq('2026-06-11T00:00:00+02:00')
-    end
-
-    it 'is authored and published by the editorial organization, not the interviewee' do
-      expect(schema[:author]).to eq('@id': "#{helper.root_url}#organization")
-      expect(schema[:publisher]).to eq('@id': "#{helper.root_url}#organization")
-    end
-
     it 'is about the interviewed advisor as a Person working for the institution' do
       expect(schema[:about]).to include(
         '@type': 'Person',
         name: 'Dupond Dupont',
         worksFor: { '@type': 'GovernmentOrganization', name: 'Banque de France' }
       )
-    end
-
-    it 'is also about the shared government service node of the graph' do
-      expect(schema[:about]).to include('@id': "#{helper.root_url}#service")
-    end
-
-    it 'omits citation when there is no "voir aussi" link' do
-      expect(schema).not_to have_key(:citation)
-    end
-
-    it 'omits potentialAction when no solicitation action url is provided' do
-      expect(schema).not_to have_key(:potentialAction)
     end
 
     context 'with a solicitation action url' do

--- a/spec/helpers/seo_helper_spec.rb
+++ b/spec/helpers/seo_helper_spec.rb
@@ -54,6 +54,24 @@ describe SeoHelper do
       expect(schema).not_to have_key(:citation)
     end
 
+    it 'omits potentialAction when no solicitation action url is provided' do
+      expect(schema).not_to have_key(:potentialAction)
+    end
+
+    context 'with a solicitation action url' do
+      subject(:schema) do
+        helper.temoignage_article_schema(temoignage: temoignage, image: '/img.jpeg', action_url: 'http://test.host/aide-entreprise/accueil/demande/tresorerie')
+      end
+
+      it 'exposes a CommunicateAction targeting the subject-specific solicitation form' do
+        expect(schema[:potentialAction]).to eq(
+          '@type': 'CommunicateAction',
+          name: 'Échanger avec un conseiller',
+          target: { '@type': 'EntryPoint', urlTemplate: 'http://test.host/aide-entreprise/accueil/demande/tresorerie' }
+        )
+      end
+    end
+
     context 'with "voir aussi" links' do
       let(:temoignage) do
         TemoignagesExperts::Temoignage.new(

--- a/spec/helpers/seo_helper_spec.rb
+++ b/spec/helpers/seo_helper_spec.rb
@@ -88,6 +88,7 @@ describe SeoHelper do
         '@type': 'Article',
         '@id': "#{helper.temoignages_expert_url(:banque_de_france)}#article",
         url: helper.temoignages_expert_url(:banque_de_france),
+        image: helper.image_url('temoignages_experts/banque_de_france.jpeg'),
         headline: 'Comment la Banque de France vous accompagne ?'
       )
     end

--- a/spec/helpers/seo_helper_spec.rb
+++ b/spec/helpers/seo_helper_spec.rb
@@ -50,4 +50,56 @@ describe SeoHelper do
       expect(schema[:about]).to include('@id': "#{helper.root_url}#service")
     end
   end
+
+  describe '#temoignages_list_schema' do
+    subject(:schema) { helper.temoignages_list_schema(temoignages: temoignages) }
+
+    let(:temoignages) do
+      {
+        banque_de_france: TemoignagesExperts::Temoignage.new(
+          title: 'Comment la Banque de France vous accompagne ?',
+          subtitle: 'J’écoute les chefs d’entreprise.',
+          institution: 'Banque de France',
+          expert: 'Dupond Dupont',
+          publication_date: Date.new(2026, 6, 11),
+          initial_publication_date: Date.new(2024, 12, 5),
+          landing_subject: 'tresorerie', mtm_kwd: 'a', voir_aussi: []
+        ),
+        douanes: TemoignagesExperts::Temoignage.new(
+          title: 'Comment les douanes accompagnent l’export ?',
+          subtitle: 'Nous levons les freins à l’international.',
+          institution: 'Douanes',
+          expert: 'Jean Valjean',
+          publication_date: Date.new(2026, 1, 1),
+          initial_publication_date: Date.new(2025, 1, 1),
+          landing_subject: 'export', mtm_kwd: 'b', voir_aussi: []
+        )
+      }
+    end
+
+    it 'is an ItemList counting every testimonial' do
+      expect(schema).to include('@type': 'ItemList', numberOfItems: 2)
+    end
+
+    it 'lists each testimonial as an Article ListItem pointing to its page' do
+      first = schema[:itemListElement].first
+      expect(first).to include('@type': 'ListItem', position: 1)
+      expect(first[:item]).to include(
+        '@type': 'Article',
+        '@id': "#{helper.temoignages_expert_url(:banque_de_france)}#article",
+        url: helper.temoignages_expert_url(:banque_de_france),
+        headline: 'Comment la Banque de France vous accompagne ?'
+      )
+    end
+
+    it 'keeps the interview modeling on each item: authored by the org, about the interviewed Person' do
+      item = schema[:itemListElement].first[:item]
+      expect(item[:author]).to eq('@id': "#{helper.root_url}#organization")
+      expect(item[:about]).to include(
+        '@type': 'Person',
+        name: 'Dupond Dupont',
+        worksFor: { '@type': 'GovernmentOrganization', name: 'Banque de France' }
+      )
+    end
+  end
 end

--- a/spec/helpers/seo_helper_spec.rb
+++ b/spec/helpers/seo_helper_spec.rb
@@ -1,0 +1,53 @@
+require 'rails_helper'
+
+describe SeoHelper do
+  describe '#temoignage_article_schema' do
+    subject(:schema) { helper.temoignage_article_schema(temoignage: temoignage, image: '/temoignages_experts/banque_de_france.jpeg') }
+
+    let(:temoignage) do
+      TemoignagesExperts::Temoignage.new(
+        title: 'Comment la Banque de France vous accompagne dès les premières inquiétudes de trésorerie ?',
+        subtitle: 'J’écoute les chefs d’entreprise pour les orienter au mieux.',
+        institution: 'Banque de France',
+        expert: 'Dupond Dupont',
+        publication_date: Date.new(2026, 6, 11),
+        initial_publication_date: Date.new(2024, 12, 5),
+        landing_subject: 'tresorerie',
+        mtm_kwd: 'article-bdf',
+        voir_aussi: []
+      )
+    end
+
+    it 'is an Article carrying the testimonial content' do
+      expect(schema).to include(
+        '@type': 'Article',
+        headline: 'Comment la Banque de France vous accompagne dès les premières inquiétudes de trésorerie ?',
+        description: 'J’écoute les chefs d’entreprise pour les orienter au mieux.',
+        image: '/temoignages_experts/banque_de_france.jpeg',
+        inLanguage: 'fr-FR'
+      )
+    end
+
+    it 'exposes the initial and last publication dates as datetimes with the Paris timezone offset' do
+      expect(schema[:datePublished]).to eq('2024-12-05T00:00:00+01:00')
+      expect(schema[:dateModified]).to eq('2026-06-11T00:00:00+02:00')
+    end
+
+    it 'is authored and published by the editorial organization, not the interviewee' do
+      expect(schema[:author]).to eq('@id': "#{helper.root_url}#organization")
+      expect(schema[:publisher]).to eq('@id': "#{helper.root_url}#organization")
+    end
+
+    it 'is about the interviewed advisor as a Person working for the institution' do
+      expect(schema[:about]).to include(
+        '@type': 'Person',
+        name: 'Dupond Dupont',
+        worksFor: { '@type': 'GovernmentOrganization', name: 'Banque de France' }
+      )
+    end
+
+    it 'is also about the shared government service node of the graph' do
+      expect(schema[:about]).to include('@id': "#{helper.root_url}#service")
+    end
+  end
+end


### PR DESCRIPTION
closes #4283 

Validation sur https://search.google.com/test/rich-results et https://validator.schema.org/

Comme il s'agit de témoignages de conseillers et non d'utilisateurs du service, j'ai mis des `Articles` avec le conseiller dans `About` et son institution. (https://schema.org/Article)

Chaque article fait référence au service rendu par CESP 

Pourquoi pas la balise `articleBody` ? Le contenu des articles est visible directement dans le HTML, l'inclure dans la balise ` articleBody` ferait doublon.

Ajoute une balise HTML `article` autour du contenu pour être cohérent avec le json-ld 

