### PR TITLE
Ajout d’une interface self-service pour les jetons d’API

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -90,6 +90,7 @@ jobs:
             DATABASE_URL: "postgres://conseillers_entreprises_test@localhost:5432/conseillers_entreprises_test"
             APPLICATION_EMAIL: "contact@mailrandom.fr"
             APPLICATION_MARKETING_EMAIL: "contact@marketing.mailrandom.fr"
+            TECH_EMAIL: "tech@entreprises.service-public.gouv.fr"
             TEST_ERROR_RENDERING: "false"
             CI: 'true'
             RORVSWILD_KEY: 'rorvswild'

--- a/.env.example
+++ b/.env.example
@@ -6,8 +6,10 @@ WEB_CONCURRENCY=2
 RAILS_MAX_THREADS=5
 
 APPLICATION_ENV_NAME="Service Public Conseillers entreprises"
-APPLICATION_EMAIL=contact@entreprises.service-public.fr
-APPLICATION_MARKETING_EMAIL=contact@at.entreprises.service-public.fr
+APPLICATION_EMAIL=contact@entreprises.service-public.gouv.fr
+APPLICATION_MARKETING_EMAIL=contact@at.entreprises.service-public.gouv.fr
+APPLICATION_REPLY_TO_EMAIL=contact@entreprises.service-public.gouv.fr
+TECH_EMAIL=tech@entreprises.service-public.gouv.fr
 SUPPORT_CONTACT_EMAIL=
 DISPLAY_QUESTIONNAIRE2026_1=
 QUESTIONNAIRE2026_1_URL=

--- a/app/admin/api_key.rb
+++ b/app/admin/api_key.rb
@@ -1,0 +1,14 @@
+ActiveAdmin.register ApiKey do
+  menu parent: :experts, priority: 4
+  actions :index, :destroy
+  config.filters = false
+
+  index do
+    column :id
+    column :institution
+    column :created_at
+    column :updated_at
+    column :valid_until
+    actions
+  end
+end

--- a/app/admin/user.rb
+++ b/app/admin/user.rb
@@ -40,6 +40,7 @@ ActiveAdmin.register User do
   scope :managers, group: :role
   scope :cooperation_managers, group: :role
   scope :sponsors, group: :role
+  scope :techs, group: :role
 
   scope :managers_not_invited, group: :invitations
   scope :not_invited, group: :invitations
@@ -209,7 +210,7 @@ ActiveAdmin.register User do
   user_rights_attributes = [:id, :rightable_element_id, :rightable_element_type, :category, :_destroy]
   permit_params :full_name, :email, :institution, :job, :phone_number, :antenne_id, :create_expert, :absence_start_at, :absence_end_at,
                 expert_ids: [], user_rights_attributes: user_rights_attributes, user_rights_for_admin_attributes: user_rights_attributes,
-                user_rights_manager_attributes: user_rights_attributes, user_rights_sponsor_attributes: user_rights_attributes, user_rights_cooperation_manager_attributes: user_rights_attributes,
+                user_rights_manager_attributes: user_rights_attributes, user_rights_sponsor_attributes: user_rights_attributes, user_rights_tech_attributes: user_rights_attributes, user_rights_cooperation_manager_attributes: user_rights_attributes,
                 user_rights_territorial_referent_attributes: user_rights_attributes
 
   form do |f|
@@ -315,6 +316,14 @@ ActiveAdmin.register User do
                  label: 'Région',
                  include_blank: 'Sélectionner une région'
         ur.input :rightable_element_type, as: :hidden, input_html: { value: 'TerritorialZone' }
+      end
+
+      # Accès technique API
+      label_base = t('activerecord.models.user_right.tech')
+      f.has_many :user_rights_tech, heading: label_base[:other], allow_destroy: true, new_record: t('active_admin.has_many_new', model: label_base[:one]) do |ur|
+        ur.input :category, as: :hidden, input_html: { value: 'tech' }
+        ur.input :rightable_element_id, as: :hidden, input_html: { value: user.institution&.id }
+        ur.input :rightable_element_type, as: :hidden, input_html: { value: 'Institution' }
       end
 
       # Droits admin

--- a/app/assets/stylesheets/components/buttons.sass
+++ b/app/assets/stylesheets/components/buttons.sass
@@ -65,6 +65,9 @@ input[type="submit" i]
   box-shadow: inset 0 0 0 1px base.$green
   color: base.$green
 
+.fr-btn[aria-current]
+  box-shadow: 0 2px 0 0 base.$blue
+
 button.fr-link
   background-image: linear-gradient(0deg, currentColor, currentColor), linear-gradient(0deg, currentColor, currentColor)
   background-image: var(--underline-img), var(--underline-img)

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -20,8 +20,10 @@ class ApplicationController < SharedController
       team_index_path
     elsif user.is_admin?
       conseiller_solicitations_path
-    else
+    elsif user.experts.present?
       quo_active_needs_path
+    else
+      user_path
     end
   end
 

--- a/app/controllers/users/registrations_controller.rb
+++ b/app/controllers/users/registrations_controller.rb
@@ -48,9 +48,11 @@ module Users
 
     def reset_api_key
       authorize @user
-      @user.institution.api_key.presence&.destroy!
+      transaction do
+            @user.institution.api_key.presence&.destroy!
 
-      key = @user.institution.create_api_key
+            key = @user.institution.create_api_key
+      end
       flash[:new_token] = key.token
       redirect_to action: :api_key
     end

--- a/app/controllers/users/registrations_controller.rb
+++ b/app/controllers/users/registrations_controller.rb
@@ -48,9 +48,7 @@ module Users
 
     def reset_api_key
       authorize @user
-      if @user.institution.api_key.present?
-        @user.institution.api_key.destroy!
-      end
+      @user.institution.api_key.presence&.destroy!
 
       key = @user.institution.create_api_key
       flash[:new_token] = key.token

--- a/app/controllers/users/registrations_controller.rb
+++ b/app/controllers/users/registrations_controller.rb
@@ -48,12 +48,13 @@ module Users
 
     def reset_api_key
       authorize @user
-      transaction do
-            @user.institution.api_key.presence&.destroy!
 
-            key = @user.institution.create_api_key
+      ApiKey.transaction do
+        @user.institution.api_key.presence&.destroy!
+        key = @user.institution.create_api_key
+        flash[:new_token] = key.token
       end
-      flash[:new_token] = key.token
+
       redirect_to action: :api_key
     end
 

--- a/app/controllers/users/registrations_controller.rb
+++ b/app/controllers/users/registrations_controller.rb
@@ -7,10 +7,10 @@ module Users
     # authenticate_scope! and set_minimum_password_length are defined and use in the superclass
     # If we redefine them with different `only:` conditions, we’ll replace the previous conditions
     # Use local blocks instead of symbols to avoid messing with the callbacks configured in the superclass
-    prepend_before_action -> { authenticate_scope! }, only: %i[password antenne]
+    prepend_before_action -> { authenticate_scope! }, only: %i[password antenne api_key reset_api_key]
     prepend_before_action -> { set_minimum_password_length }, only: %i[password]
 
-    layout 'user_tabs', only: %i[edit password antenne update update_password]
+    layout 'user_tabs', only: %i[edit password antenne update update_password api_key]
 
     # The paths for Devise are heavily customized, see routes.rb.
     # The show action exists only for /mon_compte to redirect to /mon_compte/informations
@@ -39,6 +39,20 @@ module Users
     def antenne
       @antenne = Antenne.find(params.permit(:id)[:id])
       authorize @antenne, :show?
+    end
+
+    def api_key
+      @api_key = @user.institution.api_key
+    end
+
+    def reset_api_key
+      if @user.institution.api_key.present?
+        @user.institution.api_key.destroy!
+      end
+
+      key = @user.institution.create_api_key
+      flash[:new_token] = key.token
+      redirect_to action: :api_key
     end
 
     # Override

--- a/app/controllers/users/registrations_controller.rb
+++ b/app/controllers/users/registrations_controller.rb
@@ -42,10 +42,12 @@ module Users
     end
 
     def api_key
+      authorize @user
       @api_key = @user.institution.api_key
     end
 
     def reset_api_key
+      authorize @user
       if @user.institution.api_key.present?
         @user.institution.api_key.destroy!
       end

--- a/app/models/api_key.rb
+++ b/app/models/api_key.rb
@@ -34,6 +34,7 @@ class ApiKey < ApplicationRecord
 
   ## Callbacks
   #
+  after_initialize :generate_token, if: :new_record?
   before_save :generate_token_hmac_digest
   before_save :calculate_valid_until
 
@@ -69,6 +70,12 @@ class ApiKey < ApplicationRecord
   end
 
   private
+
+  def generate_token
+    return unless self.token.nil?
+
+    self.token = SecureRandom.hex(32)
+  end
 
   def generate_token_hmac_digest
     raise ActiveRecord::RecordInvalid, 'token is required' if token.blank?

--- a/app/models/institution.rb
+++ b/app/models/institution.rb
@@ -48,7 +48,9 @@ class Institution < ApplicationRecord
 
   has_many :user_rights, as: :rightable_element, dependent: :destroy
   has_many :user_rights_sponsor, ->{ category_sponsor }, as: :rightable_element, class_name: 'UserRight', inverse_of: :rightable_element
+  has_many :user_rights_tech, ->{ category_tech }, as: :rightable_element, class_name: 'UserRight', inverse_of: :rightable_element
   has_many :sponsors, through: :user_rights_sponsor, source: :user, inverse_of: :sponsored_institutions
+  has_many :techs, through: :user_rights_tech, source: :user, inverse_of: :tech_institutions
 
   has_one :api_key
 

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -105,9 +105,11 @@ class User < ApplicationRecord
   has_many :user_rights_cooperation_manager, ->{ category_cooperation_manager }, class_name: 'UserRight', inverse_of: :user
   has_many :user_rights_territorial_referent, ->{ category_territorial_referent }, class_name: 'UserRight', inverse_of: :user
   has_many :user_rights_sponsor, ->{ category_sponsor }, class_name: 'UserRight', inverse_of: :user
+  has_many :user_rights_tech, ->{ category_tech }, class_name: 'UserRight', inverse_of: :user
   has_many :managed_antennes, ->{ distinct }, through: :user_rights_manager, source: :antenne, inverse_of: :managers
   has_many :managed_cooperations, ->{ distinct }, through: :user_rights_cooperation_manager, source: :cooperation, inverse_of: :managers
   has_many :sponsored_institutions, ->{ distinct }, through: :user_rights_sponsor, source: :institution, inverse_of: :sponsors
+  has_many :tech_institutions, ->{ distinct }, through: :user_rights_tech, source: :institution, inverse_of: :techs
 
   # Utiles pour active_admin
   accepts_nested_attributes_for :user_rights, allow_destroy: true
@@ -115,6 +117,7 @@ class User < ApplicationRecord
   accepts_nested_attributes_for :user_rights_territorial_referent, allow_destroy: true
   accepts_nested_attributes_for :user_rights_manager, allow_destroy: true
   accepts_nested_attributes_for :user_rights_sponsor, allow_destroy: true
+  accepts_nested_attributes_for :user_rights_tech, allow_destroy: true
   accepts_nested_attributes_for :user_rights_cooperation_manager, allow_destroy: true
 
   ## Validations
@@ -146,6 +149,7 @@ class User < ApplicationRecord
   scope :admin, -> { not_deleted.joins(:user_rights).merge(UserRight.category_admin) }
   scope :managers, -> { not_deleted.joins(:user_rights).merge(UserRight.category_manager).distinct }
   scope :sponsors, -> { not_deleted.joins(:user_rights).merge(UserRight.category_sponsor).distinct }
+  scope :techs, -> { not_deleted.joins(:user_rights).merge(UserRight.category_tech).distinct }
   scope :cooperation_managers, -> { not_deleted.joins(:user_rights).merge(UserRight.category_cooperation_manager).distinct }
   scope :national_referent, -> { not_deleted.joins(:user_rights).merge(UserRight.category_national_referent).distinct }
   scope :cooperations_referent, -> { not_deleted.joins(:user_rights).merge(UserRight.category_cooperations_referent).distinct }
@@ -309,6 +313,10 @@ class User < ApplicationRecord
     user_rights_sponsor.any?
   end
 
+  def is_tech?
+    user_rights_tech.any?
+  end
+
   def is_cooperation_manager?
     user_rights_cooperation_manager.any?
   end
@@ -352,7 +360,7 @@ class User < ApplicationRecord
   end
 
   def support_user
-    if self.is_sponsor? || (self.is_manager? && self.antenne.national?)
+    if self.is_sponsor? || self.is_tech? || (self.is_manager? && self.antenne.national?)
       UserRight.category_main_referent.first.user
     elsif self.is_cooperation_manager?
       self.managed_cooperations.first.support_user

--- a/app/models/user_right.rb
+++ b/app/models/user_right.rb
@@ -36,7 +36,8 @@ class UserRight < ApplicationRecord
     cooperation_manager: 4,
     cooperations_referent: 5,
     territorial_referent: 6,
-    sponsor: 7
+    sponsor: 7,
+    tech: 8
   }, prefix: true
 
   ADMIN_ONLY_CATEGORIES = %i[admin national_referent main_referent cooperations_referent territorial_referent]
@@ -53,7 +54,8 @@ class UserRight < ApplicationRecord
            :only_one_user_by_referent,
            :territorial_referent_has_managed_region,
            :only_one_territorial_referent_per_region,
-           :sponsor_has_institution
+           :sponsor_has_institution,
+           :tech_institution_is_users
 
   before_validation :create_territorial_zone_if_needed
   after_save :finalize_territorial_zone_link
@@ -108,6 +110,13 @@ class UserRight < ApplicationRecord
     return if rightable_element.is_a?(Institution)
 
     errors.add(:rightable_element_id, I18n.t('errors.sponsor_without_institution'))
+  end
+
+  def tech_institution_is_users
+    return unless category_tech?
+    return if rightable_element == user.institution
+
+    errors.add(:rightable_element_id, I18n.t('errors.tech_wrong_institution'))
   end
 
   def valid_territorial_zone_region?

--- a/app/policies/user_policy.rb
+++ b/app/policies/user_policy.rb
@@ -1,0 +1,7 @@
+class UserPolicy < ApplicationPolicy
+  def api_key?
+    admin?
+  end
+
+  alias reset_api_key? api_key?
+end

--- a/app/policies/user_policy.rb
+++ b/app/policies/user_policy.rb
@@ -1,6 +1,6 @@
 class UserPolicy < ApplicationPolicy
   def api_key?
-    admin?
+    admin? || @user.is_tech?
   end
 
   alias reset_api_key? api_key?

--- a/app/views/application/_navbar.html.haml
+++ b/app/views/application/_navbar.html.haml
@@ -18,7 +18,7 @@
             %ul.fr-btns-group
               - if user_signed_in?
                 %li
-                  = link_to user_path, class: 'fr-btn' do
+                  = active_link_to user_path, class: 'fr-btn' do
                     %span.ri-user-line.fr-mr-1w{ 'aria-hidden': 'true' }
                     = t('.profile')
                 %li

--- a/app/views/users/_menu.html.haml
+++ b/app/views/users/_menu.html.haml
@@ -12,8 +12,9 @@
           = active_link_to antenne.name, antenne_user_path(antenne), { class: 'fr-sidemenu__link', wrap_tag: :li, wrap_class: 'fr-sidemenu__item', class_active: 'fr-sidemenu__item--active' }
   - else
     = active_link_to t('.antenne'), antenne_user_path(user.antenne), { class: 'fr-sidemenu__link', wrap_tag: :li, wrap_class: 'fr-sidemenu__item', class_active: 'fr-sidemenu__item--active' }
-  %li.fr-sidemenu__item
-    = active_link_to ApiKey.model_name.human, api_key_user_path, { class: 'fr-sidemenu__link', wrap_tag: :li, wrap_class: 'fr-sidemenu__item', class_active: 'fr-sidemenu__item--active' }
+  - if policy(user).api_key?
+    %li.fr-sidemenu__item
+      = active_link_to ApiKey.model_name.human, api_key_user_path, { class: 'fr-sidemenu__link', wrap_tag: :li, wrap_class: 'fr-sidemenu__item', class_active: 'fr-sidemenu__item--active' }
 
   - if user.experts.any?
     %li.fr-sidemenu__item

--- a/app/views/users/_menu.html.haml
+++ b/app/views/users/_menu.html.haml
@@ -12,6 +12,8 @@
           = active_link_to antenne.name, antenne_user_path(antenne), { class: 'fr-sidemenu__link', wrap_tag: :li, wrap_class: 'fr-sidemenu__item', class_active: 'fr-sidemenu__item--active' }
   - else
     = active_link_to t('.antenne'), antenne_user_path(user.antenne), { class: 'fr-sidemenu__link', wrap_tag: :li, wrap_class: 'fr-sidemenu__item', class_active: 'fr-sidemenu__item--active' }
+  %li.fr-sidemenu__item
+    = active_link_to ApiKey.model_name.human, api_key_user_path, { class: 'fr-sidemenu__link', wrap_tag: :li, wrap_class: 'fr-sidemenu__item', class_active: 'fr-sidemenu__item--active' }
 
   - if user.experts.any?
     %li.fr-sidemenu__item

--- a/app/views/users/registrations/api_key.html.haml
+++ b/app/views/users/registrations/api_key.html.haml
@@ -15,6 +15,6 @@
     %p= t(".valid_until_html", datetime: l(@api_key.valid_until, format: :long_sentence))
   .fr-alert.fr-alert--warning.fr-mb-2w
     %p= t(".click_to_reset")
-  = button_to t(".reset"), reset_api_key_user_path, method: :put, class: "fr-btn fr-btn--primary"
+  = button_to t(".reset"), reset_api_key_user_path, method: :put, class: "fr-btn fr-btn--primary", data: { confirm: t('.reset_confirm') }
 - else
   = button_to t(".create"), reset_api_key_user_path, method: :put, class: "fr-btn fr-btn--primary"

--- a/app/views/users/registrations/api_key.html.haml
+++ b/app/views/users/registrations/api_key.html.haml
@@ -1,0 +1,20 @@
+%h2.fr-h5= ApiKey.model_name.human
+%p.fr-mb-2w
+  = t(".description_html", institution_name: current_user.institution, documentation_path: rswag_ui_path, email: "tech@entreprises.service-public.gouv.fr")
+
+- if flash[:new_token]
+  .fr-alert.fr-alert--info.fr-mb-2w
+    %p= t(".new_token")
+    %p
+      %b= flash[:new_token]
+    %p= t(".valid_until_html", datetime: l(@api_key.valid_until, format: :long_sentence))
+    %p= t(".copy_token_now")
+- elsif @api_key.present?
+  .fr-alert.fr-alert--info.fr-mb-2w
+    %p= t(".created_at_html", datetime: l(@api_key.created_at, format: :long_sentence))
+    %p= t(".valid_until_html", datetime: l(@api_key.valid_until, format: :long_sentence))
+  .fr-alert.fr-alert--warning.fr-mb-2w
+    = t(".click_to_reset")
+  = button_to t(".reset"), reset_api_key_user_path, method: :put, class: "fr-btn fr-btn--primary"
+- else
+  = button_to t(".create"), reset_api_key_user_path, method: :put, class: "fr-btn fr-btn--primary"

--- a/app/views/users/registrations/api_key.html.haml
+++ b/app/views/users/registrations/api_key.html.haml
@@ -14,7 +14,7 @@
     %p= t(".created_at_html", datetime: l(@api_key.created_at, format: :long_sentence))
     %p= t(".valid_until_html", datetime: l(@api_key.valid_until, format: :long_sentence))
   .fr-alert.fr-alert--warning.fr-mb-2w
-    = t(".click_to_reset")
+    %p = t(".click_to_reset")
   = button_to t(".reset"), reset_api_key_user_path, method: :put, class: "fr-btn fr-btn--primary"
 - else
   = button_to t(".create"), reset_api_key_user_path, method: :put, class: "fr-btn fr-btn--primary"

--- a/app/views/users/registrations/api_key.html.haml
+++ b/app/views/users/registrations/api_key.html.haml
@@ -14,7 +14,7 @@
     %p= t(".created_at_html", datetime: l(@api_key.created_at, format: :long_sentence))
     %p= t(".valid_until_html", datetime: l(@api_key.valid_until, format: :long_sentence))
   .fr-alert.fr-alert--warning.fr-mb-2w
-    %p = t(".click_to_reset")
+    %p= t(".click_to_reset")
   = button_to t(".reset"), reset_api_key_user_path, method: :put, class: "fr-btn fr-btn--primary"
 - else
   = button_to t(".create"), reset_api_key_user_path, method: :put, class: "fr-btn fr-btn--primary"

--- a/app/views/users/registrations/api_key.html.haml
+++ b/app/views/users/registrations/api_key.html.haml
@@ -1,6 +1,6 @@
 %h2.fr-h5= ApiKey.model_name.human
 %p.fr-mb-2w
-  = t(".description_html", institution_name: current_user.institution, documentation_path: rswag_ui_path, email: "tech@entreprises.service-public.gouv.fr")
+  = t(".description_html", institution_name: current_user.institution, documentation_path: rswag_ui_path, email: ENV.fetch('TECH_EMAIL'))
 
 - if flash[:new_token]
   .fr-alert.fr-alert--info.fr-mb-2w

--- a/config/locales/fr.yml
+++ b/config/locales/fr.yml
@@ -195,6 +195,7 @@ fr:
     page_title: Erreur - %{title}
     satisfaction_without_comment: Vous ne pouvez pas partager une satisfaction sans commentaire
     sponsor_without_institution: Une institution doit être attribuée à ce pilotage ministériel
+    tech_wrong_institution: Un accès tech ne doit être attributé qu’à l’institution propre de l’utilisateur
     template:
       body: 'Veuillez vérifier les champs suivants : '
       header:

--- a/config/locales/fr.yml
+++ b/config/locales/fr.yml
@@ -195,7 +195,7 @@ fr:
     page_title: Erreur - %{title}
     satisfaction_without_comment: Vous ne pouvez pas partager une satisfaction sans commentaire
     sponsor_without_institution: Une institution doit être attribuée à ce pilotage ministériel
-    tech_wrong_institution: Un accès tech ne doit être attributé qu’à l’institution propre de l’utilisateur
+    tech_wrong_institution: Un accès tech ne doit être attribué qu’à l’institution propre de l’utilisateur
     template:
       body: 'Veuillez vérifier les champs suivants : '
       header:

--- a/config/locales/models.fr.yml
+++ b/config/locales/models.fr.yml
@@ -813,8 +813,8 @@ fr:
         one: Antenne
         other: Antennes
       api_key:
-        one: Token d’API
-        other: Tokens d’API
+        one: Jeton d’API
+        other: Jetons d’API
       commune:
         one: Commune
         other: Communes

--- a/config/locales/models.fr.yml
+++ b/config/locales/models.fr.yml
@@ -748,6 +748,7 @@ fr:
         manager: Responsable d’antenne
         national_referent: Admin - référent national
         sponsor: Pilotage ministériel
+        tech: Accès technique API
         territorial_referent: Référent régional
     errors:
       messages:
@@ -932,6 +933,9 @@ fr:
         sponsor:
           one: Droits pilotage ministériel
           other: Droits pilotage ministériel
+        tech:
+          one: Accès technique API
+          other: Accès techniques API
         territorial_referent:
           one: Droit référent régional
           other: Droits référent régional

--- a/config/locales/views.fr.yml
+++ b/config/locales/views.fr.yml
@@ -1387,6 +1387,15 @@ fr:
       antenne:
         antenne_within_institution: Antenne (au sein de %{institution})
         no_team: Pas d’équipe
+      api_key:
+        click_to_reset: Cliquez sur Réinitialiser pour en générer un nouveau. Attention, le jeton existant cessera alors de fonctionner.
+        copy_token_now: Copiez-le maintenant, il ne pourra plus vous être affiché.
+        create: Créer un jeton
+        created_at_html: Vous avez déjà un jeton d’API, créé le <b>%{datetime}</b>.
+        description_html: Un jeton est nécessaire pour utiliser l’API de Service-Public Conseillers entreprises. Le jeton est commun à toute votre institution (%{institution_name}). Vous pouvez consulter <a href="%{documentation_path}">la documentation ici</a>, et n’hésitez pas à nous contacter à l’adresse <a href="mailto:%{email}">%{email}</a>.
+        new_token: 'Votre nouveau jeton est :'
+        reset: Réinitialiser
+        valid_until_html: Il est valide jusqu’au <b>%{datetime}</b>.
     thats_you: C’est vous !
   views:
     pagination:

--- a/config/locales/views.fr.yml
+++ b/config/locales/views.fr.yml
@@ -1395,6 +1395,7 @@ fr:
         description_html: Un jeton est nécessaire pour utiliser l’API de Service-Public Conseillers entreprises. Le jeton est commun à toute votre institution (%{institution_name}). Vous pouvez consulter <a href="%{documentation_path}">la documentation ici</a>, et n’hésitez pas à nous contacter à l’adresse <a href="mailto:%{email}">%{email}</a>.
         new_token: 'Votre nouveau jeton est :'
         reset: Réinitialiser
+        reset_confirm: Attention, votre jeton existant va cesser de fonctionner. Assurez-vous qu’il n’est plus utilisé.
         valid_until_html: Il est valide jusqu’au <b>%{datetime}</b>.
     thats_you: C’est vous !
   views:

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -55,6 +55,8 @@ Rails.application.routes.draw do
       get :password, path: 'mot_de_passe'
       put :update_password
       get 'antenne/:id', action: :antenne, as: :antenne
+      get :api_key
+      put :reset_api_key
     end
   end
 

--- a/spec/factories/api_keys.rb
+++ b/spec/factories/api_keys.rb
@@ -1,6 +1,5 @@
 FactoryBot.define do
   factory :api_key do
     institution
-    sequence(:token) { |n| Faker::Lorem.word + n.to_s }
   end
 end

--- a/spec/features/admin_controller_feature_spec.rb
+++ b/spec/features/admin_controller_feature_spec.rb
@@ -43,6 +43,8 @@ describe 'admin panel' do
       click_on 'Logos'
       click_on 'Créer Logo'
 
+      click_on 'Jetons d’API'
+
       click_on 'Thématiques'
       click_on 'Créer Thématique'
 

--- a/spec/features/application_controller_feature_spec.rb
+++ b/spec/features/application_controller_feature_spec.rb
@@ -88,7 +88,7 @@ describe 'ApplicationController specific features' do
     end
 
     context 'already connected' do
-      let(:user) { create :user, password: password, password_confirmation: password, sign_in_count: 1 }
+      let(:user) { create :user, :with_expert, password: password, password_confirmation: password, sign_in_count: 1 }
 
       it('redirects to needs quo page') { expect(current_url).to eq quo_active_needs_url }
     end

--- a/spec/features/users/registrations_controller_spec.rb
+++ b/spec/features/users/registrations_controller_spec.rb
@@ -80,4 +80,28 @@ describe 'registrations' do
       end
     end
   end
+
+  describe 'api key management' do
+    login_user
+
+    before do
+      current_user.user_rights_tech.create(institution: current_user.institution)
+    end
+
+    it 'lets user create and reset an api key' do
+      visit api_key_user_path
+      click_on 'Créer un jeton'
+      expect(page).to have_text 'Votre nouveau jeton est'
+
+      page.refresh
+      expect(page).to have_text 'Vous avez déjà un jeton d’API'
+      api_key = current_user.institution.reload.api_key
+      expect(api_key).not_to be_nil
+
+      click_on 'Réinitialiser'
+      new_api_key = current_user.institution.reload.api_key
+      expect(api_key).not_to eq new_api_key
+      expect(ApiKey.exists?(api_key.id)).to be false
+    end
+  end
 end

--- a/spec/requests/api/v1/authentication_spec.rb
+++ b/spec/requests/api/v1/authentication_spec.rb
@@ -17,16 +17,12 @@ RSpec.describe "Authentication API" do
 
       expect(response).not_to be_successful
       expect(response).to have_http_status(:not_found)
-      expect(json["errors"]).to eq([{ "message" => "n’existe pas ou est invalide", "source" => "Token d’API" }])
+      expect(json["errors"]).to eq([{ "message" => "n’existe pas ou est invalide", "source" => "Jeton d’API" }])
     end
   end
 
   describe "when token without institution" do
-    let(:token) { SecureRandom.hex(32) }
-
-    before do
-      ApiKey.create(token: token)
-    end
+    let(:token) { ApiKey.create.token }
 
     it 'returns error' do
       get "/api/v1/landings", headers: { 'Authorization' => "Bearer token=#{token}" }
@@ -34,7 +30,7 @@ RSpec.describe "Authentication API" do
 
       expect(response).not_to be_successful
       expect(response).to have_http_status(:not_found)
-      expect(json["errors"]).to eq([{ "message" => "n’existe pas ou est invalide", "source" => "Token d’API" }])
+      expect(json["errors"]).to eq([{ "message" => "n’existe pas ou est invalide", "source" => "Jeton d’API" }])
     end
   end
 

--- a/spec/requests/api/v1/landings_spec.rb
+++ b/spec/requests/api/v1/landings_spec.rb
@@ -81,7 +81,7 @@ RSpec.describe "Landings API" do
           run_test! do |response|
             expect(response.status).to eq(404)
             result = JSON.parse(response.body)
-            expect(result["errors"].first["source"]).to eq('Token d’API')
+            expect(result["errors"].first["source"]).to eq('Jeton d’API')
             expect(result["errors"].first["message"]).to eq('n’existe pas ou est invalide')
           end
         end


### PR DESCRIPTION
fixes #4598

Ça ressemble à ça:

<img width="1357" height="972" alt="Capture d’écran 2026-07-20 à 18 21 26" src="https://github.com/user-attachments/assets/d8155c64-c89a-4fc6-a95b-8b924037e9f1" />

<img width="1357" height="972" alt="Capture d’écran 2026-07-20 à 18 21 32" src="https://github.com/user-attachments/assets/e3ec8f1a-563d-455b-9ea4-e2839a864b31" />

<img width="1340" height="584" alt="Capture d’écran 2026-07-20 à 18 20 42" src="https://github.com/user-attachments/assets/537899d9-a1c1-4f1d-ac8f-02d4312e1d67" />

Et l’admin:

<img width="1357" height="972" alt="Capture d’écran 2026-07-20 à 18 21 14" src="https://github.com/user-attachments/assets/047f26f1-bf25-47a7-bcff-5c83b17f1544" />
