### PR TITLE
Properly display the cooperation matches stats according to the user

### DIFF
--- a/app/controllers/conseiller/cooperations_controller.rb
+++ b/app/controllers/conseiller/cooperations_controller.rb
@@ -30,7 +30,11 @@ class Conseiller::CooperationsController < ApplicationController
   end
 
   def matches
-    init_filters(institutions: [@cooperation.institution, current_user.institution])
+    if current_user.is_sponsor?
+      init_filters(institutions: current_user.sponsored_institutions)
+    else
+      init_filters
+    end
     set_stats_params(cooperation_id: @cooperation.id)
     @charts_names = CHART_NAMES[:matches]
   end


### PR DESCRIPTION
followup #4600

Cooperation managers only view the matches of their own institution:

<img width="1037" height="403" alt="image" src="https://github.com/user-attachments/assets/545b9953-b1a4-49ed-a339-fcb7ea7f77d2" />

Sponsors can select from all the institution they sponsor:

<img width="887" height="370" alt="image" src="https://github.com/user-attachments/assets/420e104a-5f57-4ef1-99bc-053bf2945676" />

fixes #4562 again :)