### PR TITLE
Séparer les responsables principaux et les responsables d’autres antennes

### DIFF
--- a/app/admin/cooperation.rb
+++ b/app/admin/cooperation.rb
@@ -58,9 +58,11 @@ ActiveAdmin.register Cooperation do
       row(:landings) do |c|
         div admin_link_to(c, :landings, list: true)
       end
-      row(:managers) do |c|
-        name_proc = -> (manager) { manager.institution == c.institution ? manager : "#{manager} (#{manager.institution})" }
-        div admin_link_to(c, :managers, list: true, name: name_proc)
+      row(:main_institution_managers) do |c|
+        div admin_link_to(c, :main_institution_managers, list: true)
+      end
+      row(:other_institution_managers) do |c|
+        div admin_link_to(c, :other_institution_managers, list: true, name: -> (m) { "#{m} (#{m.institution})" })
       end
     end
   end

--- a/app/models/cooperation.rb
+++ b/app/models/cooperation.rb
@@ -47,6 +47,8 @@ class Cooperation < ApplicationRecord
   has_many :user_rights, as: :rightable_element, dependent: :destroy, inverse_of: :rightable_element
   has_many :user_rights_cooperation_manager, ->{ category_cooperation_manager }, as: :rightable_element, class_name: 'UserRight', inverse_of: :rightable_element
   has_many :managers, through: :user_rights_cooperation_manager, source: :user, inverse_of: :managed_cooperations
+  has_many :main_institution_managers, -> (c) { joins(:antenne).where(antennes: { institution: c.institution }) }, through: :user_rights_cooperation_manager, source: :user, inverse_of: :managed_cooperations
+  has_many :other_institution_managers, -> (c) { joins(:antenne).where.not(antennes: { institution: c.institution }) }, through: :user_rights_cooperation_manager, source: :user, inverse_of: :managed_cooperations
 
   has_many :activity_reports, as: :reportable, dependent: :destroy, inverse_of: :reportable
   has_many :cooperation_reports, -> { category_cooperation }, class_name: 'ActivityReport', dependent: :destroy, inverse_of: :reportable

--- a/config/locales/models.fr.yml
+++ b/config/locales/models.fr.yml
@@ -268,6 +268,8 @@ fr:
         display_url: Afficher l’url du partenaire
         external: Coopération externe
         landings_or_mtm: Landing / Campagne
+        main_institution_managers: Responsables principaux
+        other_institution_managers: Responsables d’autres institutions
         wants_solicitations_export: Générer l’export de solicitations
       diagnosis:
         content: Commentaire

--- a/spec/models/cooperation_spec.rb
+++ b/spec/models/cooperation_spec.rb
@@ -37,4 +37,18 @@ RSpec.describe Cooperation do
       expect(landing_01.reload.archived_at).to be_nil
     end
   end
+
+  describe 'managers' do
+    let(:institution1) { create :institution }
+    let(:institution2) { create :institution }
+    let(:manager1) { create :user, institution: institution1 }
+    let(:manager2) { create :user, institution: institution2 }
+    let(:cooperation) { create :cooperation, institution: institution1, managers: [manager1, manager2] }
+
+    it do
+      expect(cooperation.managers).to contain_exactly(manager1, manager2)
+      expect(cooperation.main_institution_managers).to contain_exactly(manager1)
+      expect(cooperation.other_institution_managers).to contain_exactly(manager2)
+    end
+  end
 end


### PR DESCRIPTION
refs #4610 (second point)