### PR TITLE
Mise à jour de la tache de mise en production et du message qui affiche les dernières PRs

### DIFF
--- a/lib/tasks/production_announcement.rake
+++ b/lib/tasks/production_announcement.rake
@@ -1,0 +1,64 @@
+desc 'Generate the production release announcement for the team chat'
+task :production_announcement do
+  require 'json'
+
+  def deploy_range
+    # Production tip is a merge of main into production: its second parent is the deployed main commit
+    deployed = `git show -s --pretty=%P production | cut -d " " -f 2`.strip
+    exit unless $?.success?
+    if `git log --merges --oneline #{deployed}..main`.strip.empty?
+      # Nothing new on main: announce the last deploy instead
+      previously_deployed = `git show -s --pretty=%P production^1 | cut -d " " -f 2`.strip
+      [previously_deployed, deployed]
+    else
+      [deployed, 'main']
+    end
+  end
+
+  def merged_pr_numbers(range)
+    `git log --merges --pretty=%s #{range.join('..')}`.scan(/pull request #(\d+)/).flatten
+  end
+
+  def fetch_pr(pr_number)
+    query = "{ repository(owner: \"betagouv\", name: \"conseillers-entreprises\") { pullRequest(number: #{pr_number}) { number title body closingIssuesReferences(first: 10) { nodes { title labels(first: 10) { nodes { name } } } } } } }"
+    response = `gh api graphql -f query='#{query}' 2> /dev/null`
+    return nil unless $?.success?
+    JSON.parse(response).dig('data', 'repository', 'pullRequest')
+  end
+
+  def describe_pr(pr)
+    issues = pr['closingIssuesReferences']['nodes'].map do |issue|
+      "Issue liée : #{issue['title']} — labels : #{issue['labels']['nodes'].pluck('name').join(', ')}"
+    end
+    ["## PR ##{pr['number']} : #{pr['title']}", *issues, pr['body'].to_s[0, 1500]].join("\n")
+  end
+
+  def generate_announcement(digest)
+    prompt = File.read(File.expand_path('production_announcement_prompt.md', __dir__))
+    output = IO.popen(['claude', '-p'], 'r+') do |io|
+      io.write("#{prompt}\n\n---\n\n#{digest}")
+      io.close_write
+      io.read
+    end
+    output if $?.success?
+  rescue Errno::ENOENT
+    nil
+  end
+
+  range = deploy_range
+  puts "Generating announcement for #{range.join('..')}…"
+
+  prs = merged_pr_numbers(range).filter_map{ |number| fetch_pr(number) }
+  if prs.empty?
+    puts 'Could not fetch the PR details (is gh installed and authenticated?). Exiting.'
+    exit
+  end
+
+  announcement = generate_announcement(prs.map{ |pr| describe_pr(pr) }.join("\n\n"))
+  if announcement
+    puts announcement
+  else
+    puts 'claude CLI unavailable, falling back to the raw PR list:'
+    prs.each{ |pr| puts "* [##{pr['number']}](https://github.com/betagouv/conseillers-entreprises/pull/#{pr['number']}) #{pr['title']}" }
+  end
+end

--- a/lib/tasks/production_announcement.rake
+++ b/lib/tasks/production_announcement.rake
@@ -1,3 +1,19 @@
+PRODUCTION_ANNOUNCEMENT_SECTION_BY_LABEL = {
+  '🧑‍🏭 entreprises' => :entreprises,
+  '🧑‍🔧 partenaires' => :partenaires,
+  '👩‍💻 équipe CE' => :equipe,
+  'tech | maintenance' => :tech
+}.freeze
+
+PRODUCTION_ANNOUNCEMENT_SECTION_TITLES = {
+  entreprises: '**🧑‍🏭 Pour les entreprises**',
+  partenaires: '**🧑‍🔧 Pour les partenaires**',
+  equipe: "**👩‍💻 Pour l'équipe**",
+  tech: "**⚙️ Tech** — *pas d'impact visible*"
+}.freeze
+
+PRODUCTION_ANNOUNCEMENT_BUG_LABEL = '🐛 bug'
+
 desc "Generate the production release announcement for the team chat. Optional args: [from,to] commit range, e.g. rake 'production_announcement[abc123,def456]' to test by hand"
 task :production_announcement, [:from, :to] do |_t, args|
   require 'json'
@@ -26,11 +42,47 @@ task :production_announcement, [:from, :to] do |_t, args|
     JSON.parse(response).dig('data', 'repository', 'pullRequest')
   end
 
+  def closing_issues_labels(pr)
+    pr['closingIssuesReferences']['nodes'].flat_map{ |issue| issue['labels']['nodes'].pluck('name') }
+  end
+
+  # Deterministic classification from the closing issues' labels. Returns nil
+  # when no unambiguous label matched, meaning Claude has to decide instead.
+  def classify_section(pr)
+    labels = closing_issues_labels(pr)
+    PRODUCTION_ANNOUNCEMENT_SECTION_BY_LABEL.each do |label, section|
+      return section if labels.include?(label)
+    end
+    nil
+  end
+
   def describe_pr(pr)
     issues = pr['closingIssuesReferences']['nodes'].map do |issue|
       "Issue liée : #{issue['title']} — labels : #{issue['labels']['nodes'].pluck('name').join(', ')}"
     end
-    ["## PR ##{pr['number']} : #{pr['title']}", *issues, pr['body'].to_s[0, 1500]].join("\n")
+    is_bug = closing_issues_labels(pr).include?(PRODUCTION_ANNOUNCEMENT_BUG_LABEL)
+    lines = ["## PR ##{pr['number']} : #{pr['title']}", *issues]
+    lines << 'Label : 🐛 bug' if is_bug
+    [*lines, pr['body'].to_s[0, 1500]].join("\n")
+  end
+
+  # Groups PRs by their deterministic section, so Claude only has to write the
+  # announcement lines and classify the few PRs left without a clear label.
+  def build_digest(prs)
+    by_section = prs.group_by{ |pr| classify_section(pr) }
+
+    sections = PRODUCTION_ANNOUNCEMENT_SECTION_TITLES.filter_map do |key, title|
+      section_prs = by_section[key]
+      next if section_prs.blank?
+      "### Section : #{title}\n\n#{section_prs.map{ |pr| describe_pr(pr) }.join("\n\n")}"
+    end
+
+    unclassified = by_section[nil]
+    if unclassified.present?
+      sections << "### À classer toi-même dans une des sections ci-dessus\n\n#{unclassified.map{ |pr| describe_pr(pr) }.join("\n\n")}"
+    end
+
+    sections.join("\n\n")
   end
 
   def generate_announcement(digest)
@@ -54,7 +106,7 @@ task :production_announcement, [:from, :to] do |_t, args|
     exit
   end
 
-  announcement = generate_announcement(prs.map{ |pr| describe_pr(pr) }.join("\n\n"))
+  announcement = generate_announcement(build_digest(prs))
   if announcement
     puts announcement
   else

--- a/lib/tasks/production_announcement.rake
+++ b/lib/tasks/production_announcement.rake
@@ -27,7 +27,7 @@ module ProductionAnnouncement
         puts "ERROR: git show failed for #{ref} (does the branch exist locally?). Exiting."
         exit
       end
-      parents.split(' ')[1]
+      parents.split[1]
     end
 
     def deploy_range
@@ -85,6 +85,28 @@ module ProductionAnnouncement
       sections.join("\n\n")
     end
 
+    def link_pr(pr)
+      is_bug = ProductionHelpers.closing_issues_labels(pr).include?(PRODUCTION_ANNOUNCEMENT_BUG_LABEL)
+      "* #{'🐛️ ' if is_bug}[##{pr['number']}](https://github.com/betagouv/conseillers-entreprises/pull/#{pr['number']}) #{pr['title']}"
+    end
+
+    # Same section grouping as build_digest, without Claude's rewording — used
+    # as a fallback when the claude CLI is unavailable.
+    def plain_text_digest(prs)
+      by_section = prs.group_by{ |pr| classify_section(pr) }
+
+      sections = PRODUCTION_ANNOUNCEMENT_SECTION_TITLES.filter_map do |key, title|
+        section_prs = by_section[key]
+        next if section_prs.blank?
+        "#{title}\n#{section_prs.map{ |pr| link_pr(pr) }.join("\n")}"
+      end
+
+      unclassified = by_section[nil]
+      sections << unclassified.map{ |pr| link_pr(pr) }.join("\n") if unclassified.present?
+
+      sections.join("\n\n")
+    end
+
     def generate_announcement(digest)
       prompt = File.read(File.expand_path('production_announcement_prompt.md', __dir__))
       output = IO.popen(['claude', '-p'], 'r+') do |io|
@@ -111,7 +133,7 @@ module ProductionAnnouncement
           exit
         end
 
-        missing = pr_numbers.map(&:to_i) - prs.map{ |pr| pr['number'] }
+        missing = pr_numbers.map(&:to_i) - prs.pluck('number')
         puts "WARNING: could not fetch #{missing.size} PR(s), they will be missing from the announcement: #{missing.join(', ')}" if missing.any?
       end
 
@@ -119,8 +141,8 @@ module ProductionAnnouncement
       if announcement
         puts announcement
       else
-        puts 'claude CLI unavailable, falling back to the raw PR list:'
-        prs.each{ |pr| puts "* [##{pr['number']}](https://github.com/betagouv/conseillers-entreprises/pull/#{pr['number']}) #{pr['title']}" }
+        puts 'claude CLI unavailable, falling back to a plain PR list grouped by section:'
+        puts plain_text_digest(prs)
       end
     end
   end

--- a/lib/tasks/production_announcement.rake
+++ b/lib/tasks/production_announcement.rake
@@ -1,3 +1,5 @@
+require_relative 'production_helpers'
+
 PRODUCTION_ANNOUNCEMENT_SECTION_BY_LABEL = {
   '🧑‍🏭 entreprises' => :entreprises,
   '🧑‍🔧 partenaires' => :partenaires,
@@ -14,117 +16,117 @@ PRODUCTION_ANNOUNCEMENT_SECTION_TITLES = {
 
 PRODUCTION_ANNOUNCEMENT_BUG_LABEL = '🐛 bug'
 
+# Builds and prints the release announcement. Callable directly with
+# already-fetched PRs (used by push_to_production.rake to avoid re-fetching
+# the same PRs from the GitHub API), or run standalone as a rake task.
+module ProductionAnnouncement
+  class << self
+    def second_parent(ref)
+      parents = `git show -s --pretty=%P #{ref}`.strip
+      unless $?.success?
+        puts "ERROR: git show failed for #{ref} (does the branch exist locally?). Exiting."
+        exit
+      end
+      parents.split(' ')[1]
+    end
+
+    def deploy_range
+      # Production tip is a merge of main into production: its second parent is the deployed main commit
+      deployed = second_parent('production')
+      if `git log --merges --oneline #{deployed}..main`.strip.empty?
+        # Nothing new on main: announce the last deploy instead
+        previously_deployed = second_parent('production^1')
+        [previously_deployed, deployed]
+      else
+        [deployed, 'main']
+      end
+    end
+
+    def merged_pr_numbers(range)
+      `git log --merges --pretty=%s #{range.join('..')}`.scan(/pull request #(\d+)/).flatten
+    end
+
+    # Deterministic classification from the closing issues' labels. Returns nil
+    # when no unambiguous label matched, meaning Claude has to decide instead.
+    def classify_section(pr)
+      labels = ProductionHelpers.closing_issues_labels(pr)
+      PRODUCTION_ANNOUNCEMENT_SECTION_BY_LABEL.each do |label, section|
+        return section if labels.include?(label)
+      end
+      nil
+    end
+
+    def describe_pr(pr)
+      issues = pr['closingIssuesReferences']['nodes'].map do |issue|
+        "Issue liée : #{issue['title']} — labels : #{issue['labels']['nodes'].pluck('name').join(', ')}"
+      end
+      is_bug = ProductionHelpers.closing_issues_labels(pr).include?(PRODUCTION_ANNOUNCEMENT_BUG_LABEL)
+      lines = ["## PR ##{pr['number']} : #{pr['title']}", *issues]
+      lines << 'Label : 🐛 bug' if is_bug
+      [*lines, pr['body'].to_s[0, 1500]].join("\n")
+    end
+
+    # Groups PRs by their deterministic section, so Claude only has to write the
+    # announcement lines and classify the few PRs left without a clear label.
+    def build_digest(prs)
+      by_section = prs.group_by{ |pr| classify_section(pr) }
+
+      sections = PRODUCTION_ANNOUNCEMENT_SECTION_TITLES.filter_map do |key, title|
+        section_prs = by_section[key]
+        next if section_prs.blank?
+        "### Section : #{title}\n\n#{section_prs.map{ |pr| describe_pr(pr) }.join("\n\n")}"
+      end
+
+      unclassified = by_section[nil]
+      if unclassified.present?
+        sections << "### À classer toi-même dans une des sections ci-dessus\n\n#{unclassified.map{ |pr| describe_pr(pr) }.join("\n\n")}"
+      end
+
+      sections.join("\n\n")
+    end
+
+    def generate_announcement(digest)
+      prompt = File.read(File.expand_path('production_announcement_prompt.md', __dir__))
+      output = IO.popen(['claude', '-p'], 'r+') do |io|
+        io.write("#{prompt}\n\n---\n\n#{digest}")
+        io.close_write
+        io.read
+      end
+      output if $?.success? && output.present?
+    rescue Errno::ENOENT
+      nil
+    end
+
+    # prs: optional pre-fetched PR hashes (as returned by ProductionHelpers.fetch_pr),
+    # to avoid re-fetching them when the caller already has them (see push_to_production.rake).
+    def run(from: nil, to: nil, prs: nil)
+      if prs.nil?
+        range = from && to ? [from, to] : deploy_range
+        puts "Generating announcement for #{range.join('..')}…"
+
+        pr_numbers = merged_pr_numbers(range)
+        prs = pr_numbers.filter_map{ |number| ProductionHelpers.fetch_pr(number) }
+        if prs.empty?
+          puts 'Could not fetch the PR details (is gh installed and authenticated?). Exiting.'
+          exit
+        end
+
+        missing = pr_numbers.map(&:to_i) - prs.map{ |pr| pr['number'] }
+        puts "WARNING: could not fetch #{missing.size} PR(s), they will be missing from the announcement: #{missing.join(', ')}" if missing.any?
+      end
+
+      announcement = generate_announcement(build_digest(prs))
+      if announcement
+        puts announcement
+      else
+        puts 'claude CLI unavailable, falling back to the raw PR list:'
+        prs.each{ |pr| puts "* [##{pr['number']}](https://github.com/betagouv/conseillers-entreprises/pull/#{pr['number']}) #{pr['title']}" }
+      end
+    end
+  end
+end
+
 desc "Generate the production release announcement for the team chat. Optional args: [from,to] commit range, e.g. rake 'production_announcement[abc123,def456]' to test by hand"
 task :production_announcement, [:from, :to] do |_t, args|
-  require 'json'
-
-  def second_parent(ref)
-    parents = `git show -s --pretty=%P #{ref}`.strip
-    unless $?.success?
-      puts "ERROR: git show failed for #{ref} (does the branch exist locally?). Exiting."
-      exit
-    end
-    parents.split(' ')[1]
-  end
-
-  def deploy_range
-    # Production tip is a merge of main into production: its second parent is the deployed main commit
-    deployed = second_parent('production')
-    if `git log --merges --oneline #{deployed}..main`.strip.empty?
-      # Nothing new on main: announce the last deploy instead
-      previously_deployed = second_parent('production^1')
-      [previously_deployed, deployed]
-    else
-      [deployed, 'main']
-    end
-  end
-
-  def merged_pr_numbers(range)
-    `git log --merges --pretty=%s #{range.join('..')}`.scan(/pull request #(\d+)/).flatten
-  end
-
-  def fetch_pr(pr_number)
-    query = "{ repository(owner: \"betagouv\", name: \"conseillers-entreprises\") { pullRequest(number: #{pr_number}) { number title body closingIssuesReferences(first: 10) { nodes { title labels(first: 10) { nodes { name } } } } } } }"
-    response = `gh api graphql -f query='#{query}' 2> /dev/null`
-    return nil unless $?.success?
-    JSON.parse(response).dig('data', 'repository', 'pullRequest')
-  rescue JSON::ParserError
-    nil
-  end
-
-  def closing_issues_labels(pr)
-    pr['closingIssuesReferences']['nodes'].flat_map{ |issue| issue['labels']['nodes'].pluck('name') }
-  end
-
-  # Deterministic classification from the closing issues' labels. Returns nil
-  # when no unambiguous label matched, meaning Claude has to decide instead.
-  def classify_section(pr)
-    labels = closing_issues_labels(pr)
-    PRODUCTION_ANNOUNCEMENT_SECTION_BY_LABEL.each do |label, section|
-      return section if labels.include?(label)
-    end
-    nil
-  end
-
-  def describe_pr(pr)
-    issues = pr['closingIssuesReferences']['nodes'].map do |issue|
-      "Issue liée : #{issue['title']} — labels : #{issue['labels']['nodes'].pluck('name').join(', ')}"
-    end
-    is_bug = closing_issues_labels(pr).include?(PRODUCTION_ANNOUNCEMENT_BUG_LABEL)
-    lines = ["## PR ##{pr['number']} : #{pr['title']}", *issues]
-    lines << 'Label : 🐛 bug' if is_bug
-    [*lines, pr['body'].to_s[0, 1500]].join("\n")
-  end
-
-  # Groups PRs by their deterministic section, so Claude only has to write the
-  # announcement lines and classify the few PRs left without a clear label.
-  def build_digest(prs)
-    by_section = prs.group_by{ |pr| classify_section(pr) }
-
-    sections = PRODUCTION_ANNOUNCEMENT_SECTION_TITLES.filter_map do |key, title|
-      section_prs = by_section[key]
-      next if section_prs.blank?
-      "### Section : #{title}\n\n#{section_prs.map{ |pr| describe_pr(pr) }.join("\n\n")}"
-    end
-
-    unclassified = by_section[nil]
-    if unclassified.present?
-      sections << "### À classer toi-même dans une des sections ci-dessus\n\n#{unclassified.map{ |pr| describe_pr(pr) }.join("\n\n")}"
-    end
-
-    sections.join("\n\n")
-  end
-
-  def generate_announcement(digest)
-    prompt = File.read(File.expand_path('production_announcement_prompt.md', __dir__))
-    output = IO.popen(['claude', '-p'], 'r+') do |io|
-      io.write("#{prompt}\n\n---\n\n#{digest}")
-      io.close_write
-      io.read
-    end
-    output if $?.success? && output.present?
-  rescue Errno::ENOENT
-    nil
-  end
-
-  range = args[:from] && args[:to] ? [args[:from], args[:to]] : deploy_range
-  puts "Generating announcement for #{range.join('..')}…"
-
-  pr_numbers = merged_pr_numbers(range)
-  prs = pr_numbers.filter_map{ |number| fetch_pr(number) }
-  if prs.empty?
-    puts 'Could not fetch the PR details (is gh installed and authenticated?). Exiting.'
-    exit
-  end
-
-  missing = pr_numbers.map(&:to_i) - prs.map{ |pr| pr['number'] }
-  puts "WARNING: could not fetch #{missing.size} PR(s), they will be missing from the announcement: #{missing.join(', ')}" if missing.any?
-
-  announcement = generate_announcement(build_digest(prs))
-  if announcement
-    puts announcement
-  else
-    puts 'claude CLI unavailable, falling back to the raw PR list:'
-    prs.each{ |pr| puts "* [##{pr['number']}](https://github.com/betagouv/conseillers-entreprises/pull/#{pr['number']}) #{pr['title']}" }
-  end
+  ProductionAnnouncement.run(from: args[:from], to: args[:to])
 end

--- a/lib/tasks/production_announcement.rake
+++ b/lib/tasks/production_announcement.rake
@@ -1,5 +1,5 @@
-desc 'Generate the production release announcement for the team chat'
-task :production_announcement do
+desc "Generate the production release announcement for the team chat. Optional args: [from,to] commit range, e.g. rake 'production_announcement[abc123,def456]' to test by hand"
+task :production_announcement, [:from, :to] do |_t, args|
   require 'json'
 
   def deploy_range
@@ -45,7 +45,7 @@ task :production_announcement do
     nil
   end
 
-  range = deploy_range
+  range = args[:from] && args[:to] ? [args[:from], args[:to]] : deploy_range
   puts "Generating announcement for #{range.join('..')}…"
 
   prs = merged_pr_numbers(range).filter_map{ |number| fetch_pr(number) }

--- a/lib/tasks/production_announcement.rake
+++ b/lib/tasks/production_announcement.rake
@@ -18,13 +18,21 @@ desc "Generate the production release announcement for the team chat. Optional a
 task :production_announcement, [:from, :to] do |_t, args|
   require 'json'
 
+  def second_parent(ref)
+    parents = `git show -s --pretty=%P #{ref}`.strip
+    unless $?.success?
+      puts "ERROR: git show failed for #{ref} (does the branch exist locally?). Exiting."
+      exit
+    end
+    parents.split(' ')[1]
+  end
+
   def deploy_range
     # Production tip is a merge of main into production: its second parent is the deployed main commit
-    deployed = `git show -s --pretty=%P production | cut -d " " -f 2`.strip
-    exit unless $?.success?
+    deployed = second_parent('production')
     if `git log --merges --oneline #{deployed}..main`.strip.empty?
       # Nothing new on main: announce the last deploy instead
-      previously_deployed = `git show -s --pretty=%P production^1 | cut -d " " -f 2`.strip
+      previously_deployed = second_parent('production^1')
       [previously_deployed, deployed]
     else
       [deployed, 'main']
@@ -40,6 +48,8 @@ task :production_announcement, [:from, :to] do |_t, args|
     response = `gh api graphql -f query='#{query}' 2> /dev/null`
     return nil unless $?.success?
     JSON.parse(response).dig('data', 'repository', 'pullRequest')
+  rescue JSON::ParserError
+    nil
   end
 
   def closing_issues_labels(pr)
@@ -92,7 +102,7 @@ task :production_announcement, [:from, :to] do |_t, args|
       io.close_write
       io.read
     end
-    output if $?.success?
+    output if $?.success? && output.present?
   rescue Errno::ENOENT
     nil
   end
@@ -100,11 +110,15 @@ task :production_announcement, [:from, :to] do |_t, args|
   range = args[:from] && args[:to] ? [args[:from], args[:to]] : deploy_range
   puts "Generating announcement for #{range.join('..')}…"
 
-  prs = merged_pr_numbers(range).filter_map{ |number| fetch_pr(number) }
+  pr_numbers = merged_pr_numbers(range)
+  prs = pr_numbers.filter_map{ |number| fetch_pr(number) }
   if prs.empty?
     puts 'Could not fetch the PR details (is gh installed and authenticated?). Exiting.'
     exit
   end
+
+  missing = pr_numbers.map(&:to_i) - prs.map{ |pr| pr['number'] }
+  puts "WARNING: could not fetch #{missing.size} PR(s), they will be missing from the announcement: #{missing.join(', ')}" if missing.any?
 
   announcement = generate_announcement(build_digest(prs))
   if announcement

--- a/lib/tasks/production_announcement_prompt.md
+++ b/lib/tasks/production_announcement_prompt.md
@@ -1,0 +1,42 @@
+# Annonce de mise en production
+
+Tu rédiges le message d'annonce d'une mise en production de « Conseillers-Entreprises », destiné au canal de discussion de l'équipe. La majorité des lecteurs ne sont pas développeurs : ils doivent comprendre chaque ligne sans contexte technique, et savoir immédiatement ce qu'ils peuvent ignorer.
+
+À partir de la liste des PRs fournie après le séparateur `---`, rédige le message en respectant exactement le format de l'exemple ci-dessous.
+
+## Règles
+
+1. Regroupe les changements par public, dans cet ordre, en omettant les sections vides :
+   - `**🧑‍🏭 Pour les entreprises**`
+   - `**🧑‍🔧 Pour les partenaires**`
+   - `**👩‍💻 Pour l'équipe**`
+   - `**⚙️ Tech** — *pas d'impact visible, vous pouvez passer*`
+
+   Choisis la section d'après les labels des issues liées (🧑‍🏭 entreprises, 🧑‍🔧 partenaires, 👩‍💻 équipe CE). Sans label, déduis le public du titre et de la description. Tout ce qui n'a pas d'impact visible pour un utilisateur (refactoring, dépendances, CI, nettoyage…) va en Tech.
+2. Une ligne par changement : une seule phrase en français courant, factuelle, compréhensible sans contexte technique. Pas de jargon (aucun nom de classe, de gem, de layout, de table…). Conserve tels quels les acronymes et noms propres utilisés par l'équipe dans les issues (MER, TIH, DILA, CESP…), sans les développer.
+3. Termine chaque ligne par « → » suivi du ou des liens vers les PRs, au format `[#1234](https://github.com/betagouv/conseillers-entreprises/pull/1234)`.
+4. Fusionne en une seule ligne les PRs qui participent au même changement (followups, ajustements l'une de l'autre).
+5. Préfixe la ligne de 🛠️ quand c'est une correction de bug (label « 🛠️ bug » ou nature évidente).
+6. Commence le message par `🚀 **En production aujourd'hui** — N PRs` où N est le nombre total de PRs.
+7. Réponds uniquement avec le message final en markdown, sans commentaire ni introduction.
+
+## Exemple de sortie
+
+🚀 **En production aujourd'hui** — 10 PRs
+
+**🧑‍🏭 Pour les entreprises**
+- La brochure PDF a été mise à jour → [#4603](https://github.com/betagouv/conseillers-entreprises/pull/4603)
+- 🛠️ Corrections d'accessibilité suite aux retours TIH → [#4569](https://github.com/betagouv/conseillers-entreprises/pull/4569)
+- Les pages témoignages des conseillers sont mieux référencées sur Google → [#4602](https://github.com/betagouv/conseillers-entreprises/pull/4602)
+
+**🧑‍🔧 Pour les partenaires**
+- Les sponsors d'institutions ont maintenant accès aux stats de leurs antennes, avec un champ de recherche → [#4563](https://github.com/betagouv/conseillers-entreprises/pull/4563)
+- Un même compte peut suivre les stats de plusieurs coopérations, et chacun ne voit que les mises en relation de son périmètre → [#4600](https://github.com/betagouv/conseillers-entreprises/pull/4600) [#4607](https://github.com/betagouv/conseillers-entreprises/pull/4607)
+- Dans le compte, les responsables principaux et ceux des autres antennes sont maintenant présentés séparément → [#4611](https://github.com/betagouv/conseillers-entreprises/pull/4611)
+
+**👩‍💻 Pour l'équipe**
+- On peut désormais créer soi-même des jetons d'API dans l'admin (première utilisation : l'équipe IA de la DILA) → [#4605](https://github.com/betagouv/conseillers-entreprises/pull/4605)
+- Le bouton de génération des rapports dans l'admin est plus clair → [#4597](https://github.com/betagouv/conseillers-entreprises/pull/4597)
+
+**⚙️ Tech** — *pas d'impact visible, vous pouvez passer*
+- Nettoyage d'un vieux layout interne → [#4609](https://github.com/betagouv/conseillers-entreprises/pull/4609)

--- a/lib/tasks/production_announcement_prompt.md
+++ b/lib/tasks/production_announcement_prompt.md
@@ -6,17 +6,17 @@ Tu rédiges le message d'annonce d'une mise en production de « Conseillers-Entr
 
 ## Règles
 
-1. Regroupe les changements par public, dans cet ordre, en omettant les sections vides :
+1. Le digest te donne les PRs déjà groupées par section (`### Section : ...`), sauf celles du groupe `### À classer toi-même dans une des sections ci-dessus` : pour celles-là, déduis la section du titre et de la description. Restitue les sections dans cet ordre, en omettant celles qui sont vides au final :
    - `**🧑‍🏭 Pour les entreprises**`
    - `**🧑‍🔧 Pour les partenaires**`
    - `**👩‍💻 Pour l'équipe**`
-   - `**⚙️ Tech** — *pas d'impact visible, vous pouvez passer*`
+   - `**⚙️ Tech** — *pas d'impact visible*`
 
-   Choisis la section d'après les labels des issues liées (🧑‍🏭 entreprises, 🧑‍🔧 partenaires, 👩‍💻 équipe CE). Sans label, déduis le public du titre et de la description. Tout ce qui n'a pas d'impact visible pour un utilisateur (refactoring, dépendances, CI, nettoyage…) va en Tech.
+   Tout ce qui n'a pas d'impact visible pour un utilisateur (refactoring, dépendances, CI, nettoyage…) va en Tech.
 2. Une ligne par changement : une seule phrase en français courant, factuelle, compréhensible sans contexte technique. Pas de jargon (aucun nom de classe, de gem, de layout, de table…). Conserve tels quels les acronymes et noms propres utilisés par l'équipe dans les issues (MER, TIH, DILA, CESP…), sans les développer.
 3. Termine chaque ligne par « → » suivi du ou des liens vers les PRs, au format `[#1234](https://github.com/betagouv/conseillers-entreprises/pull/1234)`.
-4. Fusionne en une seule ligne les PRs qui participent au même changement (followups, ajustements l'une de l'autre).
-5. Préfixe la ligne de 🛠️ quand c'est une correction de bug (label « 🛠️ bug » ou nature évidente).
+4. Fusionne en une seule ligne les PRs qui participent au même changement (followups, ajustements l'une de l'autre), même si elles ne sont pas dans la même section du digest — dans ce cas choisis la section la plus pertinente pour le lecteur.
+5. Préfixe la ligne de 🛠️ quand c'est une correction de bug (`Label : 🐛 bug` indiqué dans le digest, ou nature évidente d'après le titre/la description).
 6. Commence le message par `🚀 **En production aujourd'hui** — N PRs` où N est le nombre total de PRs.
 7. Réponds uniquement avec le message final en markdown, sans commentaire ni introduction.
 
@@ -38,5 +38,5 @@ Tu rédiges le message d'annonce d'une mise en production de « Conseillers-Entr
 - On peut désormais créer soi-même des jetons d'API dans l'admin (première utilisation : l'équipe IA de la DILA) → [#4605](https://github.com/betagouv/conseillers-entreprises/pull/4605)
 - Le bouton de génération des rapports dans l'admin est plus clair → [#4597](https://github.com/betagouv/conseillers-entreprises/pull/4597)
 
-**⚙️ Tech** — *pas d'impact visible, vous pouvez passer*
+**⚙️ Tech** — *pas d'impact visible*
 - Nettoyage d'un vieux layout interne → [#4609](https://github.com/betagouv/conseillers-entreprises/pull/4609)

--- a/lib/tasks/production_helpers.rb
+++ b/lib/tasks/production_helpers.rb
@@ -1,0 +1,18 @@
+require 'json'
+
+# Shared between production_announcement.rake and push_to_production.rake to
+# avoid making a separate gh api graphql call per PR from each task.
+module ProductionHelpers
+  def self.fetch_pr(pr_number)
+    query = "{ repository(owner: \"betagouv\", name: \"conseillers-entreprises\") { pullRequest(number: #{pr_number}) { number title body closingIssuesReferences(first: 10) { nodes { title labels(first: 10) { nodes { name } } } } } } }"
+    response = `gh api graphql -f query='#{query}' 2> /dev/null`
+    return nil unless $?.success?
+    JSON.parse(response).dig('data', 'repository', 'pullRequest')
+  rescue JSON::ParserError
+    nil
+  end
+
+  def self.closing_issues_labels(pr)
+    pr['closingIssuesReferences']['nodes'].flat_map{ |issue| issue['labels']['nodes'].pluck('name') }.uniq
+  end
+end

--- a/lib/tasks/push_to_production.rake
+++ b/lib/tasks/push_to_production.rake
@@ -1,6 +1,7 @@
 desc 'Setup and push reviewed code to production'
 task :push_to_production do
   require 'highline/import'
+  require 'json'
 
   def fetch_main_and_production
     puts 'Updating main and production…'
@@ -26,9 +27,19 @@ task :push_to_production do
       message.match(/.*pull request #(?<pr>\d+).*\n*(?<title>.*)/)
     end
 
+    # Labels of the issues closed by the PR (bug, entreprises…), to give more context in the announce
+    def closing_issues_labels(pr_number)
+      query = "{ repository(owner: \"betagouv\", name: \"conseillers-entreprises\") { pullRequest(number: #{pr_number}) { closingIssuesReferences(first: 10) { nodes { labels(first: 10) { nodes { name } } } } } } }"
+      response = `gh api graphql -f query='#{query}' 2> /dev/null`
+      return [] unless $?.success?
+      JSON.parse(response).dig('data', 'repository', 'pullRequest', 'closingIssuesReferences', 'nodes')
+        .flat_map{ |issue| issue.dig('labels', 'nodes').pluck('name') }.uniq
+    end
+
     def format_parts(parts)
       pull_request_url = 'https://github.com/betagouv/conseillers-entreprises/pull/'
-      "* [##{parts['pr']}](#{pull_request_url}#{parts['pr']}) #{parts['title'].strip}"
+      labels = closing_issues_labels(parts['pr']).map{ |label| "`#{label}`" }.join(' ')
+      "* [##{parts['pr']}](#{pull_request_url}#{parts['pr']}) #{parts['title'].strip} #{labels}".strip
     end
 
     messages
@@ -75,4 +86,6 @@ task :push_to_production do
   ensure_clean_working_tree
   merge_main_to_production
   push_to_production
+
+  Rake::Task[:production_announcement].invoke
 end

--- a/lib/tasks/push_to_production.rake
+++ b/lib/tasks/push_to_production.rake
@@ -1,17 +1,25 @@
+require_relative 'production_helpers'
+
 desc 'Setup and push reviewed code to production'
 task :push_to_production do
   require 'highline/import'
-  require 'json'
 
   def fetch_main_and_production
     puts 'Updating main and production…'
     `git fetch origin -u main:main production:production`
-    exit unless $?.success?
+    unless $?.success?
+      puts 'ERROR: git fetch failed. Exiting.'
+      exit
+    end
   end
 
   def find_last_production_commit_on_main
-    commit = `git show -s --pretty=%P production | cut -d " " -f 2`.strip
-    exit unless $?.success?
+    parents = `git show -s --pretty=%P production`.strip
+    unless $?.success?
+      puts 'ERROR: git show failed for production (does the branch exist locally?). Exiting.'
+      exit
+    end
+    commit = parents.split(' ')[1]
     puts "Last production commit is #{commit}"
     commit
   end
@@ -22,35 +30,29 @@ task :push_to_production do
     messages.split(separator)[0...-2]
   end
 
-  def format_commit_messages(messages)
-    def pr_number_and_title(message)
-      message.match(/.*pull request #(?<pr>\d+).*\n*(?<title>.*)/)
-    end
-
-    # Labels of the issues closed by the PR (bug, entreprises…), to give more context in the announce
-    def closing_issues_labels(pr_number)
-      query = "{ repository(owner: \"betagouv\", name: \"conseillers-entreprises\") { pullRequest(number: #{pr_number}) { closingIssuesReferences(first: 10) { nodes { labels(first: 10) { nodes { name } } } } } } }"
-      response = `gh api graphql -f query='#{query}' 2> /dev/null`
-      return [] unless $?.success?
-      JSON.parse(response).dig('data', 'repository', 'pullRequest', 'closingIssuesReferences', 'nodes')
-        .flat_map{ |issue| issue.dig('labels', 'nodes').pluck('name') }.uniq
-    end
-
-    def format_parts(parts)
-      pull_request_url = 'https://github.com/betagouv/conseillers-entreprises/pull/'
-      labels = closing_issues_labels(parts['pr']).map{ |label| "`#{label}`" }.join(' ')
-      "* [##{parts['pr']}](#{pull_request_url}#{parts['pr']}) #{parts['title'].strip} #{labels}".strip
-    end
-
-    messages
-      .filter_map{ |message| pr_number_and_title(message) }
-      .map{ |parts| format_parts(parts) }
+  def pr_number_and_title(message)
+    message.match(/.*pull request #(?<pr>\d+).*\n*(?<title>.*)/)
   end
 
-  def prompt_for_confirmation(formatted)
-    puts "About to merge #{formatted.count} PRs and push to production:"
+  # Fetches each merged PR once: its data is reused both for the confirmation
+  # prompt preview below and for the production announcement afterwards.
+  def fetch_merged_prs(messages)
+    messages
+      .filter_map{ |message| pr_number_and_title(message) }
+      .filter_map{ |parts| ProductionHelpers.fetch_pr(parts['pr']) }
+  end
+
+  # Labels of the issues closed by the PR (bug, entreprises…), to give more context in the confirmation prompt
+  def format_pr(pr)
+    pull_request_url = 'https://github.com/betagouv/conseillers-entreprises/pull/'
+    labels = ProductionHelpers.closing_issues_labels(pr).map{ |label| "`#{label}`" }.join(' ')
+    "* [##{pr['number']}](#{pull_request_url}#{pr['number']}) #{pr['title'].strip} #{labels}".strip
+  end
+
+  def prompt_for_confirmation(prs)
+    puts "About to merge #{prs.count} PRs and push to production:"
     puts '🚀 '
-    puts formatted.join("\n")
+    puts prs.map{ |pr| format_pr(pr) }.join("\n")
     if !agree("Proceed?")
       exit
     end
@@ -66,12 +68,18 @@ task :push_to_production do
 
   def merge_main_to_production
     `git checkout production && git merge main --no-edit`
-    exit unless $?.success?
+    unless $?.success?
+      puts 'ERROR: merge of main into production failed (conflict?). Repo is left on the production branch — resolve or abort the merge manually.'
+      exit
+    end
   end
 
   def push_to_production
     `git push origin production`
-    exit unless $?.success?
+    unless $?.success?
+      puts 'ERROR: git push to production failed. Exiting.'
+      exit
+    end
     puts 'Done!'
   end
 
@@ -80,12 +88,12 @@ task :push_to_production do
 
   last_commit = find_last_production_commit_on_main
   merge_messages = retrieve_merge_commits_messages(last_commit)
-  formatted = format_commit_messages(merge_messages)
-  prompt_for_confirmation(formatted)
+  prs = fetch_merged_prs(merge_messages)
+  prompt_for_confirmation(prs)
 
   ensure_clean_working_tree
   merge_main_to_production
   push_to_production
 
-  Rake::Task[:production_announcement].invoke
+  ProductionAnnouncement.run(prs: prs)
 end

--- a/lib/tasks/push_to_production.rake
+++ b/lib/tasks/push_to_production.rake
@@ -19,7 +19,7 @@ task :push_to_production do
       puts 'ERROR: git show failed for production (does the branch exist locally?). Exiting.'
       exit
     end
-    commit = parents.split(' ')[1]
+    commit = parents.split[1]
     puts "Last production commit is #{commit}"
     commit
   end
@@ -37,9 +37,13 @@ task :push_to_production do
   # Fetches each merged PR once: its data is reused both for the confirmation
   # prompt preview below and for the production announcement afterwards.
   def fetch_merged_prs(messages)
-    messages
-      .filter_map{ |message| pr_number_and_title(message) }
-      .filter_map{ |parts| ProductionHelpers.fetch_pr(parts['pr']) }
+    pr_numbers = messages.filter_map{ |message| pr_number_and_title(message) }.pluck('pr')
+    prs = pr_numbers.filter_map{ |number| ProductionHelpers.fetch_pr(number) }
+
+    missing = pr_numbers.map(&:to_i) - prs.pluck('number')
+    puts "WARNING: could not fetch #{missing.size} PR(s), they will be missing from the confirmation prompt and the announcement: #{missing.join(', ')}" if missing.any?
+
+    prs
   end
 
   # Labels of the issues closed by the PR (bug, entreprises…), to give more context in the confirmation prompt


### PR DESCRIPTION
Actualise la tâche rake qui affiche les dernières PR qui vont être mises en prod pour que les non teech aient une meilleure compréhension de ce qui est mis en ligne

Avant 
<img width="563" height="253" alt="Screenshot 2026-07-27 at 15 29 08" src="https://github.com/user-attachments/assets/6160d763-ffaf-494d-9be8-ba79a72ece3d" />

Apres
<img width="925" height="326" alt="Screenshot 2026-07-27 at 15 29 46" src="https://github.com/user-attachments/assets/7017a705-1c59-4a96-b1cc-985ca001c9c1" />

Utilise Claude code en local et passe à l'ancienne version si pas installé

